### PR TITLE
feat: add subtitle background color control to in-player style panel

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1012,6 +1012,9 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         is PlayerEvent.OnSetSubtitleTextColor -> {
             scope.launch { playerSettingsDataStore.setSubtitleTextColor(event.color) }
         }
+        is PlayerEvent.OnSetSubtitleBackgroundColor -> {
+            scope.launch { playerSettingsDataStore.setSubtitleBackgroundColor(event.color) }
+        }
         is PlayerEvent.OnSetSubtitleBold -> {
             scope.launch { playerSettingsDataStore.setSubtitleBold(event.bold) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -256,6 +256,7 @@ sealed class PlayerEvent {
     // Subtitle style events (for in-player style tab)
     data class OnSetSubtitleSize(val size: Int) : PlayerEvent()
     data class OnSetSubtitleTextColor(val color: Int) : PlayerEvent()
+    data class OnSetSubtitleBackgroundColor(val color: Int) : PlayerEvent()
     data class OnSetSubtitleBold(val bold: Boolean) : PlayerEvent()
     data class OnSetSubtitleOutlineEnabled(val enabled: Boolean) : PlayerEvent()
     data class OnSetSubtitleOutlineColor(val color: Int) : PlayerEvent()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
@@ -67,6 +67,13 @@ private val PANEL_OUTLINE_COLORS = listOf(
     Color(0xFFFF5C5C)
 )
 
+private val PANEL_BACKGROUND_COLORS = listOf(
+    Color.Black,
+    Color(0xFF1A1A2E),
+    Color(0xFF1C1C1C),
+    Color.White
+)
+
 private val StyleCardWidth = 220.dp
 private val StyleCardHeight = 102.dp
 private val StyleCardGap = 12.dp
@@ -91,7 +98,7 @@ internal fun SubtitleStyleSidePanel(
     Column(
         modifier = modifier
             .width(760.dp)
-            .height(330.dp)
+            .height(440.dp)
             .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
             .background(Color(0xFF101010))
             .padding(start = 16.dp, end = 16.dp, top = 22.dp, bottom = 10.dp)
@@ -151,6 +158,54 @@ internal fun SubtitleStyleSidePanel(
                             isEnabled = subtitleStyle.bold,
                             onClick = { onEvent(PlayerEvent.OnSetSubtitleBold(!subtitleStyle.bold)) }
                         )
+                    }
+                }
+                SubtitleStyleSection(
+                    title = stringResource(R.string.subtitle_style_background),
+                    centerContent = false,
+                    modifier = Modifier
+                        .width(StyleCardWidth)
+                        .height(140.dp)
+                ) {
+                    val bgColor = Color(subtitleStyle.backgroundColor)
+                    val bgAlphaPercent = (bgColor.alpha * 100f).roundToInt().coerceIn(0, 100)
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            PANEL_BACKGROUND_COLORS.forEach { color ->
+                                SubtitleStyleColorChip(
+                                    color = color,
+                                    isSelected = bgColor.alpha > 0f && bgColor.copy(alpha = 1f).toArgb() == color.copy(alpha = 1f).toArgb(),
+                                    onClick = {
+                                        val currentAlpha = bgColor.alpha
+                                        val newAlpha = if (currentAlpha == 0f) 0.5f else currentAlpha
+                                        onEvent(PlayerEvent.OnSetSubtitleBackgroundColor(color.copy(alpha = newAlpha).toArgb()))
+                                    }
+                                )
+                            }
+                        }
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            SubtitleStyleStepperButton(
+                                icon = Icons.Default.Remove,
+                                onClick = {
+                                    val newAlpha = (bgAlphaPercent - 10).coerceAtLeast(0) / 100f
+                                    onEvent(PlayerEvent.OnSetSubtitleBackgroundColor(bgColor.copy(alpha = newAlpha).toArgb()))
+                                }
+                            )
+                            SubtitleStyleValueDisplay(text = "$bgAlphaPercent%")
+                            SubtitleStyleStepperButton(
+                                icon = Icons.Default.Add,
+                                onClick = {
+                                    val newAlpha = (bgAlphaPercent + 10).coerceAtMost(100) / 100f
+                                    onEvent(PlayerEvent.OnSetSubtitleBackgroundColor(bgColor.copy(alpha = newAlpha).toArgb()))
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1094,6 +1094,7 @@
     <string name="subtitle_style_bold">Bold</string>
     <string name="subtitle_style_text_color">Text Color</string>
     <string name="subtitle_style_text_opacity">Text Opacity</string>
+    <string name="subtitle_style_background">Background</string>
     <string name="subtitle_style_outline">Outline</string>
     <string name="subtitle_style_bottom_offset">Bottom Offset</string>
     <string name="subtitle_style_defaults">Defaults</string>


### PR DESCRIPTION
## Summary

Exposes the existing `SubtitleStyleSettings.backgroundColor` field in the in-player `SubtitleStyleSidePanel`. The data model, DataStore key, and persist method all already existed, but the UI to control it while watching was missing.

A new **Background** card appears in the style panel with color swatches (black, navy, dark grey, white) and an opacity stepper, matching the existing Text Color section pattern.

## PR type

- Small maintenance improvement

## Why

The subtitle background color was already stored in `SubtitleStyleSettings` and wired up in `PlaybackSettingsScreen`, but was never exposed in the in-player panel. Users had no way to add a background behind subtitles without leaving the player. Fixes #1567.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

- Opened in-player subtitle style panel
- Verified Background card appears in column 1 below Bold
- Selected each background color swatch and confirmed color applies
- Used opacity stepper to set 0%–100% and verified background renders correctly
- Confirmed Reset Defaults resets background to transparent (already handled by existing reset logic)

## Screenshots / Video (UI changes only)

Panel gains a new Background card with color swatches and opacity stepper, visually identical in style to the existing Text Color card.

## Breaking changes

No breaking changes. New `OnSetSubtitleBackgroundColor` event added to `PlayerEvent`; all existing events and persisted settings are unaffected.

## Linked issues

Fixes #1567