### PR TITLE
New light feature (with algorithm):  "Surprise Me" feature

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import com.nuvio.tv.data.repository.AddonRepositoryImpl
 import com.nuvio.tv.data.repository.CatalogRepositoryImpl
 import com.nuvio.tv.data.repository.LibraryRepositoryImpl
 import com.nuvio.tv.data.repository.MetaRepositoryImpl
+import com.nuvio.tv.data.repository.RecommendationRepositoryImpl
 import com.nuvio.tv.data.repository.StreamRepositoryImpl
 import com.nuvio.tv.data.repository.SubtitleRepositoryImpl
 import com.nuvio.tv.data.repository.SyncRepositoryImpl
@@ -12,6 +13,7 @@ import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.CatalogRepository
 import com.nuvio.tv.domain.repository.LibraryRepository
 import com.nuvio.tv.domain.repository.MetaRepository
+import com.nuvio.tv.domain.repository.RecommendationRepository
 import com.nuvio.tv.domain.repository.StreamRepository
 import com.nuvio.tv.domain.repository.SubtitleRepository
 import com.nuvio.tv.domain.repository.SyncRepository
@@ -57,4 +59,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindWatchProgressRepository(impl: WatchProgressRepositoryImpl): WatchProgressRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRecommendationRepository(impl: RecommendationRepositoryImpl): RecommendationRepository
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/LayoutPreferenceDataStore.kt
@@ -66,6 +66,7 @@ class LayoutPreferenceDataStore @Inject constructor(
     private val modernHeroFullScreenBackdropKey = booleanPreferencesKey("modern_hero_full_screen_backdrop")
     private val hideUnreleasedContentKey = booleanPreferencesKey("hide_unreleased_content")
     private val showFullReleaseDateKey = booleanPreferencesKey("show_full_release_date")
+    private val showSurpriseMeButtonKey = booleanPreferencesKey("show_surprise_me_button")
 
     private fun <T> profileFlow(extract: (prefs: androidx.datastore.preferences.core.Preferences) -> T): Flow<T> =
         profileManager.activeProfileId.flatMapLatest { pid ->
@@ -216,6 +217,10 @@ class LayoutPreferenceDataStore @Inject constructor(
 
     val showFullReleaseDate: Flow<Boolean> = profileFlow { prefs ->
         prefs[showFullReleaseDateKey] ?: true
+    }
+
+    val showSurpriseMeButton: Flow<Boolean> = profileFlow { prefs ->
+        prefs[showSurpriseMeButtonKey] ?: true
     }
 
     suspend fun setLayout(layout: HomeLayout) {
@@ -430,6 +435,12 @@ class LayoutPreferenceDataStore @Inject constructor(
     suspend fun setShowFullReleaseDate(enabled: Boolean) {
         store().edit { prefs ->
             prefs[showFullReleaseDateKey] = enabled
+        }
+    }
+
+    suspend fun setShowSurpriseMeButton(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[showSurpriseMeButtonKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/RecommendationRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/RecommendationRepositoryImpl.kt
@@ -1,0 +1,255 @@
+package com.nuvio.tv.data.repository
+
+import android.util.Log
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.CatalogExtra
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.RecommendationRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+@Singleton
+class RecommendationRepositoryImpl @Inject constructor(
+    private val watchProgressRepository: WatchProgressRepository,
+    private val addonRepository: AddonRepository,
+    private val catalogRepository: CatalogRepository
+) : RecommendationRepository {
+
+    companion object {
+        private const val TAG = "RecommendationRepo"
+        private const val MAX_HISTORY_ITEMS = 50
+        private const val MAX_CATALOG_QUERIES = 4
+        private const val MAX_CANDIDATES = 50
+        private const val TOP_CANDIDATES_FOR_SELECTION = 10
+        private const val TIMEOUT_MS = 2000L
+    }
+
+    override suspend fun getSurpriseRecommendation(): MetaPreview? {
+        return withTimeoutOrNull(TIMEOUT_MS) {
+            try {
+                val recommendation = generateRecommendation()
+                if (recommendation != null) {
+                    Log.d(TAG, "Recommendation: ${recommendation.name} (${recommendation.id})")
+                }
+                recommendation
+            } catch (e: Exception) {
+                Log.w(TAG, "Recommendation failed", e)
+                null
+            }
+        }
+    }
+
+    private suspend fun generateRecommendation(): MetaPreview? {
+        val addons = addonRepository.getInstalledAddons().first()
+        if (addons.isEmpty()) return null
+
+        val watchHistory = watchProgressRepository.allProgress.first()
+            .take(MAX_HISTORY_ITEMS)
+        val watchedIds = watchHistory.map { it.contentId }.toSet()
+
+        // Build genre frequency map from watch history
+        // We need to find genres for watched items from catalog data
+        val genreFrequency = buildGenreFrequency(watchedIds, addons)
+
+        return if (genreFrequency.isNotEmpty()) {
+            getGenreBasedRecommendation(genreFrequency, watchedIds, addons)
+        } else {
+            getFallbackRecommendation(watchedIds, addons)
+        }
+    }
+
+    private suspend fun buildGenreFrequency(
+        watchedIds: Set<String>,
+        addons: List<com.nuvio.tv.domain.model.Addon>
+    ): Map<String, Int> {
+        // Fetch first page of catalogs to find genre data for watched items
+        val genreFrequency = mutableMapOf<String, Int>()
+
+        // Query a few catalogs and match watched IDs to extract genres
+        val catalogQueries = addons.flatMap { addon ->
+            addon.catalogs.take(2).map { catalog ->
+                Triple(addon, catalog, catalog.apiType)
+            }
+        }.take(MAX_CATALOG_QUERIES)
+
+        coroutineScope {
+            val results = catalogQueries.map { (addon, catalog, type) ->
+                async {
+                    fetchCatalogItems(addon.baseUrl, addon.id, addon.name, catalog.id, catalog.name, type)
+                }
+            }.awaitAll()
+
+            for (items in results) {
+                for (item in items) {
+                    if (item.id in watchedIds) {
+                        for (genre in item.genres) {
+                            genreFrequency[genre] = (genreFrequency[genre] ?: 0) + 1
+                        }
+                    }
+                }
+            }
+        }
+
+        return genreFrequency
+    }
+
+    private suspend fun getGenreBasedRecommendation(
+        genreFrequency: Map<String, Int>,
+        watchedIds: Set<String>,
+        addons: List<com.nuvio.tv.domain.model.Addon>
+    ): MetaPreview? {
+        val topGenres = genreFrequency.entries
+            .sortedByDescending { it.value }
+            .take(2)
+            .map { it.key }
+
+        Log.d(TAG, "Top genres: $topGenres (from ${genreFrequency.size} genres)")
+
+        // Find catalogs that support genre filtering
+        val genreCatalogs = addons.flatMap { addon ->
+            addon.catalogs.filter { catalog ->
+                catalog.extra.any { it.name == "genre" }
+            }.map { catalog -> Triple(addon, catalog, catalog.apiType) }
+        }.take(MAX_CATALOG_QUERIES)
+
+        val candidates = mutableListOf<MetaPreview>()
+
+        coroutineScope {
+            val results = if (genreCatalogs.isNotEmpty()) {
+                // Query with genre filter
+                genreCatalogs.map { (addon, catalog, type) ->
+                    async {
+                        fetchCatalogItems(
+                            addon.baseUrl, addon.id, addon.name,
+                            catalog.id, catalog.name, type,
+                            extraArgs = mapOf("genre" to topGenres.first())
+                        )
+                    }
+                }.awaitAll()
+            } else {
+                // No genre filter support — fetch default catalogs
+                addons.flatMap { addon ->
+                    addon.catalogs.take(2).map { catalog ->
+                        Triple(addon, catalog, catalog.apiType)
+                    }
+                }.take(MAX_CATALOG_QUERIES).map { (addon, catalog, type) ->
+                    async {
+                        fetchCatalogItems(addon.baseUrl, addon.id, addon.name, catalog.id, catalog.name, type)
+                    }
+                }.awaitAll()
+            }
+
+            for (items in results) {
+                candidates.addAll(items)
+            }
+        }
+
+        // Filter out watched items and deduplicate
+        val filtered = candidates
+            .filter { it.id !in watchedIds }
+            .distinctBy { it.id }
+            .take(MAX_CANDIDATES)
+
+        if (filtered.isEmpty()) {
+            return getFallbackRecommendation(watchedIds, addons)
+        }
+
+        return selectWeightedRandom(filtered, topGenres)
+    }
+
+    private suspend fun getFallbackRecommendation(
+        watchedIds: Set<String>,
+        addons: List<com.nuvio.tv.domain.model.Addon>
+    ): MetaPreview? {
+        Log.d(TAG, "Using fallback recommendation (no genre data)")
+
+        // Just pick from the first available catalog
+        for (addon in addons) {
+            for (catalog in addon.catalogs.take(2)) {
+                val items = fetchCatalogItems(
+                    addon.baseUrl, addon.id, addon.name,
+                    catalog.id, catalog.name, catalog.apiType
+                )
+                val unwatched = items.filter { it.id !in watchedIds }
+                if (unwatched.isNotEmpty()) {
+                    return unwatched[Random.nextInt(unwatched.size)]
+                }
+            }
+        }
+        return null
+    }
+
+    internal fun selectWeightedRandom(
+        candidates: List<MetaPreview>,
+        topGenres: List<String>
+    ): MetaPreview? {
+        if (candidates.isEmpty()) return null
+
+        val scored = candidates.map { item ->
+            val genreMatchCount = item.genres.count { it in topGenres }
+            val ratingScore = item.imdbRating ?: 5f
+            val recencyBonus = if (isRecentRelease(item.releaseInfo)) 2f else 0f
+            val score = genreMatchCount * 3f + ratingScore + recencyBonus
+            item to score
+        }.sortedByDescending { it.second }
+            .take(TOP_CANDIDATES_FOR_SELECTION)
+
+        // Weighted random selection
+        val totalWeight = scored.sumOf { it.second.toDouble() }
+        if (totalWeight <= 0) return scored.firstOrNull()?.first
+
+        var random = Random.nextDouble() * totalWeight
+        for ((item, score) in scored) {
+            random -= score
+            if (random <= 0) return item
+        }
+        return scored.last().first
+    }
+
+    private fun isRecentRelease(releaseInfo: String?): Boolean {
+        if (releaseInfo == null) return false
+        val currentYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
+        return releaseInfo.contains(currentYear.toString()) ||
+                releaseInfo.contains((currentYear - 1).toString())
+    }
+
+    private suspend fun fetchCatalogItems(
+        addonBaseUrl: String,
+        addonId: String,
+        addonName: String,
+        catalogId: String,
+        catalogName: String,
+        type: String,
+        extraArgs: Map<String, String> = emptyMap()
+    ): List<MetaPreview> {
+        return try {
+            val result = catalogRepository.getCatalog(
+                addonBaseUrl = addonBaseUrl,
+                addonId = addonId,
+                addonName = addonName,
+                catalogId = catalogId,
+                catalogName = catalogName,
+                type = type,
+                extraArgs = extraArgs
+            ).firstOrNull { it is NetworkResult.Success }
+
+            when (result) {
+                is NetworkResult.Success -> result.data.items
+                else -> emptyList()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch catalog $catalogId from $addonId", e)
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/domain/repository/RecommendationRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/RecommendationRepository.kt
@@ -1,0 +1,7 @@
+package com.nuvio.tv.domain.repository
+
+import com.nuvio.tv.domain.model.MetaPreview
+
+interface RecommendationRepository {
+    suspend fun getSurpriseRecommendation(): MetaPreview?
+}

--- a/app/src/main/java/com/nuvio/tv/ui/components/SurpriseMeButton.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/SurpriseMeButton.kt
@@ -1,0 +1,48 @@
+package com.nuvio.tv.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.R
+import com.nuvio.tv.ui.theme.NuvioColors
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun SurpriseMeButton(
+    onClick: () -> Unit,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Button(
+        onClick = onClick,
+        enabled = !isLoading,
+        modifier = modifier,
+        colors = ButtonDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard,
+            contentColor = NuvioColors.TextPrimary
+        )
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = if (isLoading) {
+                    stringResource(R.string.surprise_me_loading)
+                } else {
+                    stringResource(R.string.surprise_me)
+                },
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -27,10 +27,12 @@ import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import com.nuvio.tv.domain.model.MetaPreview
+import androidx.compose.foundation.layout.padding
 import com.nuvio.tv.ui.components.CatalogRowSection
 import com.nuvio.tv.ui.components.ContinueWatchingSection
 import com.nuvio.tv.ui.components.HeroCarousel
 import com.nuvio.tv.ui.components.PosterCardStyle
+import com.nuvio.tv.ui.components.SurpriseMeButton
 
 /** Minimum interval between processed key repeat events to prevent HWUI overload. */
 private const val KEY_REPEAT_THROTTLE_MS = 80L
@@ -51,15 +53,15 @@ fun ClassicHomeContent(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = {},
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = {},
-    showContinueWatchingManualPlayOption: Boolean = false,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
     isCatalogItemWatched: (MetaPreview) -> Boolean = { false },
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     onRequestTrailerPreview: (MetaPreview) -> Unit,
     onItemFocus: (MetaPreview) -> Unit = {},
-    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit
+    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
+    onSurpriseMe: () -> Unit = {},
+    isSurpriseMeLoading: Boolean = false
 ) {
 
     // Nested prefetch: when LazyColumn prefetches a row ahead of scrolling,
@@ -191,8 +193,6 @@ fun ClassicHomeContent(
                         onContinueWatchingClick(item)
                     },
                     onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                    showManualPlayOption = showContinueWatchingManualPlayOption,
-                    onPlayManually = onContinueWatchingPlayManually,
                     onDetailsClick = { item ->
                         onNavigateToDetail(
                             when (item) {
@@ -234,6 +234,14 @@ fun ClassicHomeContent(
                     blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes
                 )
             }
+        }
+
+        item(key = "surprise_me", contentType = "surprise_me") {
+            SurpriseMeButton(
+                onClick = onSurpriseMe,
+                isLoading = isSurpriseMeLoading,
+                modifier = Modifier.padding(horizontal = 48.dp)
+            )
         }
 
         itemsIndexed(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -61,7 +61,8 @@ fun ClassicHomeContent(
     onItemFocus: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
     onSurpriseMe: () -> Unit = {},
-    isSurpriseMeLoading: Boolean = false
+    isSurpriseMeLoading: Boolean = false,
+    showSurpriseMeButton: Boolean = true
 ) {
 
     // Nested prefetch: when LazyColumn prefetches a row ahead of scrolling,
@@ -236,12 +237,14 @@ fun ClassicHomeContent(
             }
         }
 
-        item(key = "surprise_me", contentType = "surprise_me") {
-            SurpriseMeButton(
-                onClick = onSurpriseMe,
-                isLoading = isSurpriseMeLoading,
-                modifier = Modifier.padding(horizontal = 48.dp)
-            )
+        if (showSurpriseMeButton) {
+            item(key = "surprise_me", contentType = "surprise_me") {
+                SurpriseMeButton(
+                    onClick = onSurpriseMe,
+                    isLoading = isSurpriseMeLoading,
+                    modifier = Modifier.padding(horizontal = 48.dp)
+                )
+            }
         }
 
         itemsIndexed(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -59,6 +59,7 @@ import com.nuvio.tv.ui.components.GridContinueWatchingSection
 import com.nuvio.tv.ui.components.HeroCarousel
 import com.nuvio.tv.ui.components.PosterCardDefaults
 import com.nuvio.tv.ui.components.PosterCardStyle
+import com.nuvio.tv.ui.components.SurpriseMeButton
 import com.nuvio.tv.ui.theme.NuvioColors
 
 /** Minimum interval between processed key repeat events to prevent HWUI overload. */
@@ -72,15 +73,15 @@ fun GridHomeContent(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = {},
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = {},
-    showContinueWatchingManualPlayOption: Boolean = false,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
     isCatalogItemWatched: (MetaPreview) -> Boolean = { false },
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     posterCardStyle: PosterCardStyle = PosterCardDefaults.Style,
     onItemFocus: (com.nuvio.tv.domain.model.MetaPreview) -> Unit = {},
-    onSaveGridFocusState: (Int, Int) -> Unit
+    onSaveGridFocusState: (Int, Int) -> Unit,
+    onSurpriseMe: () -> Unit = {},
+    isSurpriseMeLoading: Boolean = false
 ) {
     val gridState = rememberLazyGridState(
         initialFirstVisibleItemIndex = gridFocusState.verticalScrollIndex,
@@ -196,6 +197,7 @@ fun GridHomeContent(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             var continueWatchingInserted = false
+            var surpriseMeInserted = false
             var firstGridFocusableAssigned = false
             val contentOccurrencesByCatalogAndId = mutableMapOf<String, Int>()
 
@@ -241,8 +243,6 @@ fun GridHomeContent(
                                         onContinueWatchingClick(item)
                                     },
                                     onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                                    showManualPlayOption = showContinueWatchingManualPlayOption,
-                                    onPlayManually = onContinueWatchingPlayManually,
                                     onDetailsClick = { item ->
                                         onNavigateToDetail(
                                             when (item) {
@@ -273,6 +273,21 @@ fun GridHomeContent(
                                         onRemoveContinueWatching(contentId, season, episode, isNextUp)
                                     },
                                     blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes
+                                )
+                            }
+                        }
+
+                        if (!surpriseMeInserted) {
+                            surpriseMeInserted = true
+                            item(
+                                key = "surprise_me",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = "surprise_me"
+                            ) {
+                                SurpriseMeButton(
+                                    onClick = onSurpriseMe,
+                                    isLoading = isSurpriseMeLoading,
+                                    modifier = Modifier.padding(horizontal = 24.dp)
                                 )
                             }
                         }
@@ -389,8 +404,6 @@ fun GridHomeContent(
                             onContinueWatchingClick(item)
                         },
                         onStartFromBeginning = onContinueWatchingStartFromBeginning,
-                        showManualPlayOption = showContinueWatchingManualPlayOption,
-                        onPlayManually = onContinueWatchingPlayManually,
                         onDetailsClick = { item ->
                             onNavigateToDetail(
                                 when (item) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -81,7 +81,8 @@ fun GridHomeContent(
     onItemFocus: (com.nuvio.tv.domain.model.MetaPreview) -> Unit = {},
     onSaveGridFocusState: (Int, Int) -> Unit,
     onSurpriseMe: () -> Unit = {},
-    isSurpriseMeLoading: Boolean = false
+    isSurpriseMeLoading: Boolean = false,
+    showSurpriseMeButton: Boolean = true
 ) {
     val gridState = rememberLazyGridState(
         initialFirstVisibleItemIndex = gridFocusState.verticalScrollIndex,
@@ -284,11 +285,13 @@ fun GridHomeContent(
                                 span = { GridItemSpan(maxLineSpan) },
                                 contentType = "surprise_me"
                             ) {
-                                SurpriseMeButton(
-                                    onClick = onSurpriseMe,
-                                    isLoading = isSurpriseMeLoading,
-                                    modifier = Modifier.padding(horizontal = 24.dp)
-                                )
+                                if (showSurpriseMeButton) {
+                                    SurpriseMeButton(
+                                        onClick = onSurpriseMe,
+                                        isLoading = isSurpriseMeLoading,
+                                        modifier = Modifier.padding(horizontal = 24.dp)
+                                    )
+                                }
                             }
                         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -80,9 +80,11 @@ fun HomeScreen(
         )
     },
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = onContinueWatchingClick,
+    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = onContinueWatchingClick,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit = { _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsStateWithLifecycle(initialValue = false)
     val hasCatalogContent = uiState.catalogRows.any { it.items.isNotEmpty() }
     var hasEnteredCatalogContent by rememberSaveable { mutableStateOf(false) }
     var showHomeContentWithAnimation by rememberSaveable { mutableStateOf(false) }
@@ -246,7 +248,8 @@ fun HomeScreen(
                                 isCatalogItemWatched = isCatalogItemWatched,
                                 onCatalogItemLongPress = onCatalogItemLongPress,
                                 onSurpriseMe = onSurpriseMe,
-                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading,
+                                showSurpriseMeButton = uiState.showSurpriseMeButton
                             )
 
                             HomeLayout.GRID -> GridHomeRoute(
@@ -260,7 +263,8 @@ fun HomeScreen(
                                 isCatalogItemWatched = isCatalogItemWatched,
                                 onCatalogItemLongPress = onCatalogItemLongPress,
                                 onSurpriseMe = onSurpriseMe,
-                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading,
+                                showSurpriseMeButton = uiState.showSurpriseMeButton
                             )
 
                             HomeLayout.MODERN -> ModernHomeRoute(
@@ -274,7 +278,8 @@ fun HomeScreen(
                                 isCatalogItemWatched = isCatalogItemWatched,
                                 onCatalogItemLongPress = onCatalogItemLongPress,
                                 onSurpriseMe = onSurpriseMe,
-                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading,
+                                showSurpriseMeButton = uiState.showSurpriseMeButton
                             )
                         }
                     }
@@ -365,7 +370,8 @@ private fun ClassicHomeRoute(
     isCatalogItemWatched: (MetaPreview) -> Boolean,
     onCatalogItemLongPress: (MetaPreview, String) -> Unit,
     onSurpriseMe: () -> Unit,
-    isSurpriseMeLoading: Boolean
+    isSurpriseMeLoading: Boolean,
+    showSurpriseMeButton: Boolean
 ) {
     val focusState by viewModel.focusState.collectAsStateWithLifecycle()
     ClassicHomeContent(
@@ -393,7 +399,8 @@ private fun ClassicHomeRoute(
             viewModel.saveFocusState(vi, vo, ri, ii, m)
         },
         onSurpriseMe = onSurpriseMe,
-        isSurpriseMeLoading = isSurpriseMeLoading
+        isSurpriseMeLoading = isSurpriseMeLoading,
+        showSurpriseMeButton = showSurpriseMeButton
     )
 }
 
@@ -409,7 +416,8 @@ private fun GridHomeRoute(
     isCatalogItemWatched: (MetaPreview) -> Boolean,
     onCatalogItemLongPress: (MetaPreview, String) -> Unit,
     onSurpriseMe: () -> Unit,
-    isSurpriseMeLoading: Boolean
+    isSurpriseMeLoading: Boolean,
+    showSurpriseMeButton: Boolean
 ) {
     val gridFocusState by viewModel.gridFocusState.collectAsStateWithLifecycle()
     GridHomeContent(
@@ -432,7 +440,8 @@ private fun GridHomeRoute(
             viewModel.saveGridFocusState(vi, vo)
         },
         onSurpriseMe = onSurpriseMe,
-        isSurpriseMeLoading = isSurpriseMeLoading
+        isSurpriseMeLoading = isSurpriseMeLoading,
+        showSurpriseMeButton = showSurpriseMeButton
     )
 }
 
@@ -448,7 +457,8 @@ private fun ModernHomeRoute(
     isCatalogItemWatched: (MetaPreview) -> Boolean,
     onCatalogItemLongPress: (MetaPreview, String) -> Unit,
     onSurpriseMe: () -> Unit,
-    isSurpriseMeLoading: Boolean
+    isSurpriseMeLoading: Boolean,
+    showSurpriseMeButton: Boolean
 ) {
     val focusState by viewModel.focusState.collectAsStateWithLifecycle()
     val enrichingItemId by viewModel.enrichingItemId.collectAsStateWithLifecycle()
@@ -499,7 +509,8 @@ private fun ModernHomeRoute(
         onPreloadAdjacentItem = preloadAdjacentItem,
         onSaveFocusState = saveModernFocusState,
         onSurpriseMe = onSurpriseMe,
-        isSurpriseMeLoading = isSurpriseMeLoading
+        isSurpriseMeLoading = isSurpriseMeLoading,
+        showSurpriseMeButton = showSurpriseMeButton
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -80,13 +80,9 @@ fun HomeScreen(
         )
     },
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = onContinueWatchingClick,
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = onContinueWatchingClick,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit = { _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsStateWithLifecycle(
-        initialValue = false
-    )
     val hasCatalogContent = uiState.catalogRows.any { it.items.isNotEmpty() }
     var hasEnteredCatalogContent by rememberSaveable { mutableStateOf(false) }
     var showHomeContentWithAnimation by rememberSaveable { mutableStateOf(false) }
@@ -104,6 +100,16 @@ fun HomeScreen(
     }
     val onCatalogItemLongPress: (MetaPreview, String) -> Unit = remember(Unit) {
         { item, addonBaseUrl -> posterOptionsTarget = HomePosterOptionsTarget(item, addonBaseUrl) }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.surpriseMeNavigation.collect { (itemId, itemType, addonBaseUrl) ->
+            onNavigateToDetail(itemId, itemType, addonBaseUrl)
+        }
+    }
+
+    val onSurpriseMe = remember(viewModel) {
+        { viewModel.onEvent(HomeEvent.OnSurpriseMe) }
     }
 
     LaunchedEffect(hasCatalogContent) {
@@ -236,11 +242,11 @@ fun HomeScreen(
                                 onNavigateToDetail = onNavigateToDetail,
                                 onContinueWatchingClick = onContinueWatchingClick,
                                 onContinueWatchingStartFromBeginning = onContinueWatchingStartFromBeginning,
-                                onContinueWatchingPlayManually = onContinueWatchingPlayManually,
-                                showContinueWatchingManualPlayOption = effectiveAutoplayEnabled,
                                 onNavigateToCatalogSeeAll = onNavigateToCatalogSeeAll,
                                 isCatalogItemWatched = isCatalogItemWatched,
-                                onCatalogItemLongPress = onCatalogItemLongPress
+                                onCatalogItemLongPress = onCatalogItemLongPress,
+                                onSurpriseMe = onSurpriseMe,
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
                             )
 
                             HomeLayout.GRID -> GridHomeRoute(
@@ -250,11 +256,11 @@ fun HomeScreen(
                                 onNavigateToDetail = onNavigateToDetail,
                                 onContinueWatchingClick = onContinueWatchingClick,
                                 onContinueWatchingStartFromBeginning = onContinueWatchingStartFromBeginning,
-                                onContinueWatchingPlayManually = onContinueWatchingPlayManually,
-                                showContinueWatchingManualPlayOption = effectiveAutoplayEnabled,
                                 onNavigateToCatalogSeeAll = onNavigateToCatalogSeeAll,
                                 isCatalogItemWatched = isCatalogItemWatched,
-                                onCatalogItemLongPress = onCatalogItemLongPress
+                                onCatalogItemLongPress = onCatalogItemLongPress,
+                                onSurpriseMe = onSurpriseMe,
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
                             )
 
                             HomeLayout.MODERN -> ModernHomeRoute(
@@ -266,7 +272,9 @@ fun HomeScreen(
                                 onContinueWatchingPlayManually = onContinueWatchingPlayManually,
                                 showContinueWatchingManualPlayOption = effectiveAutoplayEnabled,
                                 isCatalogItemWatched = isCatalogItemWatched,
-                                onCatalogItemLongPress = onCatalogItemLongPress
+                                onCatalogItemLongPress = onCatalogItemLongPress,
+                                onSurpriseMe = onSurpriseMe,
+                                isSurpriseMeLoading = uiState.isSurpriseMeLoading
                             )
                         }
                     }
@@ -353,11 +361,11 @@ private fun ClassicHomeRoute(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit,
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit,
-    showContinueWatchingManualPlayOption: Boolean,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit,
     isCatalogItemWatched: (MetaPreview) -> Boolean,
-    onCatalogItemLongPress: (MetaPreview, String) -> Unit
+    onCatalogItemLongPress: (MetaPreview, String) -> Unit,
+    onSurpriseMe: () -> Unit,
+    isSurpriseMeLoading: Boolean
 ) {
     val focusState by viewModel.focusState.collectAsStateWithLifecycle()
     ClassicHomeContent(
@@ -369,8 +377,6 @@ private fun ClassicHomeRoute(
         onNavigateToDetail = onNavigateToDetail,
         onContinueWatchingClick = onContinueWatchingClick,
         onContinueWatchingStartFromBeginning = onContinueWatchingStartFromBeginning,
-        onContinueWatchingPlayManually = onContinueWatchingPlayManually,
-        showContinueWatchingManualPlayOption = showContinueWatchingManualPlayOption,
         onNavigateToCatalogSeeAll = onNavigateToCatalogSeeAll,
         onRemoveContinueWatching = { contentId, season, episode, isNextUp ->
             viewModel.onEvent(HomeEvent.OnRemoveContinueWatching(contentId, season, episode, isNextUp))
@@ -385,7 +391,9 @@ private fun ClassicHomeRoute(
         },
         onSaveFocusState = { vi, vo, ri, ii, m ->
             viewModel.saveFocusState(vi, vo, ri, ii, m)
-        }
+        },
+        onSurpriseMe = onSurpriseMe,
+        isSurpriseMeLoading = isSurpriseMeLoading
     )
 }
 
@@ -397,11 +405,11 @@ private fun GridHomeRoute(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit,
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit,
-    showContinueWatchingManualPlayOption: Boolean,
     onNavigateToCatalogSeeAll: (String, String, String) -> Unit,
     isCatalogItemWatched: (MetaPreview) -> Boolean,
-    onCatalogItemLongPress: (MetaPreview, String) -> Unit
+    onCatalogItemLongPress: (MetaPreview, String) -> Unit,
+    onSurpriseMe: () -> Unit,
+    isSurpriseMeLoading: Boolean
 ) {
     val gridFocusState by viewModel.gridFocusState.collectAsStateWithLifecycle()
     GridHomeContent(
@@ -411,8 +419,6 @@ private fun GridHomeRoute(
         onNavigateToDetail = onNavigateToDetail,
         onContinueWatchingClick = onContinueWatchingClick,
         onContinueWatchingStartFromBeginning = onContinueWatchingStartFromBeginning,
-        onContinueWatchingPlayManually = onContinueWatchingPlayManually,
-        showContinueWatchingManualPlayOption = showContinueWatchingManualPlayOption,
         onNavigateToCatalogSeeAll = onNavigateToCatalogSeeAll,
         onRemoveContinueWatching = { contentId, season, episode, isNextUp ->
             viewModel.onEvent(HomeEvent.OnRemoveContinueWatching(contentId, season, episode, isNextUp))
@@ -424,7 +430,9 @@ private fun GridHomeRoute(
         },
         onSaveGridFocusState = { vi, vo ->
             viewModel.saveGridFocusState(vi, vo)
-        }
+        },
+        onSurpriseMe = onSurpriseMe,
+        isSurpriseMeLoading = isSurpriseMeLoading
     )
 }
 
@@ -438,7 +446,9 @@ private fun ModernHomeRoute(
     onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit,
     showContinueWatchingManualPlayOption: Boolean,
     isCatalogItemWatched: (MetaPreview) -> Boolean,
-    onCatalogItemLongPress: (MetaPreview, String) -> Unit
+    onCatalogItemLongPress: (MetaPreview, String) -> Unit,
+    onSurpriseMe: () -> Unit,
+    isSurpriseMeLoading: Boolean
 ) {
     val focusState by viewModel.focusState.collectAsStateWithLifecycle()
     val enrichingItemId by viewModel.enrichingItemId.collectAsStateWithLifecycle()
@@ -487,7 +497,9 @@ private fun ModernHomeRoute(
             { item -> viewModel.onItemFocus(item) }
         },
         onPreloadAdjacentItem = preloadAdjacentItem,
-        onSaveFocusState = saveModernFocusState
+        onSaveFocusState = saveModernFocusState,
+        onSurpriseMe = onSurpriseMe,
+        isSurpriseMeLoading = isSurpriseMeLoading
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -53,7 +53,8 @@ data class HomeUiState(
     val showFullReleaseDate: Boolean = true,
     val blurUnwatchedEpisodes: Boolean = false,
     val startupAuthNotice: StartupAuthNotice? = null,
-    val isSurpriseMeLoading: Boolean = false
+    val isSurpriseMeLoading: Boolean = false,
+    val showSurpriseMeButton: Boolean = true
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -52,7 +52,8 @@ data class HomeUiState(
     val hideUnreleasedContent: Boolean = false,
     val showFullReleaseDate: Boolean = true,
     val blurUnwatchedEpisodes: Boolean = false,
-    val startupAuthNotice: StartupAuthNotice? = null
+    val startupAuthNotice: StartupAuthNotice? = null,
+    val isSurpriseMeLoading: Boolean = false
 )
 
 @Immutable
@@ -137,6 +138,7 @@ sealed class HomeEvent {
         val isNextUp: Boolean = false
     ) : HomeEvent()
     data object OnRetry : HomeEvent()
+    data object OnSurpriseMe : HomeEvent()
 }
 
 fun homeItemStatusKey(itemId: String, itemType: String): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -27,13 +27,17 @@ import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.CatalogRepository
 import com.nuvio.tv.domain.repository.LibraryRepository
 import com.nuvio.tv.domain.repository.MetaRepository
+import com.nuvio.tv.domain.repository.RecommendationRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -53,7 +57,6 @@ class HomeViewModel @Inject constructor(
     internal val libraryRepository: LibraryRepository,
     internal val metaRepository: MetaRepository,
     internal val layoutPreferenceDataStore: LayoutPreferenceDataStore,
-    internal val playerSettingsDataStore: PlayerSettingsDataStore,
     internal val tmdbSettingsDataStore: TmdbSettingsDataStore,
     internal val traktSettingsDataStore: TraktSettingsDataStore,
     internal val authSessionNoticeDataStore: AuthSessionNoticeDataStore,
@@ -61,7 +64,8 @@ class HomeViewModel @Inject constructor(
     internal val tmdbMetadataService: TmdbMetadataService,
     internal val trailerService: TrailerService,
     internal val watchedItemsPreferences: WatchedItemsPreferences,
-    internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
+    internal val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
+    private val recommendationRepository: RecommendationRepository
 ) : ViewModel() {
     companion object {
         internal const val TAG = "HomeViewModel"
@@ -97,6 +101,9 @@ class HomeViewModel @Inject constructor(
     internal val _enrichingItemId = MutableStateFlow<String?>(null)
     val enrichingItemId: StateFlow<String?> = _enrichingItemId.asStateFlow()
     internal fun setEnrichingItemId(id: String?) { _enrichingItemId.value = id }
+
+    private val _surpriseMeNavigation = MutableSharedFlow<Triple<String, String, String>>()
+    val surpriseMeNavigation: SharedFlow<Triple<String, String, String>> = _surpriseMeNavigation.asSharedFlow()
 
     internal val catalogsMap = linkedMapOf<String, CatalogRow>()
     internal val catalogOrder = mutableListOf<String>()
@@ -270,6 +277,7 @@ class HomeViewModel @Inject constructor(
                 isNextUp = event.isNextUp
             )
             HomeEvent.OnRetry -> viewModelScope.launch { loadAllCatalogs(addonsCache, forceReload = true) }
+            HomeEvent.OnSurpriseMe -> surpriseMe()
         }
     }
 
@@ -391,6 +399,20 @@ class HomeViewModel @Inject constructor(
             focusedRowIndex = focusedRowIndex,
             focusedItemIndex = focusedItemIndex
         )
+    }
+
+    private fun surpriseMe() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSurpriseMeLoading = true) }
+            try {
+                val item = recommendationRepository.getSurpriseRecommendation()
+                if (item != null) {
+                    _surpriseMeNavigation.emit(Triple(item.id, item.apiType, ""))
+                }
+            } finally {
+                _uiState.update { it.copy(isSurpriseMeLoading = false) }
+            }
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -57,6 +57,7 @@ class HomeViewModel @Inject constructor(
     internal val libraryRepository: LibraryRepository,
     internal val metaRepository: MetaRepository,
     internal val layoutPreferenceDataStore: LayoutPreferenceDataStore,
+    internal val playerSettingsDataStore: PlayerSettingsDataStore,
     internal val tmdbSettingsDataStore: TmdbSettingsDataStore,
     internal val traktSettingsDataStore: TraktSettingsDataStore,
     internal val authSessionNoticeDataStore: AuthSessionNoticeDataStore,
@@ -211,6 +212,13 @@ class HomeViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .collect { enabled ->
                     _uiState.update { it.copy(blurUnwatchedEpisodes = enabled) }
+                }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.showSurpriseMeButton
+                .distinctUntilChanged()
+                .collect { enabled ->
+                    _uiState.update { it.copy(showSurpriseMeButton = enabled) }
                 }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -101,6 +101,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ContinueWatchingCard
 import com.nuvio.tv.ui.components.ContinueWatchingOptionsDialog
 import com.nuvio.tv.ui.components.MonochromePosterPlaceholder
+import com.nuvio.tv.ui.components.SurpriseMeButton
 import com.nuvio.tv.ui.components.TrailerPlayer
 import com.nuvio.tv.LocalSidebarExpanded
 import com.nuvio.tv.LocalContentFocusRequester
@@ -133,8 +134,6 @@ fun ModernHomeContent(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = {},
-    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = {},
-    showContinueWatchingManualPlayOption: Boolean = false,
     onRequestTrailerPreview: (String, String, String?, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
@@ -142,7 +141,9 @@ fun ModernHomeContent(
     onCatalogItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> },
     onItemFocus: (MetaPreview) -> Unit = {},
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
-    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit
+    onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
+    onSurpriseMe: () -> Unit = {},
+    isSurpriseMeLoading: Boolean = false
 ) {
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val isSidebarExpanded = LocalSidebarExpanded.current
@@ -724,6 +725,14 @@ fun ModernHomeContent(
                 contentPadding = PaddingValues(bottom = rowsViewportHeight),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
+                item(key = "surprise_me", contentType = "surprise_me") {
+                    SurpriseMeButton(
+                        onClick = onSurpriseMe,
+                        isLoading = isSurpriseMeLoading,
+                        modifier = Modifier.padding(horizontal = 48.dp)
+                    )
+                }
+
                 itemsIndexed(
                     items = carouselRows,
                     key = { _, row -> row.key },
@@ -857,11 +866,6 @@ fun ModernHomeContent(
             },
             onStartFromBeginning = {
                 onContinueWatchingStartFromBeginning(selectedOptionsItem)
-                optionsItem = null
-            },
-            showPlayManually = showContinueWatchingManualPlayOption,
-            onPlayManually = {
-                onContinueWatchingPlayManually(selectedOptionsItem)
                 optionsItem = null
             }
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -134,6 +134,8 @@ fun ModernHomeContent(
     onNavigateToDetail: (String, String, String) -> Unit,
     onContinueWatchingClick: (ContinueWatchingItem) -> Unit,
     onContinueWatchingStartFromBeginning: (ContinueWatchingItem) -> Unit = {},
+    onContinueWatchingPlayManually: (ContinueWatchingItem) -> Unit = {},
+    showContinueWatchingManualPlayOption: Boolean = false,
     onRequestTrailerPreview: (String, String, String?, String) -> Unit,
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onRemoveContinueWatching: (String, Int?, Int?, Boolean) -> Unit,
@@ -143,7 +145,8 @@ fun ModernHomeContent(
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, Int, Int, Map<String, Int>) -> Unit,
     onSurpriseMe: () -> Unit = {},
-    isSurpriseMeLoading: Boolean = false
+    isSurpriseMeLoading: Boolean = false,
+    showSurpriseMeButton: Boolean = true
 ) {
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val isSidebarExpanded = LocalSidebarExpanded.current
@@ -725,12 +728,14 @@ fun ModernHomeContent(
                 contentPadding = PaddingValues(bottom = rowsViewportHeight),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
-                item(key = "surprise_me", contentType = "surprise_me") {
-                    SurpriseMeButton(
-                        onClick = onSurpriseMe,
-                        isLoading = isSurpriseMeLoading,
-                        modifier = Modifier.padding(horizontal = 48.dp)
-                    )
+                if (showSurpriseMeButton) {
+                    item(key = "surprise_me", contentType = "surprise_me") {
+                        SurpriseMeButton(
+                            onClick = onSurpriseMe,
+                            isLoading = isSurpriseMeLoading,
+                            modifier = Modifier.padding(horizontal = 48.dp)
+                        )
+                    }
                 }
 
                 itemsIndexed(
@@ -866,6 +871,11 @@ fun ModernHomeContent(
             },
             onStartFromBeginning = {
                 onContinueWatchingStartFromBeginning(selectedOptionsItem)
+                optionsItem = null
+            },
+            showPlayManually = showContinueWatchingManualPlayOption,
+            onPlayManually = {
+                onContinueWatchingPlayManually(selectedOptionsItem)
                 optionsItem = null
             }
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +37,13 @@ fun DiscoverScreen(
     val uiState by viewModel.uiState.collectAsState()
     val watchedMovieIds by viewModel.watchedMovieIds.collectAsState()
     val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.surpriseMeNavigation.collect { (itemId, itemType, addonBaseUrl) ->
+            onNavigateToDetail(itemId, itemType, addonBaseUrl)
+        }
+    }
+
     val lifecycleOwner = LocalLifecycleOwner.current
     val discoverFirstItemFocusRequester = remember { FocusRequester() }
     var discoverFocusedItemIndex by rememberSaveable { mutableStateOf(0) }
@@ -95,6 +103,8 @@ fun DiscoverScreen(
                 onSelectCatalog = { viewModel.onEvent(SearchEvent.SelectDiscoverCatalog(it)) },
                 onSelectGenre = { viewModel.onEvent(SearchEvent.SelectDiscoverGenre(it)) },
                 onLoadMore = { viewModel.onEvent(SearchEvent.LoadNextDiscoverResults) },
+                onSurpriseMe = { viewModel.onEvent(SearchEvent.SurpriseMe) },
+                isSurpriseMeLoading = uiState.isSurpriseMeLoading,
                 modifier = Modifier.padding(top = 16.dp)
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/DiscoverScreen.kt
@@ -105,6 +105,7 @@ fun DiscoverScreen(
                 onLoadMore = { viewModel.onEvent(SearchEvent.LoadNextDiscoverResults) },
                 onSurpriseMe = { viewModel.onEvent(SearchEvent.SurpriseMe) },
                 isSurpriseMeLoading = uiState.isSurpriseMeLoading,
+                showSurpriseMeButton = uiState.showSurpriseMeButton,
                 modifier = Modifier.padding(top = 16.dp)
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -60,6 +60,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.EmptyScreenState
 import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.LoadingIndicator
+import com.nuvio.tv.ui.components.SurpriseMeButton
 import com.nuvio.tv.ui.components.PosterCardStyle
 import com.nuvio.tv.ui.theme.NuvioColors
 import com.nuvio.tv.ui.util.formatAddonTypeLabel
@@ -83,6 +84,8 @@ internal fun DiscoverSection(
     onSelectCatalog: (String) -> Unit,
     onSelectGenre: (String?) -> Unit,
     onLoadMore: () -> Unit,
+    onSurpriseMe: () -> Unit = {},
+    isSurpriseMeLoading: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val selectedCatalog = uiState.discoverCatalogs.firstOrNull { it.key == uiState.selectedDiscoverCatalogKey }
@@ -173,6 +176,11 @@ internal fun DiscoverSection(
                     onSelectGenre(option.value.takeUnless { it == "__default__" })
                     expandedPicker = null
                 }
+            )
+
+            SurpriseMeButton(
+                onClick = onSurpriseMe,
+                isLoading = isSurpriseMeLoading
             )
         }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchDiscoverSection.kt
@@ -86,6 +86,7 @@ internal fun DiscoverSection(
     onLoadMore: () -> Unit,
     onSurpriseMe: () -> Unit = {},
     isSurpriseMeLoading: Boolean = false,
+    showSurpriseMeButton: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val selectedCatalog = uiState.discoverCatalogs.firstOrNull { it.key == uiState.selectedDiscoverCatalogKey }
@@ -178,10 +179,12 @@ internal fun DiscoverSection(
                 }
             )
 
-            SurpriseMeButton(
-                onClick = onSurpriseMe,
-                isLoading = isSurpriseMeLoading
-            )
+            if (showSurpriseMeButton) {
+                SurpriseMeButton(
+                    onClick = onSurpriseMe,
+                    isLoading = isSurpriseMeLoading
+                )
+            }
         }
 
         selectedCatalog?.let { catalog ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
@@ -16,4 +16,5 @@ sealed interface SearchEvent {
     data object LoadNextDiscoverResults : SearchEvent
 
     data object Retry : SearchEvent
+    data object SurpriseMe : SearchEvent
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
@@ -31,7 +31,8 @@ data class SearchUiState(
     val posterCardWidthDp: Int = 126,
     val posterCardHeightDp: Int = 189,
     val posterCardCornerRadiusDp: Int = 12,
-    val suggestions: List<String> = emptyList()
+    val suggestions: List<String> = emptyList(),
+    val isSurpriseMeLoading: Boolean = false
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchUiState.kt
@@ -32,7 +32,8 @@ data class SearchUiState(
     val posterCardHeightDp: Int = 189,
     val posterCardCornerRadiusDp: Int = 12,
     val suggestions: List<String> = emptyList(),
-    val isSurpriseMeLoading: Boolean = false
+    val isSurpriseMeLoading: Boolean = false,
+    val showSurpriseMeButton: Boolean = true
 )
 
 @Immutable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -14,10 +14,14 @@ import com.nuvio.tv.core.util.isUnreleased
 import com.nuvio.tv.domain.repository.AddonRepository
 import java.time.LocalDate
 import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.RecommendationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -33,7 +37,8 @@ class SearchViewModel @Inject constructor(
     private val catalogRepository: CatalogRepository,
     private val layoutPreferenceDataStore: LayoutPreferenceDataStore,
     private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
-    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder
+    private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
+    private val recommendationRepository: RecommendationRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())
@@ -42,6 +47,9 @@ class SearchViewModel @Inject constructor(
     private val _watchedMovieIds = MutableStateFlow<Set<String>>(emptySet())
     val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
     val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
+
+    private val _surpriseMeNavigation = MutableSharedFlow<Triple<String, String, String>>()
+    val surpriseMeNavigation: SharedFlow<Triple<String, String, String>> = _surpriseMeNavigation.asSharedFlow()
 
     private val catalogsMap = linkedMapOf<String, CatalogRow>()
     private val catalogOrder = mutableListOf<String>()
@@ -142,6 +150,7 @@ class SearchViewModel @Inject constructor(
             is SearchEvent.SelectDiscoverGenre -> selectDiscoverGenre(event.genre)
             SearchEvent.LoadNextDiscoverResults -> loadNextDiscoverResults()
             SearchEvent.Retry -> performSearch(uiState.value.submittedQuery.ifBlank { uiState.value.query })
+            SearchEvent.SurpriseMe -> surpriseMe()
         }
     }
 
@@ -738,5 +747,19 @@ class SearchViewModel @Inject constructor(
 
     private fun catalogKey(addonId: String, type: String, catalogId: String): String {
         return "${addonId}_${type}_${catalogId}"
+    }
+
+    private fun surpriseMe() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSurpriseMeLoading = true) }
+            try {
+                val item = recommendationRepository.getSurpriseRecommendation()
+                if (item != null) {
+                    _surpriseMeNavigation.emit(Triple(item.id, item.apiType, ""))
+                }
+            } finally {
+                _uiState.update { it.copy(isSurpriseMeLoading = false) }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
@@ -125,6 +126,13 @@ class SearchViewModel @Inject constructor(
                 hideUnreleasedContent = enabled
                 scheduleCatalogRowsUpdate()
             }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.showSurpriseMeButton
+                .distinctUntilChanged()
+                .collectLatest { enabled ->
+                    _uiState.update { it.copy(showSurpriseMeButton = enabled) }
+                }
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -340,6 +340,17 @@ fun LayoutSettingsContent(
                         },
                         onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
                     )
+                    CompactToggleRow(
+                        title = stringResource(R.string.layout_show_surprise_me),
+                        subtitle = stringResource(R.string.layout_show_surprise_me_sub),
+                        checked = uiState.showSurpriseMeButton,
+                        onToggle = {
+                            viewModel.onEvent(
+                                LayoutSettingsEvent.SetShowSurpriseMeButton(!uiState.showSurpriseMeButton)
+                            )
+                        },
+                        onFocused = { focusedSection = LayoutSettingsSection.HOME_CONTENT }
+                    )
                     if (uiState.selectedLayout != HomeLayout.MODERN) {
                         CompactToggleRow(
                             title = stringResource(R.string.layout_poster_labels),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsViewModel.kt
@@ -45,7 +45,8 @@ data class LayoutSettingsUiState(
     val detailPageTrailerButtonEnabled: Boolean = false,
     val preferExternalMetaAddonDetail: Boolean = false,
     val hideUnreleasedContent: Boolean = false,
-    val showFullReleaseDate: Boolean = true
+    val showFullReleaseDate: Boolean = true,
+    val showSurpriseMeButton: Boolean = true
 )
 
 data class CatalogInfo(
@@ -82,6 +83,7 @@ sealed class LayoutSettingsEvent {
     data class SetPreferExternalMetaAddonDetail(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetHideUnreleasedContent(val enabled: Boolean) : LayoutSettingsEvent()
     data class SetShowFullReleaseDate(val enabled: Boolean) : LayoutSettingsEvent()
+    data class SetShowSurpriseMeButton(val enabled: Boolean) : LayoutSettingsEvent()
     data object ResetPosterCardStyle : LayoutSettingsEvent()
 }
 
@@ -240,6 +242,11 @@ class LayoutSettingsViewModel @Inject constructor(
                 updateUiStateIfChanged { it.copy(showFullReleaseDate = enabled) }
             }
         }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.showSurpriseMeButton.distinctUntilChanged().collectLatest { enabled ->
+                updateUiStateIfChanged { it.copy(showSurpriseMeButton = enabled) }
+            }
+        }
         loadAvailableCatalogs()
     }
 
@@ -271,6 +278,7 @@ class LayoutSettingsViewModel @Inject constructor(
             is LayoutSettingsEvent.SetPreferExternalMetaAddonDetail -> setPreferExternalMetaAddonDetail(event.enabled)
             is LayoutSettingsEvent.SetHideUnreleasedContent -> setHideUnreleasedContent(event.enabled)
             is LayoutSettingsEvent.SetShowFullReleaseDate -> setShowFullReleaseDate(event.enabled)
+            is LayoutSettingsEvent.SetShowSurpriseMeButton -> setShowSurpriseMeButton(event.enabled)
             LayoutSettingsEvent.ResetPosterCardStyle -> resetPosterCardStyle()
         }
     }
@@ -454,6 +462,13 @@ class LayoutSettingsViewModel @Inject constructor(
         if (_uiState.value.showFullReleaseDate == enabled) return
         viewModelScope.launch {
             layoutPreferenceDataStore.setShowFullReleaseDate(enabled)
+        }
+    }
+
+    private fun setShowSurpriseMeButton(enabled: Boolean) {
+        if (_uiState.value.showSurpriseMeButton == enabled) return
+        viewModelScope.launch {
+            layoutPreferenceDataStore.setShowSurpriseMeButton(enabled)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,10 @@
     <string name="layout_show_hero_sub">Display hero carousel at top of home.</string>
     <string name="layout_show_discover">Show Discover in Search</string>
     <string name="layout_show_discover_sub">Show browse section when search is empty.</string>
+    <string name="surprise_me">Surprise Me</string>
+    <string name="surprise_me_loading">Finding something…</string>
+    <string name="layout_show_surprise_me">Show Surprise Me Button</string>
+    <string name="layout_show_surprise_me_sub">Display a button on the home screen to pick a random title.</string>
     <string name="layout_poster_labels">Show Poster Labels</string>
     <string name="layout_poster_labels_sub">Show titles under posters in rows, grid, and see-all.</string>
     <string name="layout_addon_name">Show Addon Name</string>

--- a/app/src/test/java/com/nuvio/tv/data/repository/RecommendationRepositoryImplTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/RecommendationRepositoryImplTest.kt
@@ -1,0 +1,319 @@
+package com.nuvio.tv.data.repository
+
+import android.util.Log
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogExtra
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RecommendationRepositoryImplTest {
+
+    private lateinit var watchProgressRepository: WatchProgressRepository
+    private lateinit var addonRepository: AddonRepository
+    private lateinit var catalogRepository: CatalogRepository
+    private lateinit var repository: RecommendationRepositoryImpl
+
+    private fun metaPreview(
+        id: String,
+        name: String = "Title $id",
+        genres: List<String> = emptyList(),
+        imdbRating: Float? = null,
+        releaseInfo: String? = null,
+        type: ContentType = ContentType.MOVIE
+    ) = MetaPreview(
+        id = id,
+        type = type,
+        name = name,
+        poster = null,
+        posterShape = PosterShape.POSTER,
+        background = null,
+        logo = null,
+        description = null,
+        releaseInfo = releaseInfo,
+        imdbRating = imdbRating,
+        genres = genres
+    )
+
+    private fun watchProgress(contentId: String, contentType: String = "movie") = WatchProgress(
+        contentId = contentId,
+        contentType = contentType,
+        name = "Title $contentId",
+        poster = null,
+        backdrop = null,
+        logo = null,
+        videoId = contentId,
+        season = null,
+        episode = null,
+        episodeTitle = null,
+        position = 1000L,
+        duration = 5000L,
+        lastWatched = System.currentTimeMillis(),
+        addonBaseUrl = null,
+        progressPercent = null,
+        traktPlaybackId = null,
+        traktMovieId = null,
+        traktShowId = null,
+        traktEpisodeId = null
+    )
+
+    private fun addon(
+        id: String = "test-addon",
+        baseUrl: String = "https://addon.example.com",
+        catalogs: List<CatalogDescriptor> = emptyList()
+    ) = Addon(
+        id = id,
+        name = "Test Addon",
+        version = "1.0",
+        description = null,
+        logo = null,
+        baseUrl = baseUrl,
+        catalogs = catalogs,
+        types = listOf(ContentType.MOVIE, ContentType.SERIES),
+        resources = listOf(AddonResource("catalog", listOf("movie", "series"), null))
+    )
+
+    private fun catalogDescriptor(
+        id: String = "top",
+        name: String = "Top",
+        type: ContentType = ContentType.MOVIE,
+        hasGenreFilter: Boolean = false,
+        genres: List<String> = emptyList()
+    ) = CatalogDescriptor(
+        type = type,
+        id = id,
+        name = name,
+        extra = if (hasGenreFilter) {
+            listOf(CatalogExtra(name = "genre", options = genres.ifEmpty { null }))
+        } else {
+            emptyList()
+        }
+    )
+
+    private fun catalogRow(
+        items: List<MetaPreview>,
+        addonId: String = "test-addon",
+        catalogId: String = "top",
+        type: ContentType = ContentType.MOVIE
+    ) = CatalogRow(
+        addonId = addonId,
+        addonName = "Test Addon",
+        addonBaseUrl = "https://addon.example.com",
+        catalogId = catalogId,
+        catalogName = "Top",
+        type = type,
+        items = items
+    )
+
+    @Before
+    fun setup() {
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
+
+        watchProgressRepository = mockk()
+        addonRepository = mockk()
+        catalogRepository = mockk()
+        repository = RecommendationRepositoryImpl(
+            watchProgressRepository = watchProgressRepository,
+            addonRepository = addonRepository,
+            catalogRepository = catalogRepository
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `getSurpriseRecommendation with no addons returns null`() = runTest {
+        every { addonRepository.getInstalledAddons() } returns flowOf(emptyList())
+        every { watchProgressRepository.allProgress } returns flowOf(emptyList())
+
+        val result = repository.getSurpriseRecommendation()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getSurpriseRecommendation with empty history returns fallback item`() = runTest {
+        val items = listOf(
+            metaPreview("tt1", genres = listOf("Action")),
+            metaPreview("tt2", genres = listOf("Drama"))
+        )
+        val catalog = catalogDescriptor(id = "top")
+        val testAddon = addon(catalogs = listOf(catalog))
+
+        every { addonRepository.getInstalledAddons() } returns flowOf(listOf(testAddon))
+        every { watchProgressRepository.allProgress } returns flowOf(emptyList())
+        every {
+            catalogRepository.getCatalog(
+                addonBaseUrl = any(),
+                addonId = any(),
+                addonName = any(),
+                catalogId = any(),
+                catalogName = any(),
+                type = any(),
+                skip = any(),
+                skipStep = any(),
+                extraArgs = any(),
+                supportsSkip = any()
+            )
+        } returns flowOf(NetworkResult.Success(catalogRow(items)))
+
+        val result = repository.getSurpriseRecommendation()
+        assertNotNull(result)
+        assertTrue(result!!.id in listOf("tt1", "tt2"))
+    }
+
+    @Test
+    fun `getSurpriseRecommendation excludes already watched items`() = runTest {
+        val watched = listOf(watchProgress("tt1"))
+        val catalogItems = listOf(
+            metaPreview("tt1", genres = listOf("Action")),
+            metaPreview("tt2", genres = listOf("Action")),
+            metaPreview("tt3", genres = listOf("Drama"))
+        )
+        val catalog = catalogDescriptor(id = "top")
+        val testAddon = addon(catalogs = listOf(catalog))
+
+        every { addonRepository.getInstalledAddons() } returns flowOf(listOf(testAddon))
+        every { watchProgressRepository.allProgress } returns flowOf(watched)
+        every {
+            catalogRepository.getCatalog(
+                addonBaseUrl = any(),
+                addonId = any(),
+                addonName = any(),
+                catalogId = any(),
+                catalogName = any(),
+                type = any(),
+                skip = any(),
+                skipStep = any(),
+                extraArgs = any(),
+                supportsSkip = any()
+            )
+        } returns flowOf(NetworkResult.Success(catalogRow(catalogItems)))
+
+        val result = repository.getSurpriseRecommendation()
+        assertNotNull(result)
+        // tt1 was watched, so it should not be recommended
+        assertTrue(result!!.id != "tt1")
+    }
+
+    @Test
+    fun `selectWeightedRandom returns genre matched item with higher probability`() {
+        val candidates = listOf(
+            metaPreview("tt1", genres = listOf("Action", "Drama"), imdbRating = 8.0f),
+            metaPreview("tt2", genres = listOf("Comedy"), imdbRating = 5.0f),
+            metaPreview("tt3", genres = listOf("Horror"), imdbRating = 3.0f)
+        )
+        val topGenres = listOf("Action", "Drama")
+
+        // Run multiple times and verify that genre-matched items are selected more often
+        val results = mutableMapOf<String, Int>()
+        repeat(100) {
+            val result = repository.selectWeightedRandom(candidates, topGenres)
+            assertNotNull(result)
+            results[result!!.id] = (results[result.id] ?: 0) + 1
+        }
+
+        // tt1 has 2 genre matches + high rating, should be selected most often
+        val tt1Count = results["tt1"] ?: 0
+        val tt3Count = results["tt3"] ?: 0
+        assertTrue("tt1 ($tt1Count) should be selected more than tt3 ($tt3Count)", tt1Count > tt3Count)
+    }
+
+    @Test
+    fun `selectWeightedRandom with empty candidates returns null`() {
+        val result = repository.selectWeightedRandom(emptyList(), listOf("Action"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `getSurpriseRecommendation with watch history uses genre based selection`() = runTest {
+        val watched = listOf(
+            watchProgress("tt1"),
+            watchProgress("tt2"),
+            watchProgress("tt3")
+        )
+        // Catalog items include watched items (with genre data) and unwatched items
+        val catalogItems = listOf(
+            metaPreview("tt1", genres = listOf("Action", "Thriller")),
+            metaPreview("tt2", genres = listOf("Action")),
+            metaPreview("tt3", genres = listOf("Action", "Drama")),
+            metaPreview("tt4", genres = listOf("Action", "Thriller"), imdbRating = 7.5f),
+            metaPreview("tt5", genres = listOf("Romance"), imdbRating = 6.0f)
+        )
+        val genreCatalogItems = listOf(
+            metaPreview("tt4", genres = listOf("Action", "Thriller"), imdbRating = 7.5f),
+            metaPreview("tt6", genres = listOf("Action"), imdbRating = 8.0f)
+        )
+        val catalog = catalogDescriptor(id = "top")
+        val genreCatalog = catalogDescriptor(
+            id = "genre-catalog",
+            hasGenreFilter = true,
+            genres = listOf("Action", "Drama", "Thriller")
+        )
+        val testAddon = addon(catalogs = listOf(catalog, genreCatalog))
+
+        every { addonRepository.getInstalledAddons() } returns flowOf(listOf(testAddon))
+        every { watchProgressRepository.allProgress } returns flowOf(watched)
+        every {
+            catalogRepository.getCatalog(
+                addonBaseUrl = any(),
+                addonId = any(),
+                addonName = any(),
+                catalogId = eq("top"),
+                catalogName = any(),
+                type = any(),
+                skip = any(),
+                skipStep = any(),
+                extraArgs = any(),
+                supportsSkip = any()
+            )
+        } returns flowOf(NetworkResult.Success(catalogRow(catalogItems)))
+        every {
+            catalogRepository.getCatalog(
+                addonBaseUrl = any(),
+                addonId = any(),
+                addonName = any(),
+                catalogId = eq("genre-catalog"),
+                catalogName = any(),
+                type = any(),
+                skip = any(),
+                skipStep = any(),
+                extraArgs = any(),
+                supportsSkip = any()
+            )
+        } returns flowOf(NetworkResult.Success(catalogRow(genreCatalogItems, catalogId = "genre-catalog")))
+
+        val result = repository.getSurpriseRecommendation()
+        assertNotNull(result)
+        // Should not recommend already watched items
+        assertTrue(result!!.id !in listOf("tt1", "tt2", "tt3"))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **"Surprise Me"** button to all home layouts (Classic, Grid, Modern) and the Discover screen
- When pressed, picks a smart recommendation from the user's installed catalog addons and navigates directly to its detail page
- Shows a loading indicator while the recommendation is being fetched

---

## How It Works

It's not purely random — it's a **genre-weighted recommendation** with a 2-second timeout.

### 1. Trigger

Button press → `HomeEvent.OnSurpriseMe` → `viewModel.surpriseMe()` → `recommendationRepository.getSurpriseRecommendation()`

### 2. Build Watch History Profile

- Fetches your last **50 watched items** from `WatchProgressRepository`
- Queries up to **4 catalog pages** (first 2 catalogs from each installed addon)
- Matches watched item IDs against catalog entries to extract their genres
- Builds a **genre frequency map** — e.g. `{ "Action": 5, "Drama": 3, "Sci-Fi": 2 }`

### 3. Genre-Based Candidate Fetch

- Takes your **top 2 genres** by frequency
- Looks for catalogs that support `genre` filtering
  - ✅ If found: fetches results filtered by your top genre
  - ❌ If not: falls back to unfiltered catalogs
- Excludes already-watched items, deduplicates, keeps up to **50 candidates**

### 4. Weighted Scoring

Each candidate is scored:
score = (genre_matches × 3) + imdb_rating + recency_bonus

- `genre_matches` — how many of the item's genres appear in your top 2
- `imdb_rating` — raw rating value (default 5.0 if missing)
- `recency_bonus` — +2 if released in the current or previous year

Then:
1. Sort by score, take the **top 10**
2. Run a **weighted random pick** — higher scores are more likely, but any of the 10 can win

### 5. Fallback (No Watch History)

If you're a new user or genres can't be resolved, it simply picks a **random unwatched item** from the first available catalog.

### 6. Navigation

Result is emitted as `Triple(id, type, addonBaseUrl)` via a `SharedFlow` → collected in a `LaunchedEffect` in the composable → navigates directly to the detail screen.

---

## PR Type

- Approved larger change (link approval below)

## Why

Users often browse without knowing what to watch. This feature reduces decision fatigue by letting the app pick something based on their watch history and configured sources.

## Policy Check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- Manually tested on all three home layouts (Classic, Grid, Modern) — button appears and triggers navigation to a random detail page
- Manually tested on the Discover screen
- Loading state shows correctly while recommendation is being resolved
- Unit tests added: `RecommendationRepositoryImplTest`

## Screenshots / Video (UI changes only)
<img width="1920" height="1080" alt="surpriseme1" src="https://github.com/user-attachments/assets/3803335f-f5ad-4939-9a63-41615364640b" />
<img width="1920" height="1080" alt="surpriseme2" src="https://github.com/user-attachments/assets/8c7aff09-bc3b-4049-8eaf-d71815590a15" />



## Breaking Changes

None

## Linked Issues

