### PR TITLE
Subtitles long press and icon updates

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -278,6 +278,7 @@ class PlayerRuntimeController(
     internal var pendingAudioSelectionAfterSubtitleRefresh: PendingAudioSelection? = null
     internal var rememberedTrackPreference: TrackPreference? = null
     internal var persistedTrackPreference: TrackPreference? = null
+    internal var lastEnabledSubtitleSelection: RememberedSubtitleSelection? = null
     internal var pendingEngineSwitchTrackPreference: PendingEngineSwitchTrackPreference? = null
     internal var explicitSubtitleSelectionForEngineSwitch: ExplicitSubtitleSelectionForEngineSwitch? = null
     internal var effectiveSubtitleSelectionForEngineSwitch: ExplicitSubtitleSelectionForEngineSwitch? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -713,6 +713,14 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                 ) 
             }
         }
+        PlayerEvent.OnToggleSubtitlesFromLongPress -> {
+            logSwitchTrace(
+                stage = "event-toggle-subtitles-long-press",
+                message = "selectedSubtitleIndex=${_uiState.value.selectedSubtitleTrackIndex} " +
+                    "addonSelected=${_uiState.value.selectedAddonSubtitle != null}"
+            )
+            toggleSubtitlesFromLongPress()
+        }
         is PlayerEvent.OnSelectAddonSubtitle -> {
             logSwitchTrace(
                 stage = "event-select-subtitle-addon",

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -339,11 +339,7 @@ internal fun PlayerRuntimeController.toggleSubtitlesFromLongPress() {
 
     if (activeSelection != null) {
         lastEnabledSubtitleSelection = activeSelection
-        autoSubtitleSelected = true
-        pendingAddonSubtitleLanguage = null
-        pendingAddonSubtitleTrackId = null
-        pendingAudioSelectionAfterSubtitleRefresh = null
-        resetSubtitleAutoSyncState()
+        clearSubtitleStateForToggle()
         rememberSubtitleDisabled()
         disableSubtitles()
         _uiState.update {
@@ -418,11 +414,7 @@ private fun PlayerRuntimeController.restoreLastEnabledSubtitleSelection(
         is PlayerRuntimeController.RememberedSubtitleSelection.Internal -> {
             val index = findMatchingTrackIndex(_uiState.value.subtitleTracks, selection.track)
             if (index < 0) return false
-            autoSubtitleSelected = true
-            pendingAddonSubtitleLanguage = null
-            pendingAddonSubtitleTrackId = null
-            pendingAudioSelectionAfterSubtitleRefresh = null
-            resetSubtitleAutoSyncState()
+            clearSubtitleStateForToggle()
             rememberInternalSubtitleSelection(index)
             selectSubtitleTrack(index)
             _uiState.update {
@@ -469,6 +461,14 @@ private fun PlayerRuntimeController.restoreLastEnabledSubtitleSelection(
         PlayerRuntimeController.RememberedSubtitleSelection.Disabled,
         null -> false
     }
+}
+
+private fun PlayerRuntimeController.clearSubtitleStateForToggle() {
+    autoSubtitleSelected = true
+    pendingAddonSubtitleLanguage = null
+    pendingAddonSubtitleTrackId = null
+    pendingAudioSelectionAfterSubtitleRefresh = null
+    resetSubtitleAutoSyncState()
 }
 
 internal fun PlayerRuntimeController.buildAddonSubtitleTrackId(subtitle: Subtitle): String {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -333,6 +333,144 @@ internal fun PlayerRuntimeController.rememberSubtitleDisabled() {
     persistTrackPreference()
 }
 
+internal fun PlayerRuntimeController.toggleSubtitlesFromLongPress() {
+    val state = _uiState.value
+    val activeSelection = currentEnabledSubtitleSelection(state)
+
+    if (activeSelection != null) {
+        lastEnabledSubtitleSelection = activeSelection
+        autoSubtitleSelected = true
+        pendingAddonSubtitleLanguage = null
+        pendingAddonSubtitleTrackId = null
+        pendingAudioSelectionAfterSubtitleRefresh = null
+        resetSubtitleAutoSyncState()
+        rememberSubtitleDisabled()
+        disableSubtitles()
+        _uiState.update {
+            it.copy(
+                showSubtitleOverlay = false,
+                showSubtitleStylePanel = false,
+                showSubtitleTimingDialog = false,
+                showSubtitleDelayOverlay = false,
+                showControls = true,
+                selectedAddonSubtitle = null,
+                selectedSubtitleTrackIndex = -1
+            )
+        }
+        return
+    }
+
+    val restored = restoreLastEnabledSubtitleSelection(
+        lastEnabledSubtitleSelection
+            ?: effectiveSubtitleSelectionForEngineSwitch?.takeIf { it.streamUrl == currentStreamUrl }?.selection
+            ?: persistedTrackPreference?.subtitle?.takeUnless {
+                it == PlayerRuntimeController.RememberedSubtitleSelection.Disabled
+            }
+    )
+
+    if (!restored) {
+        _uiState.update {
+            it.copy(
+                showSubtitleOverlay = true,
+                showAudioOverlay = false,
+                showSubtitleStylePanel = false,
+                showMoreDialog = false,
+                showSubtitleTimingDialog = false,
+                showSubtitleDelayOverlay = false,
+                showControls = true
+            )
+        }
+    }
+}
+
+private fun PlayerRuntimeController.currentEnabledSubtitleSelection(
+    state: PlayerUiState
+): PlayerRuntimeController.RememberedSubtitleSelection? {
+    state.selectedAddonSubtitle?.let { addon ->
+        return PlayerRuntimeController.RememberedSubtitleSelection.Addon(
+            id = addon.id,
+            url = addon.url,
+            language = PlayerSubtitleUtils.normalizeLanguageCode(addon.lang),
+            addonName = addon.addonName
+        )
+    }
+
+    val selectedTrack = state.subtitleTracks.getOrNull(state.selectedSubtitleTrackIndex)
+        ?: state.subtitleTracks.firstOrNull { it.isSelected }
+    return selectedTrack?.let { track ->
+        PlayerRuntimeController.RememberedSubtitleSelection.Internal(
+            track = buildRememberedInternalSubtitleSelectionForEngineSwitch(
+                state = state,
+                language = track.language,
+                name = track.name,
+                trackId = track.trackId,
+                isForced = track.isForced,
+                selectedUiTrackOverride = track
+            )
+        )
+    }
+}
+
+private fun PlayerRuntimeController.restoreLastEnabledSubtitleSelection(
+    selection: PlayerRuntimeController.RememberedSubtitleSelection?
+): Boolean {
+    return when (selection) {
+        is PlayerRuntimeController.RememberedSubtitleSelection.Internal -> {
+            val index = findMatchingTrackIndex(_uiState.value.subtitleTracks, selection.track)
+            if (index < 0) return false
+            autoSubtitleSelected = true
+            pendingAddonSubtitleLanguage = null
+            pendingAddonSubtitleTrackId = null
+            pendingAudioSelectionAfterSubtitleRefresh = null
+            resetSubtitleAutoSyncState()
+            rememberInternalSubtitleSelection(index)
+            selectSubtitleTrack(index)
+            _uiState.update {
+                it.copy(
+                    showSubtitleOverlay = false,
+                    showSubtitleStylePanel = false,
+                    showSubtitleTimingDialog = false,
+                    showSubtitleDelayOverlay = false,
+                    showControls = true,
+                    selectedAddonSubtitle = null,
+                    selectedSubtitleTrackIndex = index
+                )
+            }
+            true
+        }
+
+        is PlayerRuntimeController.RememberedSubtitleSelection.Addon -> {
+            val addonMatch = _uiState.value.addonSubtitles.firstOrNull { subtitle ->
+                subtitle.addonName == selection.addonName && subtitle.id == selection.id
+            } ?: _uiState.value.addonSubtitles.firstOrNull { subtitle ->
+                subtitle.addonName == selection.addonName &&
+                    PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, selection.language)
+            } ?: _uiState.value.addonSubtitles.firstOrNull { subtitle ->
+                PlayerSubtitleUtils.matchesLanguageCode(subtitle.lang, selection.language)
+            } ?: return false
+
+            autoSubtitleSelected = true
+            rememberAddonSubtitleSelection(addonMatch)
+            selectAddonSubtitle(addonMatch)
+            _uiState.update {
+                it.copy(
+                    showSubtitleOverlay = false,
+                    showSubtitleStylePanel = false,
+                    showSubtitleTimingDialog = false,
+                    showSubtitleDelayOverlay = false,
+                    showControls = true,
+                    selectedAddonSubtitle = addonMatch,
+                    selectedSubtitleTrackIndex = -1
+                )
+            }
+            true
+        }
+
+        PlayerRuntimeController.RememberedSubtitleSelection.Disabled,
+        null -> false
+    }
+}
+
 internal fun PlayerRuntimeController.buildAddonSubtitleTrackId(subtitle: Subtitle): String {
     val urlHashSuffix = subtitle.url.hashCode().toUInt().toString(16)
     return "${PlayerRuntimeController.ADDON_SUBTITLE_TRACK_ID_PREFIX}${subtitle.id}:$urlHashSuffix"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -49,12 +49,13 @@ import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Subtitles
+import androidx.compose.material.icons.filled.SubtitlesOff
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -836,6 +837,7 @@ fun PlayerScreen(
                 onShowSourcesPanel = { viewModel.onEvent(PlayerEvent.OnShowSourcesPanel) },
                 onShowAudioDialog = { viewModel.onEvent(PlayerEvent.OnShowAudioOverlay) },
                 onShowSubtitleDialog = { viewModel.onEvent(PlayerEvent.OnShowSubtitleOverlay) },
+                onSubtitleLongPress = { viewModel.onEvent(PlayerEvent.OnToggleSubtitlesFromLongPress) },
                 onShowSpeedDialog = { viewModel.onEvent(PlayerEvent.OnShowSpeedDialog) },
                 onToggleAspectRatio = {
                     Log.d("PlayerScreen", "onToggleAspectRatio called - dispatching event")
@@ -1460,6 +1462,7 @@ private fun PlayerControlsOverlay(
     onShowSourcesPanel: () -> Unit,
     onShowAudioDialog: () -> Unit,
     onShowSubtitleDialog: () -> Unit,
+    onSubtitleLongPress: () -> Unit,
     onShowSpeedDialog: () -> Unit,
     onToggleAspectRatio: () -> Unit,
     onSwitchPlayerEngine: () -> Unit,
@@ -1473,7 +1476,6 @@ private fun PlayerControlsOverlay(
 ) {
     val customPlayPainter = rememberRawSvgPainter(R.raw.ic_player_play)
     val customPausePainter = rememberRawSvgPainter(R.raw.ic_player_pause)
-    val customSubtitlePainter = rememberRawSvgPainter(R.raw.ic_player_subtitles)
     val customAudioPainter = rememberRawSvgPainter(R.raw.ic_player_audio_filled)
     val customSourcePainter = rememberRawSvgPainter(R.raw.ic_player_source)
     val customAspectPainter = rememberRawSvgPainter(R.raw.ic_player_aspect_ratio)
@@ -1650,11 +1652,14 @@ private fun PlayerControlsOverlay(
                     }
 
                     if (hasSubtitleControl) {
+                        val subtitlesActive = uiState.selectedSubtitleTrackIndex >= 0 ||
+                            uiState.selectedAddonSubtitle != null ||
+                            uiState.subtitleTracks.any { it.isSelected }
                         ControlButton(
-                            icon = Icons.Default.ClosedCaption,
-                            iconPainter = customSubtitlePainter,
+                            icon = if (subtitlesActive) Icons.Default.Subtitles else Icons.Default.SubtitlesOff,
                             contentDescription = stringResource(R.string.cd_subtitles),
                             onClick = onShowSubtitleDialog,
+                            onLongClick = onSubtitleLongPress,
                             upFocusRequester = progressBarFocusRequester,
                             onDownKey = onHideControls,
                             onFocused = onResetHideTimer
@@ -1831,12 +1836,14 @@ private fun ControlButton(
     iconPainter: Painter? = null,
     contentDescription: String,
     onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
     focusRequester: FocusRequester? = null,
     upFocusRequester: FocusRequester? = null,
     onDownKey: (() -> Unit)? = null,
     onFocused: (() -> Unit)? = null
 ) {
     var isFocused by remember { mutableStateOf(false) }
+    var longClickSent by remember { mutableStateOf(false) }
 
     IconButton(
         onClick = onClick,
@@ -1854,6 +1861,31 @@ private fun ControlButton(
                 }
             )
             .onPreviewKeyEvent { keyEvent ->
+                val keyCode = keyEvent.nativeKeyEvent.keyCode
+                val isPrimaryClickKey = keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                    keyCode == KeyEvent.KEYCODE_ENTER ||
+                    keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER
+                if (
+                    onLongClick != null &&
+                    isPrimaryClickKey &&
+                    keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                    keyEvent.nativeKeyEvent.repeatCount > 0 &&
+                    !longClickSent
+                ) {
+                    longClickSent = true
+                    onLongClick.invoke()
+                    return@onPreviewKeyEvent true
+                }
+                if (
+                    isPrimaryClickKey &&
+                    keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_UP
+                ) {
+                    if (longClickSent) {
+                        longClickSent = false
+                        return@onPreviewKeyEvent true
+                    }
+                    longClickSent = false
+                }
                 if (
                     upFocusRequester != null &&
                     keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -214,6 +214,7 @@ sealed class PlayerEvent {
     data class OnSetPersistAudioAmplification(val enabled: Boolean) : PlayerEvent()
     data class OnSelectSubtitleTrack(val index: Int) : PlayerEvent()
     data object OnDisableSubtitles : PlayerEvent()
+    data object OnToggleSubtitlesFromLongPress : PlayerEvent()
     data class OnSelectAddonSubtitle(val subtitle: Subtitle) : PlayerEvent()
     data class OnSetPlaybackSpeed(val speed: Float) : PlayerEvent()
     data object OnToggleControls : PlayerEvent()


### PR DESCRIPTION
## Summary

Users can now long-press the subtitles button to quickly toggle subtitles on and off. To improve user feedback, the icon dynamically switches between Subtitles and SubtitlesOff based on the active state.

More details:

Long-press subtitle control now toggles subtitles:
- If subtitles are active, it disables them and remembers the active internal/addon selection.
- If subtitles are off, it restores the last enabled selection when possible.
- If nothing restorable exists, it opens the subtitle selector like a normal click.

Subtitle button now uses Material Icons:
- Icons.Default.Subtitles when active.
- Icons.Default.SubtitlesOff when inactive.

Long-press key handling consumes the release event so it won’t also fire the normal click.

## PR type

<!-- Pick one and delete the others -->

- Small maintenance improvement

## Why

Without a quick toggle option by long pressing select, there isn't an unobtrusive way of quickly toggling subtitles off and on. This can be useful for if a particular scene requires them, someone is making noise in the house and you need to hear or you need to mute and put them on. Likewise, useful to turn off if you don't want them on but usually do. 

The icon update is necessary to enable this feature, and also the previous icon was not technically correct as not all subtitles are CC.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Built APK, tested playing content with subtitles, long pressing icon to turn off, noticing icon update, long pressing to turn back on. Verified single click still works.

## Screenshots / Video (UI changes only)

Before:
<img width="3072" height="4080" alt="PXL_20260430_215235238 MP" src="https://github.com/user-attachments/assets/313dd19b-7556-4434-89b3-87a6e16c2b22" />

https://streamable.com/hgh66y

After: 
<img width="3072" height="4080" alt="PXL_20260430_215205647 MP" src="https://github.com/user-attachments/assets/e4c4d4c3-869e-4805-b1e1-76905361da87" />

https://streamable.com/5xtcm3

## Breaking changes

Nothing broken in testing elements affected; all okay.

## Linked issues

Implements: https://github.com/NuvioMedia/NuvioTV/issues/1589