### PR TITLE
Feature/frame rate detection mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
@@ -355,6 +355,7 @@ object FrameRateUtils {
         sourceUrl: String,
         headers: Map<String, String> = emptyMap()
     ): FrameRateDetection? {
+        Log.d(TAG, "probe=NextLib ENTER")
         return detectFrameRateWithNextLib(context, sourceUrl, headers)
     }
 
@@ -363,6 +364,7 @@ object FrameRateUtils {
         sourceUrl: String,
         headers: Map<String, String> = emptyMap()
     ): FrameRateDetection? {
+        Log.d(TAG, "probe=Extractor ENTER")
         if (isResolveProxyUrl(sourceUrl)) {
             val embeddedResolveUrl = extractEmbeddedResolveUrl(sourceUrl)
             if (!embeddedResolveUrl.isNullOrBlank()) {

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -182,6 +182,7 @@ data class PlayerSettings(
     val mpvHardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE,
     // Display settings
     val frameRateMatchingMode: FrameRateMatchingMode = FrameRateMatchingMode.OFF,
+    val frameRateDetectionMode: FrameRateDetectionMode = FrameRateDetectionMode.ACCURATE,
     val resolutionMatchingEnabled: Boolean = false,
     // Stream selection settings
     val streamAutoPlayMode: StreamAutoPlayMode = StreamAutoPlayMode.MANUAL,
@@ -218,6 +219,12 @@ enum class FrameRateMatchingMode {
     OFF,
     START,
     START_STOP
+}
+
+enum class FrameRateDetectionMode {
+    ACCURATE,
+    FAST,
+    SEAMLESS
 }
 
 enum class NextEpisodeThresholdMode {
@@ -311,6 +318,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
     private val frameRateMatchingKey = booleanPreferencesKey("frame_rate_matching")
     private val frameRateMatchingModeKey = stringPreferencesKey("frame_rate_matching_mode")
+    private val frameRateDetectionModeKey = stringPreferencesKey("frame_rate_detection_mode")
     private val resolutionMatchingEnabledKey = booleanPreferencesKey("resolution_matching_enabled")
     private val streamAutoPlayModeKey = stringPreferencesKey("stream_auto_play_mode")
     private val streamAutoPlaySourceKey = stringPreferencesKey("stream_auto_play_source")
@@ -466,6 +474,9 @@ class PlayerSettingsDataStore @Inject constructor(
                 } else {
                     FrameRateMatchingMode.OFF
                 },
+                frameRateDetectionMode = prefs[frameRateDetectionModeKey]?.let {
+                    runCatching { FrameRateDetectionMode.valueOf(it) }.getOrNull()
+                } ?: FrameRateDetectionMode.ACCURATE,
                 resolutionMatchingEnabled = prefs[resolutionMatchingEnabledKey] ?: false,
                 streamAutoPlayMode = prefs[streamAutoPlayModeKey]?.let {
                     runCatching { StreamAutoPlayMode.valueOf(it) }.getOrDefault(StreamAutoPlayMode.MANUAL)
@@ -666,6 +677,12 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             prefs[frameRateMatchingModeKey] = mode.name
             prefs[frameRateMatchingKey] = mode != FrameRateMatchingMode.OFF
+        }
+    }
+
+    suspend fun setFrameRateDetectionMode(mode: FrameRateDetectionMode) {
+        store().edit { prefs ->
+            prefs[frameRateDetectionModeKey] = mode.name
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withContext
 
 private const val AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS = 30000L
+private const val AFR_PREFLIGHT_FAST_EXTRACTOR_TIMEOUT_MS = 30000L
 private const val AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS = 5500L
 
 internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
@@ -61,7 +62,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
 
             FrameRateDetectionMode.FAST -> {
                 Log.d(PlayerRuntimeController.TAG, "AFR preflight detection mode=FAST (extractor-only)")
-                withTimeoutOrNull(AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS) {
+                withTimeoutOrNull(AFR_PREFLIGHT_FAST_EXTRACTOR_TIMEOUT_MS) {
                     withContext(Dispatchers.IO) {
                         FrameRateUtils.detectFrameRateFromExtractor(
                             context = context,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerAfrPreflight.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.os.Build
 import android.util.Log
 import com.nuvio.tv.core.player.FrameRateUtils
+import com.nuvio.tv.data.local.FrameRateDetectionMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -17,6 +18,7 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
     url: String,
     headers: Map<String, String>,
     frameRateMatchingMode: FrameRateMatchingMode,
+    frameRateDetectionMode: FrameRateDetectionMode,
     resolutionMatchingEnabled: Boolean
 ) {
     mpvDelayStartAfterAfrSwitch = false
@@ -51,37 +53,69 @@ internal suspend fun PlayerRuntimeController.runAfrPreflightIfEnabled(
     val probeHeaders = headers.filterKeys { !it.equals("Range", ignoreCase = true) }
 
     try {
-        val nextLibDetection = withTimeoutOrNull(AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS) {
-            withContext(Dispatchers.IO) {
-                FrameRateUtils.detectFrameRateFromNextLib(
-                    context = context,
-                    sourceUrl = url,
-                    headers = probeHeaders
-                )
+        val detection = when (frameRateDetectionMode) {
+            FrameRateDetectionMode.SEAMLESS -> {
+                Log.d(PlayerRuntimeController.TAG, "AFR preflight detection mode=SEAMLESS (skip probe)")
+                null
             }
-        }
-        val detection = if (nextLibDetection != null) {
-            nextLibDetection
-        } else {
-            Log.w(
-                PlayerRuntimeController.TAG,
-                "AFR preflight NextLib probe failed/timed out after ${AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS}ms; trying extractor fallback"
-            )
-            withTimeoutOrNull(AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS) {
-                withContext(Dispatchers.IO) {
-                    FrameRateUtils.detectFrameRateFromExtractor(
-                        context = context,
-                        sourceUrl = url,
-                        headers = probeHeaders
+
+            FrameRateDetectionMode.FAST -> {
+                Log.d(PlayerRuntimeController.TAG, "AFR preflight detection mode=FAST (extractor-only)")
+                withTimeoutOrNull(AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS) {
+                    withContext(Dispatchers.IO) {
+                        FrameRateUtils.detectFrameRateFromExtractor(
+                            context = context,
+                            sourceUrl = url,
+                            headers = probeHeaders
+                        )
+                    }
+                }
+            }
+
+            FrameRateDetectionMode.ACCURATE -> {
+                Log.d(PlayerRuntimeController.TAG, "AFR preflight detection mode=ACCURATE (NextLib first)")
+                val nextLibDetection = withTimeoutOrNull(AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS) {
+                    withContext(Dispatchers.IO) {
+                        FrameRateUtils.detectFrameRateFromNextLib(
+                            context = context,
+                            sourceUrl = url,
+                            headers = probeHeaders
+                        )
+                    }
+                }
+                if (nextLibDetection != null) {
+                    nextLibDetection
+                } else {
+                    Log.w(
+                        PlayerRuntimeController.TAG,
+                        "AFR preflight NextLib probe failed/timed out after ${AFR_PREFLIGHT_NEXTLIB_TIMEOUT_MS}ms; trying extractor fallback"
                     )
+                    withTimeoutOrNull(AFR_PREFLIGHT_FALLBACK_TIMEOUT_MS) {
+                        withContext(Dispatchers.IO) {
+                            FrameRateUtils.detectFrameRateFromExtractor(
+                                context = context,
+                                sourceUrl = url,
+                                headers = probeHeaders
+                            )
+                        }
+                    }
                 }
             }
         }
 
+        if (frameRateDetectionMode == FrameRateDetectionMode.SEAMLESS) {
+            return
+        }
+
         if (detection == null) {
+            val modeLabel = when (frameRateDetectionMode) {
+                FrameRateDetectionMode.ACCURATE -> "NextLib + extractor fallback"
+                FrameRateDetectionMode.FAST -> "extractor-only"
+                FrameRateDetectionMode.SEAMLESS -> "seamless"
+            }
             Log.w(
                 PlayerRuntimeController.TAG,
-                "AFR preflight probe timed out/failed (NextLib + extractor fallback)"
+                "AFR preflight probe timed out/failed ($modeLabel)"
             )
             return
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -33,6 +33,7 @@ import androidx.media3.session.MediaSession
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.SUBTITLE_LANGUAGE_FORCED
+import com.nuvio.tv.data.local.FrameRateDetectionMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerSettings
@@ -100,6 +101,23 @@ internal fun PlayerRuntimeController.initializePlayer(
             val effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             runtimeInternalPlayerEngineOverride = overrideInternalPlayerEngine
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
+            val supportsSeamlessAfr =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                    effectiveInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER
+            val effectiveFrameRateDetectionMode = when {
+                playerSettings.frameRateDetectionMode == FrameRateDetectionMode.SEAMLESS &&
+                    supportsSeamlessAfr -> FrameRateDetectionMode.SEAMLESS
+                playerSettings.frameRateDetectionMode == FrameRateDetectionMode.SEAMLESS ->
+                    FrameRateDetectionMode.ACCURATE
+                else -> playerSettings.frameRateDetectionMode
+            }
+            val exoVideoChangeFrameRateStrategy = if (
+                effectiveFrameRateDetectionMode == FrameRateDetectionMode.SEAMLESS
+            ) {
+                C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_ONLY_IF_SEAMLESS
+            } else {
+                C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF
+            }
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus
             _uiState.update {
                 it.copy(
@@ -115,6 +133,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     url = url,
                     headers = headers,
                     frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                    frameRateDetectionMode = effectiveFrameRateDetectionMode,
                     resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
                 )
             }
@@ -239,6 +258,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setMediaSourceFactory(DefaultMediaSourceFactory(context, extractorsFactory))
                     .setRenderersFactory(renderersFactory)
                     .setLoadControl(loadControl)
+                    .setVideoChangeFrameRateStrategy(exoVideoChangeFrameRateStrategy)
                     .setReleaseTimeoutMs(3000)
                     .build()
             }
@@ -248,6 +268,7 @@ internal fun PlayerRuntimeController.initializePlayer(
                     .setLoadControl(loadControl)
                     .setTrackSelector(trackSelector!!)
                     .setMediaSourceFactory(DefaultMediaSourceFactory(context, extractorsFactory))
+                    .setVideoChangeFrameRateStrategy(exoVideoChangeFrameRateStrategy)
                     .setReleaseTimeoutMs(3000)
                     .buildWithAssSupportCompat(
                         context = context,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -247,6 +247,9 @@ fun PlaybackSettingsContent(
                 onSetOsdClockEnabled = { enabled -> coroutineScope.launch { viewModel.setOsdClockEnabled(enabled) } },
                 onSetSkipIntroEnabled = { enabled -> coroutineScope.launch { viewModel.setSkipIntroEnabled(enabled) } },
                 onSetFrameRateMatchingMode = { mode -> coroutineScope.launch { viewModel.setFrameRateMatchingMode(mode) } },
+                onSetFrameRateDetectionMode = { mode ->
+                    coroutineScope.launch { viewModel.setFrameRateDetectionMode(mode) }
+                },
                 onSetResolutionMatchingEnabled = { enabled ->
                     coroutineScope.launch { viewModel.setResolutionMatchingEnabled(enabled) }
                 },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -2,6 +2,7 @@
 
 package com.nuvio.tv.ui.screens.settings
 
+import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -56,6 +57,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
+import com.nuvio.tv.data.local.FrameRateDetectionMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.PlayerPreference
@@ -126,6 +128,7 @@ internal fun PlaybackSettingsSections(
     onSetOsdClockEnabled: (Boolean) -> Unit,
     onSetSkipIntroEnabled: (Boolean) -> Unit,
     onSetFrameRateMatchingMode: (FrameRateMatchingMode) -> Unit,
+    onSetFrameRateDetectionMode: (FrameRateDetectionMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
     onSetTrailerEnabled: (Boolean) -> Unit,
     onSetTrailerDelaySeconds: (Int) -> Unit,
@@ -285,9 +288,13 @@ internal fun PlaybackSettingsSections(
                 item(key = "general_afr_options") {
                     FrameRateMatchingModeOptions(
                         selectedMode = playerSettings.frameRateMatchingMode,
+                        selectedDetectionMode = playerSettings.frameRateDetectionMode,
                         resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled,
                         onSelect = onSetFrameRateMatchingMode,
+                        onSelectDetectionMode = onSetFrameRateDetectionMode,
                         onSetResolutionMatchingEnabled = onSetResolutionMatchingEnabled,
+                        seamlessDetectionSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                            playerSettings.internalPlayerEngine == InternalPlayerEngine.EXOPLAYER,
                         onFocused = { focusedSection = PlaybackSection.GENERAL },
                         enabled = !generalUi.isExternalPlayer
                     )
@@ -485,9 +492,12 @@ private fun PlaybackSectionHeader(
 @Composable
 private fun FrameRateMatchingModeOptions(
     selectedMode: FrameRateMatchingMode,
+    selectedDetectionMode: FrameRateDetectionMode,
     resolutionMatchingEnabled: Boolean,
     onSelect: (FrameRateMatchingMode) -> Unit,
+    onSelectDetectionMode: (FrameRateDetectionMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
+    seamlessDetectionSupported: Boolean,
     onFocused: () -> Unit,
     enabled: Boolean
 ) {
@@ -525,6 +535,48 @@ private fun FrameRateMatchingModeOptions(
 
         Spacer(modifier = Modifier.height(8.dp))
 
+        Text(
+            text = stringResource(R.string.playback_frame_rate_detection),
+            style = MaterialTheme.typography.bodySmall,
+            color = NuvioColors.TextSecondary,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        RenderTypeSettingsItem(
+            title = stringResource(R.string.playback_afr_detection_accurate),
+            subtitle = stringResource(R.string.playback_afr_detection_accurate_sub),
+            isSelected = selectedDetectionMode == FrameRateDetectionMode.ACCURATE,
+            onClick = { onSelectDetectionMode(FrameRateDetectionMode.ACCURATE) },
+            onFocused = onFocused,
+            enabled = enabled && selectedMode != FrameRateMatchingMode.OFF
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        RenderTypeSettingsItem(
+            title = stringResource(R.string.playback_afr_detection_fast),
+            subtitle = stringResource(R.string.playback_afr_detection_fast_sub),
+            isSelected = selectedDetectionMode == FrameRateDetectionMode.FAST,
+            onClick = { onSelectDetectionMode(FrameRateDetectionMode.FAST) },
+            onFocused = onFocused,
+            enabled = enabled && selectedMode != FrameRateMatchingMode.OFF
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        RenderTypeSettingsItem(
+            title = stringResource(R.string.playback_afr_detection_seamless),
+            subtitle = stringResource(R.string.playback_afr_detection_seamless_sub),
+            isSelected = selectedDetectionMode == FrameRateDetectionMode.SEAMLESS,
+            onClick = { onSelectDetectionMode(FrameRateDetectionMode.SEAMLESS) },
+            onFocused = onFocused,
+            enabled = enabled && selectedMode != FrameRateMatchingMode.OFF && seamlessDetectionSupported
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         ToggleSettingsItem(
             icon = Icons.Default.Image,
             title = stringResource(R.string.playback_resolution_matching),
@@ -532,7 +584,8 @@ private fun FrameRateMatchingModeOptions(
             isChecked = resolutionMatchingEnabled,
             onCheckedChange = onSetResolutionMatchingEnabled,
             onFocused = onFocused,
-            enabled = enabled
+            enabled = enabled && selectedMode != FrameRateMatchingMode.OFF &&
+                selectedDetectionMode != FrameRateDetectionMode.SEAMLESS
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.FrameRateDetectionMode
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
@@ -119,6 +120,10 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setFrameRateMatchingMode(mode: FrameRateMatchingMode) {
         playerSettingsDataStore.setFrameRateMatchingMode(mode)
+    }
+
+    suspend fun setFrameRateDetectionMode(mode: FrameRateDetectionMode) {
+        playerSettingsDataStore.setFrameRateDetectionMode(mode)
     }
 
     suspend fun setResolutionMatchingEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,13 @@
     <string name="playback_afr_on_start_sub">Switch when playback starts.</string>
     <string name="playback_afr_on_start_stop">On start/stop</string>
     <string name="playback_afr_on_start_stop_sub">Switch on start and restore on stop.</string>
+    <string name="playback_frame_rate_detection">Frame Rate Detection</string>
+    <string name="playback_afr_detection_accurate">Accurate</string>
+    <string name="playback_afr_detection_accurate_sub">Use NextLib first, then MediaExtractor fallback.</string>
+    <string name="playback_afr_detection_fast">Fast</string>
+    <string name="playback_afr_detection_fast_sub">Use MediaExtractor only for faster startup.</string>
+    <string name="playback_afr_detection_seamless">Seamless (Android 11+, Exo only)</string>
+    <string name="playback_afr_detection_seamless_sub">Use Exo seamless switching. Skips AFR preflight probe.</string>
     <string name="playback_resolution_matching">Resolution matching</string>
     <string name="playback_resolution_matching_sub">Allow display mode changes to match video resolution.</string>
     <string name="playback_player_external_desc">Always open streams in an external app</string>


### PR DESCRIPTION
## Summary
This PR adds a new Frame Rate Detection setting with 3 modes and updates AFR startup behavior:

Accurate = NextLib (30s) + MediaExtractor fallback (5.5s)
Fast = MediaExtractor only (30s max)
Seamless (Android 11+, Exo only) = Exo seamless frame-rate strategy, no manual AFR preflight probe
It also wires the new setting through DataStore, ViewModel, and Settings UI, and applies Exo seamless strategy only when supported.

## PR type
Bug fix/small improvement

## Why
Some users reported slower stream startup and inconsistent AFR behavior after NextLib/AAR changes.
This PR gives explicit AFR detection modes so users can choose between maximum compatibility (Accurate), faster/simple probing (Fast), or platform-driven switching (Seamless), and improves Fast reliability on slow links

## Policy check
[X] This PR is not cosmetic-only, unless it is a translation PR.
[X]  This PR does not add a new major feature without prior approval.
[X]  This PR is small in scope and focused on one problem.
[]  If this is a larger or directional change, I linked the issue where it was approved.

## Testing

Confirmed mode logs:
AFR preflight detection mode=ACCURATE|FAST|SEAMLESS
Confirmed probe path:
probe=NextLib ENTER for Accurate
probe=Extractor ENTER for Fast
no preflight probe for Seamless
Confirmed manual display switch logs for non-seamless path when applicable.
I can't confirm Seamless swith as I don't have a compatible device.


## Screenshots / Video (UI changes only)
UI changed (new settings options).

## Breaking changes
None.

## Linked issues
None.


