### PR TITLE
feat: add cast/crew row to player controls

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -774,6 +774,9 @@ fun NuvioNavHost(
                         }
                     }
                 },
+                onNavigateToCastDetail = { personId, personName, preferCrew ->
+                    navController.navigate(Screen.CastDetail.createRoute(personId, personName, preferCrew))
+                },
                 onPlaybackErrorBack = {
                     val returnedToStream = navController.popBackStack(Screen.Stream.route, inclusive = false)
                     if (!returnedToStream) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerCastRow.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerCastRow.kt
@@ -1,0 +1,224 @@
+@file:OptIn(
+    ExperimentalTvMaterial3Api::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class
+)
+
+package com.nuvio.tv.ui.screens.player
+
+import android.view.KeyEvent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Border
+import androidx.tv.material3.Card
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.MetaCastMember
+
+@Composable
+internal fun PlayerCastRow(
+    castMembers: List<MetaCastMember>,
+    firstCastItemFocusRequester: FocusRequester,
+    onCastMemberClick: (MetaCastMember) -> Unit,
+    onDownKey: () -> Unit,
+    upFocusRequester: FocusRequester,
+    onFocused: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val displayMembers = remember(castMembers) { castMembers.take(10) }
+
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.pause_cast_label),
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.7f)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 4.dp),
+            modifier = Modifier.focusRestorer { firstCastItemFocusRequester }
+        ) {
+            items(
+                items = displayMembers,
+                key = { it.tmdbId ?: it.name.hashCode() }
+            ) { member ->
+                val isFirst = member == displayMembers.firstOrNull()
+                PlayerCastMemberItem(
+                    member = member,
+                    focusRequester = if (isFirst) firstCastItemFocusRequester else null,
+                    upFocusRequester = upFocusRequester,
+                    onDownKey = onDownKey,
+                    onFocused = onFocused,
+                    onClick = { onCastMemberClick(member) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerCastMemberItem(
+    member: MetaCastMember,
+    focusRequester: FocusRequester?,
+    upFocusRequester: FocusRequester,
+    onDownKey: () -> Unit,
+    onFocused: () -> Unit,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val cardSizePx = remember(density) { with(density) { 64.dp.roundToPx() } }
+    var isFocused by remember { mutableStateOf(false) }
+
+    val photoModel = remember(context, member.photo, cardSizePx) {
+        member.photo?.takeIf { it.isNotBlank() }?.let { url ->
+            ImageRequest.Builder(context)
+                .data(url)
+                .crossfade(false)
+                .size(width = cardSizePx, height = cardSizePx)
+                .build()
+        }
+    }
+
+    Column(
+        modifier = Modifier.width(90.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Card(
+            onClick = onClick,
+            modifier = Modifier
+                .size(64.dp)
+                .align(Alignment.Start)
+                .then(
+                    if (focusRequester != null) Modifier.focusRequester(focusRequester)
+                    else Modifier
+                )
+                .focusProperties { up = upFocusRequester }
+                .onPreviewKeyEvent { keyEvent ->
+                    if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                        keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_DOWN
+                    ) {
+                        onDownKey()
+                        true
+                    } else {
+                        false
+                    }
+                }
+                .onFocusChanged { state ->
+                    isFocused = state.isFocused
+                    if (state.isFocused) onFocused()
+                },
+            shape = CardDefaults.shape(shape = CircleShape),
+            colors = CardDefaults.colors(
+                containerColor = Color.Transparent,
+                focusedContainerColor = Color.Transparent
+            ),
+            border = CardDefaults.border(
+                focusedBorder = Border(
+                    border = BorderStroke(2.dp, Color.White),
+                    shape = CircleShape
+                )
+            )
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                val bgColor = if (isFocused) Color.White.copy(alpha = 0.2f) else Color.White.copy(alpha = 0.1f)
+                val bgPainter = remember(bgColor) { ColorPainter(bgColor) }
+
+                if (photoModel != null) {
+                    AsyncImage(
+                        model = photoModel,
+                        contentDescription = member.name,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop,
+                        placeholder = bgPainter,
+                        error = bgPainter,
+                        fallback = bgPainter
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(bgColor),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = member.name.firstOrNull()?.uppercase() ?: "?",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = member.name,
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.9f),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        val character = member.character
+        if (!character.isNullOrBlank()) {
+            val displayCharacter = when {
+                character.equals("Creator", ignoreCase = true) -> stringResource(R.string.cast_role_creator)
+                character.equals("Director", ignoreCase = true) -> stringResource(R.string.cast_role_director)
+                character.equals("Writer", ignoreCase = true) -> stringResource(R.string.cast_role_writer)
+                else -> character
+            }
+            Text(
+                text = displayCharacter,
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.5f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerCastRow.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerCastRow.kt
@@ -60,6 +60,7 @@ internal fun PlayerCastRow(
     onDownKey: () -> Unit,
     upFocusRequester: FocusRequester,
     onFocused: () -> Unit,
+    onUpKey: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val displayMembers = remember(castMembers) { castMembers.take(10) }
@@ -88,6 +89,7 @@ internal fun PlayerCastRow(
                     focusRequester = if (isFirst) firstCastItemFocusRequester else null,
                     upFocusRequester = upFocusRequester,
                     onDownKey = onDownKey,
+                    onUpKey = onUpKey,
                     onFocused = onFocused,
                     onClick = { onCastMemberClick(member) }
                 )
@@ -102,6 +104,7 @@ private fun PlayerCastMemberItem(
     focusRequester: FocusRequester?,
     upFocusRequester: FocusRequester,
     onDownKey: () -> Unit,
+    onUpKey: (() -> Unit)?,
     onFocused: () -> Unit,
     onClick: () -> Unit
 ) {
@@ -133,12 +136,21 @@ private fun PlayerCastMemberItem(
                     if (focusRequester != null) Modifier.focusRequester(focusRequester)
                     else Modifier
                 )
-                .focusProperties { up = upFocusRequester }
+                .then(
+                    if (onUpKey == null) Modifier.focusProperties { up = upFocusRequester }
+                    else Modifier
+                )
                 .onPreviewKeyEvent { keyEvent ->
                     if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
                         keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_DOWN
                     ) {
                         onDownKey()
+                        true
+                    } else if (onUpKey != null &&
+                        keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                        keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DPAD_UP
+                    ) {
+                        onUpKey()
                         true
                     } else {
                         false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -19,6 +19,8 @@ import com.nuvio.tv.data.repository.TraktScrobbleItem
 import com.nuvio.tv.data.repository.TraktScrobbleService
 import com.nuvio.tv.domain.model.Video
 import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.StreamRepository
@@ -49,6 +51,8 @@ class PlayerRuntimeController(
     internal val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     internal val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
     internal val trackPreferenceDataStore: com.nuvio.tv.data.local.TrackPreferenceDataStore,
+    internal val tmdbService: TmdbService,
+    internal val tmdbMetadataService: TmdbMetadataService,
     savedStateHandle: SavedStateHandle,
     internal val scope: CoroutineScope
 ) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -2,12 +2,16 @@ package com.nuvio.tv.ui.screens.player
 
 import com.nuvio.tv.R
 import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.Meta
+import com.nuvio.tv.domain.model.MetaCastMember
 import com.nuvio.tv.domain.model.Stream
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?) {
     if (id.isNullOrBlank() || type.isNullOrBlank()) return
@@ -21,12 +25,62 @@ internal fun PlayerRuntimeController.fetchMetaDetails(id: String?, type: String?
                 applyMetaDetails(result.data)
             }
             is NetworkResult.Error -> {
-                
+
             }
             NetworkResult.Loading -> {
-                
+
             }
         }
+
+        // Enrich cast from TMDB if addon didn't provide cast data
+        if (_uiState.value.castMembers.isEmpty()) {
+            fetchTmdbCast(id, type)
+        }
+    }
+}
+
+private suspend fun PlayerRuntimeController.fetchTmdbCast(id: String, type: String) {
+    try {
+        val tmdbType = when (type.lowercase()) {
+            "movie" -> "movie"
+            "series", "tv" -> "tv"
+            else -> return
+        }
+        val tmdbId = withContext(Dispatchers.IO) {
+            tmdbService.ensureTmdbId(id, tmdbType)
+        } ?: return
+
+        val tmdbContentType = when (type.lowercase()) {
+            "movie" -> ContentType.MOVIE
+            "series", "tv" -> ContentType.SERIES
+            else -> return
+        }
+        val enrichment = withContext(Dispatchers.IO) {
+            tmdbMetadataService.fetchEnrichment(
+                tmdbId = tmdbId,
+                contentType = tmdbContentType
+            )
+        } ?: return
+
+        val castMembers = buildList {
+            addAll(enrichment.directorMembers)
+            addAll(enrichment.writerMembers)
+            addAll(enrichment.castMembers)
+        }
+            .filter { it.name.isNotBlank() }
+            .distinctBy { it.tmdbId ?: (it.name.lowercase() + "|" + (it.character ?: "")) }
+
+        if (castMembers.isNotEmpty()) {
+            _uiState.update { state ->
+                if (state.castMembers.isEmpty()) {
+                    state.copy(castMembers = castMembers)
+                } else {
+                    state
+                }
+            }
+        }
+    } catch (_: Exception) {
+        // TMDB enrichment is best-effort, don't crash the player
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1044,11 +1044,23 @@ private fun PlayerControlsOverlay(
     val customEpisodesPainter = rememberRawSvgPainter(R.raw.ic_player_episodes)
 
     val firstCastItemFocusRequester = remember { FocusRequester() }
+    var showCastRow by remember { mutableStateOf(false) }
     val handleDownFromControls: () -> Unit = {
         if (uiState.castMembers.isNotEmpty()) {
-            try { firstCastItemFocusRequester.requestFocus() } catch (_: Exception) {}
+            showCastRow = true
         } else {
             onHideControls()
+        }
+    }
+    val handleCastRowUpKey: () -> Unit = {
+        showCastRow = false
+        try { playPauseFocusRequester.requestFocus() } catch (_: Exception) {}
+    }
+
+    // Focus first cast item when row becomes visible
+    LaunchedEffect(showCastRow) {
+        if (showCastRow) {
+            try { firstCastItemFocusRequester.requestFocus() } catch (_: Exception) {}
         }
     }
 
@@ -1073,7 +1085,7 @@ private fun PlayerControlsOverlay(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(if (uiState.castMembers.isNotEmpty()) 310.dp else 200.dp)
+                .height(200.dp)
                 .align(Alignment.BottomCenter)
                 .background(
                     Brush.verticalGradient(
@@ -1347,24 +1359,51 @@ private fun PlayerControlsOverlay(
                 )
             }
 
-            // Cast row below controls
-            if (uiState.castMembers.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(12.dp))
-                PlayerCastRow(
-                    castMembers = uiState.castMembers,
-                    firstCastItemFocusRequester = firstCastItemFocusRequester,
-                    onCastMemberClick = { member ->
-                        member.tmdbId?.let { id ->
-                            val preferCrew = member.character.equals("Creator", ignoreCase = true) ||
-                                member.character.equals("Director", ignoreCase = true) ||
-                                member.character.equals("Writer", ignoreCase = true)
-                            onCastMemberClick(id, member.name, preferCrew)
-                        }
-                    },
-                    onDownKey = onHideControls,
-                    upFocusRequester = playPauseFocusRequester,
-                    onFocused = onResetHideTimer
+            // Cast hint chevron
+            if (uiState.castMembers.isNotEmpty() && !showCastRow) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "▾",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.4f),
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
+            }
+
+            // Cast row - slides in when user presses down from controls
+            AnimatedVisibility(
+                visible = showCastRow && uiState.castMembers.isNotEmpty(),
+                enter = fadeIn(animationSpec = tween(200)) + slideInVertically(
+                    animationSpec = tween(200),
+                    initialOffsetY = { it / 2 }
+                ),
+                exit = fadeOut(animationSpec = tween(150)) + slideOutVertically(
+                    animationSpec = tween(150),
+                    targetOffsetY = { it / 2 }
+                )
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    PlayerCastRow(
+                        castMembers = uiState.castMembers,
+                        firstCastItemFocusRequester = firstCastItemFocusRequester,
+                        onCastMemberClick = { member ->
+                            member.tmdbId?.let { id ->
+                                val preferCrew = member.character.equals("Creator", ignoreCase = true) ||
+                                    member.character.equals("Director", ignoreCase = true) ||
+                                    member.character.equals("Writer", ignoreCase = true)
+                                onCastMemberClick(id, member.name, preferCrew)
+                            }
+                        },
+                        onDownKey = {
+                            showCastRow = false
+                            onHideControls()
+                        },
+                        upFocusRequester = playPauseFocusRequester,
+                        onFocused = onResetHideTimer,
+                        onUpKey = handleCastRowUpKey
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -118,7 +118,8 @@ fun PlayerScreen(
     viewModel: PlayerViewModel = hiltViewModel(),
     onBackPress: (currentSeason: Int?, currentEpisode: Int?, autoPlayEnabled: Boolean) -> Unit,
     onPlaybackErrorBack: () -> Unit = { onBackPress(null, null, false) },
-    onPlaybackEnded: ((nextVideoId: String?, nextSeason: Int?, nextEpisode: Int?) -> Unit)? = null
+    onPlaybackEnded: ((nextVideoId: String?, nextSeason: Int?, nextEpisode: Int?) -> Unit)? = null,
+    onNavigateToCastDetail: (personId: Int, personName: String, preferCrew: Boolean) -> Unit = { _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -775,7 +776,8 @@ fun PlayerScreen(
                 onResetHideTimer = { viewModel.scheduleHideControls(); viewModel.onUserInteraction() },
                 onHideControls = { viewModel.hideControls() },
                 onBack = { exitPlayer() },
-                skipButtonVisible = skipButtonActuallyVisible
+                skipButtonVisible = skipButtonActuallyVisible,
+                onCastMemberClick = onNavigateToCastDetail
             )
         }
 
@@ -1030,7 +1032,8 @@ private fun PlayerControlsOverlay(
     onResetHideTimer: () -> Unit,
     onHideControls: () -> Unit,
     onBack: () -> Unit,
-    skipButtonVisible: Boolean = false
+    skipButtonVisible: Boolean = false,
+    onCastMemberClick: (personId: Int, personName: String, preferCrew: Boolean) -> Unit = { _, _, _ -> }
 ) {
     val customPlayPainter = rememberRawSvgPainter(R.raw.ic_player_play)
     val customPausePainter = rememberRawSvgPainter(R.raw.ic_player_pause)
@@ -1039,6 +1042,15 @@ private fun PlayerControlsOverlay(
     val customSourcePainter = rememberRawSvgPainter(R.raw.ic_player_source)
     val customAspectPainter = rememberRawSvgPainter(R.raw.ic_player_aspect_ratio)
     val customEpisodesPainter = rememberRawSvgPainter(R.raw.ic_player_episodes)
+
+    val firstCastItemFocusRequester = remember { FocusRequester() }
+    val handleDownFromControls: () -> Unit = {
+        if (uiState.castMembers.isNotEmpty()) {
+            try { firstCastItemFocusRequester.requestFocus() } catch (_: Exception) {}
+        } else {
+            onHideControls()
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Top gradient
@@ -1061,7 +1073,7 @@ private fun PlayerControlsOverlay(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(200.dp)
+                .height(if (uiState.castMembers.isNotEmpty()) 310.dp else 200.dp)
                 .align(Alignment.BottomCenter)
                 .background(
                     Brush.verticalGradient(
@@ -1193,7 +1205,7 @@ private fun PlayerControlsOverlay(
                         onClick = onPlayPause,
                         focusRequester = playPauseFocusRequester,
                         upFocusRequester = progressBarFocusRequester,
-                        onDownKey = onHideControls,
+                        onDownKey = handleDownFromControls,
                         onFocused = onResetHideTimer
                     )
 
@@ -1203,7 +1215,7 @@ private fun PlayerControlsOverlay(
                             contentDescription = stringResource(R.string.next_episode_label),
                             onClick = onPlayNextEpisode,
                             upFocusRequester = progressBarFocusRequester,
-                            onDownKey = onHideControls,
+                            onDownKey = handleDownFromControls,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1215,7 +1227,7 @@ private fun PlayerControlsOverlay(
                             contentDescription = "Subtitles",
                             onClick = onShowSubtitleDialog,
                             upFocusRequester = progressBarFocusRequester,
-                            onDownKey = onHideControls,
+                            onDownKey = handleDownFromControls,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1227,7 +1239,7 @@ private fun PlayerControlsOverlay(
                             contentDescription = "Audio tracks",
                             onClick = onShowAudioDialog,
                             upFocusRequester = progressBarFocusRequester,
-                            onDownKey = onHideControls,
+                            onDownKey = handleDownFromControls,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1238,7 +1250,7 @@ private fun PlayerControlsOverlay(
                         contentDescription = "Sources",
                         onClick = onShowSourcesPanel,
                         upFocusRequester = progressBarFocusRequester,
-                        onDownKey = onHideControls,
+                        onDownKey = handleDownFromControls,
                         onFocused = onResetHideTimer
                     )
 
@@ -1249,7 +1261,7 @@ private fun PlayerControlsOverlay(
                             contentDescription = "Episodes",
                             onClick = onShowEpisodesPanel,
                             upFocusRequester = progressBarFocusRequester,
-                            onDownKey = onHideControls,
+                            onDownKey = handleDownFromControls,
                             onFocused = onResetHideTimer
                         )
                     }
@@ -1276,7 +1288,7 @@ private fun PlayerControlsOverlay(
                                     onShowSpeedDialog()
                                 },
                                 upFocusRequester = progressBarFocusRequester,
-                                onDownKey = onHideControls,
+                                onDownKey = handleDownFromControls,
                                 onFocused = onResetHideTimer
                             )
                             ControlButton(
@@ -1287,7 +1299,7 @@ private fun PlayerControlsOverlay(
                                     onToggleAspectRatio()
                                 },
                                 upFocusRequester = progressBarFocusRequester,
-                                onDownKey = onHideControls,
+                                onDownKey = handleDownFromControls,
                                 onFocused = onResetHideTimer
                             )
                             ControlButton(
@@ -1297,7 +1309,7 @@ private fun PlayerControlsOverlay(
                                     onOpenInExternalPlayer()
                                 },
                                 upFocusRequester = progressBarFocusRequester,
-                                onDownKey = onHideControls,
+                                onDownKey = handleDownFromControls,
                                 onFocused = onResetHideTimer
                             )
                             ControlButton(
@@ -1307,7 +1319,7 @@ private fun PlayerControlsOverlay(
                                     onShowStreamInfo()
                                 },
                                 upFocusRequester = progressBarFocusRequester,
-                                onDownKey = onHideControls,
+                                onDownKey = handleDownFromControls,
                                 onFocused = onResetHideTimer
                             )
                         }
@@ -1322,7 +1334,7 @@ private fun PlayerControlsOverlay(
                         contentDescription = if (uiState.showMoreDialog) "Close more actions" else "More actions",
                         onClick = onToggleMoreActions,
                         upFocusRequester = progressBarFocusRequester,
-                        onDownKey = onHideControls,
+                        onDownKey = handleDownFromControls,
                         onFocused = onResetHideTimer
                     )
                 }
@@ -1332,6 +1344,26 @@ private fun PlayerControlsOverlay(
                     text = "${formatTime(uiState.currentPosition)} / ${formatTime(uiState.duration)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = Color.White.copy(alpha = 0.9f)
+                )
+            }
+
+            // Cast row below controls
+            if (uiState.castMembers.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                PlayerCastRow(
+                    castMembers = uiState.castMembers,
+                    firstCastItemFocusRequester = firstCastItemFocusRequester,
+                    onCastMemberClick = { member ->
+                        member.tmdbId?.let { id ->
+                            val preferCrew = member.character.equals("Creator", ignoreCase = true) ||
+                                member.character.equals("Director", ignoreCase = true) ||
+                                member.character.equals("Writer", ignoreCase = true)
+                            onCastMemberClick(id, member.name, preferCrew)
+                        }
+                    },
+                    onDownKey = onHideControls,
+                    upFocusRequester = playPauseFocusRequester,
+                    onFocused = onResetHideTimer
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -12,6 +12,8 @@ import com.nuvio.tv.data.repository.ParentalGuideRepository
 import com.nuvio.tv.data.repository.SkipIntroRepository
 import com.nuvio.tv.data.repository.TraktEpisodeMappingService
 import com.nuvio.tv.data.repository.TraktScrobbleService
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.StreamRepository
@@ -39,6 +41,8 @@ class PlayerViewModel @Inject constructor(
     private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     private val watchedItemsPreferences: com.nuvio.tv.data.local.WatchedItemsPreferences,
     private val trackPreferenceDataStore: com.nuvio.tv.data.local.TrackPreferenceDataStore,
+    private val tmdbService: TmdbService,
+    private val tmdbMetadataService: TmdbMetadataService,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -59,6 +63,8 @@ class PlayerViewModel @Inject constructor(
         layoutPreferenceDataStore = layoutPreferenceDataStore,
         watchedItemsPreferences = watchedItemsPreferences,
         trackPreferenceDataStore = trackPreferenceDataStore,
+        tmdbService = tmdbService,
+        tmdbMetadataService = tmdbMetadataService,
         savedStateHandle = savedStateHandle,
         scope = viewModelScope
     )


### PR DESCRIPTION
## Summary
Adds a horizontally scrollable cast/crew row to the player controls overlay, similar to the Plex player experience.

- **Hidden by default** — press DOWN from control buttons to reveal the cast row (a subtle chevron hint indicates it's available)
- Browse cast members with circular photos and names via D-pad
- Click a cast member to navigate to their full bio and filmography page
- Adds TMDB cast enrichment when addons don't provide cast data
- Falls back to original behavior (hide controls on DOWN) when no cast data available

## Changes
- **New:** `PlayerCastRow.kt` — compact cast row composable with 64dp circular photos, TV focus management, slide-in animation
- **Modified:** `PlayerScreen.kt` — integrated cast row into controls overlay with AnimatedVisibility, redirected D-pad DOWN from buttons to cast row, added chevron hint indicator
- **Modified:** `PlayerRuntimeControllerMetadata.kt` — added TMDB cast enrichment when addons don't provide cast
- **Modified:** `PlayerViewModel.kt` / `PlayerRuntimeController.kt` — injected TMDB services
- **Modified:** `NuvioNavHost.kt` — wired navigation from player to CastDetailScreen

## Test plan
- [ ] Play a movie with TMDB cast data
- [ ] Press DOWN → controls appear, press DOWN again → cast row slides in with animation
- [ ] Navigate LEFT/RIGHT between cast members
- [ ] Press UP from cast row → row hides, focus returns to control buttons
- [ ] Click cast member → CastDetailScreen loads with bio and filmography
- [ ] Press BACK → returns to player (paused)
- [ ] Press play → playback resumes from where it left off
- [ ] Test with content that has no cast data (DOWN from buttons hides controls)
- [ ] Test on Android TV with physical remote