### PR TITLE
Improve app loading times avatar catalog

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -312,15 +312,19 @@ class MainActivity : ComponentActivity() {
             }
 
             var avatarCatalog by remember { mutableStateOf(emptyList<com.nuvio.tv.data.remote.supabase.AvatarCatalogItem>()) }
+            val activeProfileAvatarId = activeProfile?.avatarId
+            val activeProfileAvatarUrl = activeProfile?.avatarUrl?.takeIf { it.isNotBlank() }
 
-            LaunchedEffect(Unit) {
-                avatarCatalog = runCatching { avatarRepository.getAvatarCatalog() }
-                    .getOrDefault(emptyList())
+            LaunchedEffect(activeProfileAvatarId, activeProfileAvatarUrl) {
+                if (activeProfileAvatarUrl == null && activeProfileAvatarId != null && avatarCatalog.isEmpty()) {
+                    avatarCatalog = runCatching { avatarRepository.getAvatarCatalog() }
+                        .getOrDefault(emptyList())
+                }
             }
 
-            val activeProfileAvatarImageUrl = remember(activeProfile, avatarCatalog) {
-                activeProfile?.avatarUrl?.takeIf { it.isNotBlank() }
-                    ?: activeProfile?.avatarId?.let { avatarRepository.getAvatarImageUrl(it, avatarCatalog) }
+            val activeProfileAvatarImageUrl = remember(activeProfileAvatarId, activeProfileAvatarUrl, avatarCatalog) {
+                activeProfileAvatarUrl
+                    ?: activeProfileAvatarId?.let { avatarRepository.getAvatarImageUrl(it, avatarCatalog) }
             }
 
             val mainUiPrefsFlow = remember(themeDataStore, layoutPreferenceDataStore, experienceModeDataStore) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -197,6 +197,14 @@ fun ProfileSelectionScreen(
             focusedAvatarColor = parseProfileColor(colorHex)
         }
     }
+    val needsAvatarCatalogForProfileCards = remember(profiles) {
+        profiles.any { it.avatarUrl.isNullOrBlank() && !it.avatarId.isNullOrBlank() }
+    }
+    LaunchedEffect(needsAvatarCatalogForProfileCards, showCreateProfile, profileToEdit) {
+        if (needsAvatarCatalogForProfileCards || showCreateProfile || profileToEdit != null) {
+            viewModel.loadAvatarCatalog()
+        }
+    }
     val isManagementMode = screenMode == ProfileSelectionMode.Management
     val screenTitle = if (isManagementMode) {
         stringResource(R.string.profile_manage_title)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionViewModel.kt
@@ -52,7 +52,9 @@ class ProfileSelectionViewModel @Inject constructor(
     val isPinOperationInProgress: StateFlow<Boolean> = _isPinOperationInProgress.asStateFlow()
 
     init {
-        loadAvatarCatalog()
+        if (profiles.value.any { it.avatarUrl.isNullOrBlank() && !it.avatarId.isNullOrBlank() }) {
+            loadAvatarCatalog()
+        }
         refreshProfilePinStates()
     }
 


### PR DESCRIPTION
## Summary

Avoid loading the full avatar catalog during profile selection startup when existing profiles already have direct avatar URLs. The catalog is now fetched only when needed to resolve legacy avatar IDs or when opening the avatar picker for create/edit. 

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [x] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Loading the full avatar catalog during profile selection startup can add unnecessary work when profiles already store a usable avatar URL. Deferring that fetch keeps startup/profile selection lighter while preserving catalog loading for older avatar-id-only profiles and avatar editing.

## Issue or approval

No linked issue: small focused startup maintenance with no UI or behavior change.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only profile avatar catalog loading was adjusted. No avatar picker UI, profile editing behavior, sync behavior, navigation, or playback code was changed.

## Testing

Source-level verification performed:
- Confirmed direct avatar URLs no longer trigger the full avatar catalog fetch on profile selection startup.
- Confirmed legacy profiles with `avatarId` but no `avatarUrl` still request the catalog so profile card images can resolve.
- Confirmed opening create/edit profile still requests the catalog for the avatar picker.
- Ran `git diff --check`.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - small focused startup maintenance with no UI or behavior change.
