### PR TITLE
Add ExoPlayer Late AFR mode with dynamic FPS detection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -226,6 +226,7 @@ data class PlayerSettings(
     val mpvHardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE,
     // Display settings
     val frameRateMatchingMode: FrameRateMatchingMode = FrameRateMatchingMode.OFF,
+    val exoPlayerAfrMode: ExoPlayerAfrMode = ExoPlayerAfrMode.PREFLIGHT_ONLY,
     val resolutionMatchingEnabled: Boolean = false,
     // Stream selection settings
     val streamAutoPlayMode: StreamAutoPlayMode = StreamAutoPlayMode.MANUAL,
@@ -288,6 +289,11 @@ enum class FrameRateMatchingMode {
     OFF,
     START,
     START_STOP
+}
+
+enum class ExoPlayerAfrMode {
+    PREFLIGHT_ONLY,
+    LATE_ONLY
 }
 
 enum class NextEpisodeThresholdMode {
@@ -413,6 +419,7 @@ class PlayerSettingsDataStore @Inject constructor(
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
     private val frameRateMatchingKey = booleanPreferencesKey("frame_rate_matching")
     private val frameRateMatchingModeKey = stringPreferencesKey("frame_rate_matching_mode")
+    private val exoPlayerAfrModeKey = stringPreferencesKey("exo_player_afr_mode")
     private val resolutionMatchingEnabledKey = booleanPreferencesKey("resolution_matching_enabled")
     private val streamAutoPlayModeKey = stringPreferencesKey("stream_auto_play_mode")
     private val streamAutoPlaySourceKey = stringPreferencesKey("stream_auto_play_source")
@@ -624,6 +631,9 @@ class PlayerSettingsDataStore @Inject constructor(
                 } else {
                     FrameRateMatchingMode.OFF
                 },
+                exoPlayerAfrMode = prefs[exoPlayerAfrModeKey]?.let {
+                    runCatching { ExoPlayerAfrMode.valueOf(it) }.getOrNull()
+                } ?: ExoPlayerAfrMode.PREFLIGHT_ONLY,
                 resolutionMatchingEnabled = prefs[resolutionMatchingEnabledKey] ?: false,
                 streamAutoPlayMode = prefs[streamAutoPlayModeKey]?.let {
                     runCatching { StreamAutoPlayMode.valueOf(it) }.getOrDefault(StreamAutoPlayMode.MANUAL)
@@ -902,6 +912,12 @@ class PlayerSettingsDataStore @Inject constructor(
         store().edit { prefs ->
             prefs[frameRateMatchingModeKey] = mode.name
             prefs[frameRateMatchingKey] = mode != FrameRateMatchingMode.OFF
+        }
+    }
+
+    suspend fun setExoPlayerAfrMode(mode: ExoPlayerAfrMode) {
+        store().edit { prefs ->
+            prefs[exoPlayerAfrModeKey] = mode.name
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/DynamicFpsCalculator.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/DynamicFpsCalculator.kt
@@ -1,0 +1,115 @@
+package com.nuvio.tv.ui.screens.player
+
+import android.util.Log
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.video.VideoFrameMetadataListener
+import com.nuvio.tv.core.player.FrameRateUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class DynamicFpsCalculator(
+    private val exoPlayer: ExoPlayer,
+    private val scope: CoroutineScope,
+    private val onFpsCalculated: (Float) -> Unit,
+    private val onTimeout: () -> Unit = {}
+) : VideoFrameMetadataListener {
+    private val timestamps = ConcurrentLinkedQueue<Long>()
+    private val framesToIgnore = 5
+    private val framesToCollect = 30
+    private val targetSize = framesToIgnore + framesToCollect
+    private val isCompleted = AtomicBoolean(false)
+    private val timeoutJob: Job?
+    private val timeoutMs = 5000L
+
+    companion object {
+        private const val TAG = "DynamicFpsCalculator"
+    }
+
+    init {
+        timeoutJob = scope.launch {
+            delay(timeoutMs)
+            if (!isCompleted.get()) {
+                Log.w(TAG, "[DYNAMIC] Timeout after ${timeoutMs}ms, cancelling")
+                cancel()
+                onTimeout()
+            }
+        }
+    }
+
+    override fun onVideoFrameAboutToBeRendered(
+        presentationTimeUs: Long,
+        releaseTimeNs: Long,
+        format: androidx.media3.common.Format,
+        mediaFormat: android.media.MediaFormat?
+    ) {
+        if (isCompleted.get()) return
+
+        timestamps.add(presentationTimeUs)
+
+        // Loggare ogni frame intasa il logcat, lo facciamo solo se necessario al debug
+        // Log.d(TAG, "[DYNAMIC] Collected frame ${timestamps.size}/$targetSize, time=$presentationTimeUs")
+
+        if (timestamps.size >= targetSize) {
+            // Launch calculation on background thread to avoid blocking rendering thread
+            scope.launch(Dispatchers.Default) {
+                calculateAndTrigger()
+            }
+        }
+    }
+
+    private fun calculateAndTrigger() {
+        if (isCompleted.compareAndSet(false, true)) {
+            timeoutJob?.cancel()
+            Log.d(TAG, "[DYNAMIC] Collected enough frames, calculating FPS")
+
+            // CRITICO: Sganciamo il listener dal player per non consumare CPU per il resto del film.
+            // Le API di ExoPlayer richiedono che queste operazioni avvengano sul Main Thread.
+            scope.launch(Dispatchers.Main) {
+                exoPlayer.clearVideoFrameMetadataListener(this@DynamicFpsCalculator)
+            }
+
+            scope.launch(Dispatchers.Default) {
+                // Ordiniamo i timestamp per evitare sbalzi negativi causati dai B-Frames
+                val validTimestamps = timestamps.toList().takeLast(framesToCollect).sorted()
+                val deltas = mutableListOf<Long>()
+
+                for (i in 1 until validTimestamps.size) {
+                    val delta = validTimestamps[i] - validTimestamps[i - 1]
+                    if (delta > 0) {
+                        deltas.add(delta)
+                    }
+                }
+
+                if (deltas.isNotEmpty()) {
+                    val averageDeltaUs = deltas.average().toLong()
+                    val measuredFps = 1_000_000f / averageDeltaUs
+                    Log.d(TAG, "[DYNAMIC] Average delta: ${averageDeltaUs}us, Measured FPS: $measuredFps")
+
+                    val snappedFps = FrameRateUtils.snapToStandardRate(measuredFps)
+                    Log.d(TAG, "[DYNAMIC] Snapped FPS: $snappedFps")
+
+                    scope.launch(Dispatchers.Main) {
+                        onFpsCalculated(snappedFps)
+                    }
+                } else {
+                    Log.w(TAG, "[DYNAMIC] No valid deltas calculated")
+                }
+            }
+        }
+    }
+
+    fun cancel() {
+        if (isCompleted.compareAndSet(false, true)) {
+            Log.d(TAG, "[DYNAMIC] Cancelled")
+            timeoutJob?.cancel()
+            scope.launch(Dispatchers.Main) {
+                exoPlayer.clearVideoFrameMetadataListener(this@DynamicFpsCalculator)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -247,6 +247,21 @@ class PlayerRuntimeController(
     internal var seekProgressSyncJob: Job? = null
     internal var frameRateProbeJob: Job? = null
     internal var frameRateProbeToken: Long = 0L
+    internal var prefer23976ProbeBias: Boolean = false
+    @Volatile
+    internal var afrPendingNativeFallback: Boolean = false
+    @Volatile
+    internal var lateAfrInProgress = false
+    @Volatile
+    internal var waitingForLateAfrSwitch: Boolean = false
+    @Volatile
+    internal var exoFpsPollingInProgress = false
+    @Volatile
+    internal var mpvFpsPollingInProgress = false
+    @Volatile
+    internal var dynamicFpsCalculator: DynamicFpsCalculator? = null
+    @Volatile
+    internal var afrPreflightInProgress = false
     internal var hideAspectRatioIndicatorJob: Job? = null
     internal var hideStreamSourceIndicatorJob: Job? = null
     internal var hidePlayerEngineSwitchInfoJob: Job? = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -98,6 +99,13 @@ private fun PlayerRuntimeController.disposeExoPlayerBeforeRebuild() {
         runCatching { player.stop() }
         runCatching { player.clearMediaItems() }
         runCatching { player.clearVideoSurface() }
+        // Restore audio if FPS calculation was interrupted
+        if (waitingForLateAfrSwitch) {
+            player.volume = 1f
+            waitingForLateAfrSwitch = false
+        }
+        dynamicFpsCalculator?.cancel()
+        dynamicFpsCalculator = null
         runCatching { player.release() }
     }
     _exoPlayer = null
@@ -163,6 +171,13 @@ internal fun PlayerRuntimeController.initializePlayer(
             currentInternalPlayerEngine = effectiveInternalPlayerEngine
             val showLoadingStatus = playerSettings.showPlayerLoadingStatus
             val deviceAspectMode = deviceLocalPlayerPreferences.aspectMode.first()
+            
+            // Set afrPendingNativeFallback based on ExoPlayerAfrMode setting
+            // Late AFR is only used for ExoPlayer when ExoPlayerAfrMode == LATE_ONLY
+            afrPendingNativeFallback = effectiveInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER &&
+                playerSettings.exoPlayerAfrMode == com.nuvio.tv.data.local.ExoPlayerAfrMode.LATE_ONLY &&
+                playerSettings.frameRateMatchingMode != com.nuvio.tv.data.local.FrameRateMatchingMode.OFF
+            
             _uiState.update {
                 it.copy(
                     internalPlayerEngine = effectiveInternalPlayerEngine,
@@ -174,12 +189,18 @@ internal fun PlayerRuntimeController.initializePlayer(
                 )
             }
             val afrJob = async {
-                runAfrPreflightIfEnabled(
-                    url = url,
-                    headers = headers,
-                    frameRateMatchingMode = playerSettings.frameRateMatchingMode,
-                    resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
-                )
+                // Skip preflight if ExoPlayer AFR mode is LATE_ONLY
+                if (effectiveInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER &&
+                    playerSettings.exoPlayerAfrMode == com.nuvio.tv.data.local.ExoPlayerAfrMode.LATE_ONLY) {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR] Skipping preflight for ExoPlayer (LATE_ONLY mode)")
+                } else {
+                    runAfrPreflightIfEnabled(
+                        url = url,
+                        headers = headers,
+                        frameRateMatchingMode = playerSettings.frameRateMatchingMode,
+                        resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled
+                    )
+                }
             }
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.MVP_PLAYER) {
                 mpvInitializationInProgress = true
@@ -548,14 +569,87 @@ internal fun PlayerRuntimeController.initializePlayer(
                         updateAvailableTracks(tracks)
                     }
 
+                    @androidx.annotation.OptIn(UnstableApi::class)
                     override fun onRenderedFirstFrame() {
+                        Log.d(PlayerRuntimeController.TAG, "[EXO] onRenderedFirstFrame")
                         hasRenderedFirstFrame = true
                         updateAudioControlAvailability()
+
+                        // Late AFR trigger for ExoPlayer - use dynamic FPS calculation
+                        // Check if calculator is already null to prevent duplicate creation
+                        if (!exoFpsPollingInProgress && dynamicFpsCalculator == null && afrPendingNativeFallback) {
+                            exoFpsPollingInProgress = true
+                            scope.launch {
+                                try {
+                                    val player = _exoPlayer
+                                    if (player != null) {
+                                        Log.d(PlayerRuntimeController.TAG, "[EXO] Starting dynamic FPS calculation")
+                                        val calculator = DynamicFpsCalculator(
+                                            exoPlayer = player,
+                                            scope = scope,
+                                            onFpsCalculated = { snappedFps ->
+                                                Log.d(PlayerRuntimeController.TAG, "[EXO] Dynamic FPS calculated: $snappedFps")
+                                                dynamicFpsCalculator = null
+                                                if (snappedFps > 0f && !isUsingMpvEngine()) {
+                                                    triggerLateAfr(
+                                                        fps = snappedFps,
+                                                        width = _exoPlayer?.videoFormat?.width,
+                                                        height = _exoPlayer?.videoFormat?.height
+                                                    )
+                                                } else {
+                                                    Log.w(PlayerRuntimeController.TAG, "[EXO] Dynamic FPS invalid or player changed, skipping AFR")
+                                                }
+                                            },
+                                            onTimeout = {
+                                                Log.w(PlayerRuntimeController.TAG, "[EXO] Dynamic FPS calculation timed out, restoring audio and hiding loading overlay")
+                                                dynamicFpsCalculator = null
+                                                // Only restore if late AFR is not in progress
+                                                if (!lateAfrInProgress) {
+                                                    _exoPlayer?.volume = 1f
+                                                    waitingForLateAfrSwitch = false
+                                                    _uiState.update {
+                                                        it.copy(
+                                                            showLoadingOverlay = false,
+                                                            loadingMessage = null,
+                                                            loadingProgress = if (it.loadingProgress != null) 1f else null
+                                                        )
+                                                    }
+                                                }
+                                            }
+                                        )
+                                        dynamicFpsCalculator = calculator
+                                        player.setVideoFrameMetadataListener(calculator)
+                                    }
+                                } finally {
+                                    exoFpsPollingInProgress = false
+                                }
+                            }
+                        }
+
                         // Start playback now that the first video frame is
                         // visible: audio and video begin in sync.
+                        // If Late AFR is pending, start playback but keep loading overlay visible
+                        // until the switch completes (DynamicFpsCalculator needs frames to calculate FPS)
                         if (!startPaused && !userPausedManually) {
-                            playWhenReady = true
-                            play()
+                            if (afrPendingNativeFallback) {
+                                waitingForLateAfrSwitch = true
+                                Log.d(PlayerRuntimeController.TAG, "[EXO] onRenderedFirstFrame - Late AFR pending, starting playback with loading overlay (SILENT START)")
+                                // Silent Start: Mute audio during FPS calculation to prevent audio leak
+                                _exoPlayer?.volume = 0f
+                                // Update UI to show FPS calculation in progress
+                                _uiState.update {
+                                    it.copy(
+                                        loadingMessage = context.getString(R.string.obtaining_frame_rate),
+                                        loadingProgress = 0.3f
+                                    )
+                                }
+                                playWhenReady = true
+                                play()
+                                // Don't hide loading overlay - will hide after Late AFR completes
+                            } else {
+                                playWhenReady = true
+                                play()
+                            }
                         }
                         refreshStableProgressResetGate()
                         // Restore speed after PCM fallback: audio sink is already
@@ -563,16 +657,19 @@ internal fun PlayerRuntimeController.initializePlayer(
                         if (hasTriedAudioPcmFallback) {
                             _exoPlayer?.playbackParameters = PlaybackParameters(1f)
                         }
-                        _uiState.update {
-                            it.copy(
-                                showLoadingOverlay = false,
-                                loadingMessage = null,
-                                // Snap the loading-logo fill to 100% so the logo
-                                // appears fully filled as the overlay fades out
-                                // (rather than freezing at the partial buffer %).
-                                loadingProgress = if (it.loadingProgress != null) 1f else null,
-                                showPlayerEngineSwitchInfo = false
-                            )
+                        // Only hide loading overlay if NOT waiting for Late AFR
+                        if (!waitingForLateAfrSwitch) {
+                            _uiState.update {
+                                it.copy(
+                                    showLoadingOverlay = false,
+                                    loadingMessage = null,
+                                    // Snap the loading-logo fill to 100% so the logo
+                                    // appears fully filled as the overlay fades out
+                                    // (rather than freezing at the partial buffer %).
+                                    loadingProgress = if (it.loadingProgress != null) 1f else null,
+                                    showPlayerEngineSwitchInfo = false
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -10,6 +10,7 @@ internal fun PlayerRuntimeController.releasePlayer() {
 
 internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) {
     isReleasingPlayer = true
+    waitingForLateAfrSwitch = false
     if (flushPlaybackState) {
         stopTorrentStream()
         flushPlaybackSnapshotForSwitchOrExit()
@@ -29,6 +30,8 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     watchProgressSaveJob?.cancel()
     seekProgressSyncJob?.cancel()
     frameRateProbeJob?.cancel()
+    dynamicFpsCalculator?.cancel()
+    dynamicFpsCalculator = null
     hideStreamSourceIndicatorJob?.cancel()
     hideStreamSourceIndicatorJob = null
     _uiState.update { it.copy(showStreamSourceIndicator = false) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.util.Log
 import androidx.media3.common.Player
 import com.nuvio.tv.R
+import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.data.local.SubtitleStyleSettings
 import com.nuvio.tv.data.repository.SkipInterval
 import com.nuvio.tv.data.repository.TraktScrobbleItem
@@ -14,6 +15,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 internal const val AUDIO_AMPLIFICATION_MIN_DB = 0
 internal const val AUDIO_AMPLIFICATION_MAX_DB = 10
@@ -1259,5 +1263,220 @@ private fun formatTorrentSpeed(bytesPerSec: Long): String {
         bytesPerSec >= 1_048_576 -> String.format("%.1f MB/s", bytesPerSec / 1_048_576.0)
         bytesPerSec >= 1_024 -> String.format("%.0f KB/s", bytesPerSec / 1_024.0)
         else -> "$bytesPerSec B/s"
+    }
+}
+
+internal fun PlayerRuntimeController.triggerLateAfr(fps: Float, width: Int? = null, height: Int? = null) {
+    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Called - afrPendingNativeFallback=$afrPendingNativeFallback, fps=$fps, lateAfrInProgress=$lateAfrInProgress")
+    if (!afrPendingNativeFallback || fps <= 0f) {
+        Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Skipped - afrPendingNativeFallback=$afrPendingNativeFallback, fps=$fps")
+        return
+    }
+    if (lateAfrInProgress) {
+        Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Skipped - already in progress")
+        return
+    }
+    val currentDetection = _uiState.value.detectedFrameRate
+    if (currentDetection > 0f) {
+        if (kotlin.math.abs(currentDetection - fps) < 0.1f) {
+            Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Skipped - FPS already matched (current=$currentDetection, new=$fps)")
+            return
+        }
+    }
+
+    scope.launch {
+        lateAfrInProgress = true
+        try {
+            afrPendingNativeFallback = false
+            Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Starting coroutine - fps=$fps, size=${width}x${height}")
+            val activity = currentHostActivity() ?: return@launch
+            val settings = kotlinx.coroutines.withTimeoutOrNull(2000L) {
+                playerSettingsDataStore.playerSettings.first()
+            }
+            if (settings == null) {
+                Log.w(PlayerRuntimeController.TAG, "[AFR LATE] Failed to retrieve settings within timeout")
+                return@launch
+            }
+            if (settings.frameRateMatchingMode == com.nuvio.tv.data.local.FrameRateMatchingMode.OFF) {
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Skipped - AFR disabled in settings")
+                return@launch
+            }
+
+            Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Starting Safe Late-AFR sequence for ${fps}fps size=${width}x${height}")
+
+            // Update UI to show display mode switching
+            _uiState.update {
+                it.copy(
+                    loadingMessage = activity.getString(R.string.obtaining_frame_rate),
+                    loadingProgress = 0.6f
+                )
+            }
+
+            val wasPlaying = isPlaybackCurrentlyPlaying()
+            val resumePos = currentPlaybackPositionMs() ?: 0L
+            var switchedDisplayMode = false
+
+            try {
+                // 1. PAUSE: Freeze the buffer and decoder to prevent crashes during mode change
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] PAUSE - wasPlaying=$wasPlaying, resumePos=$resumePos")
+                setPlaybackPaused(true)
+
+                // TRACK KILLER: Disable video track to force MediaCodecVideoRenderer destruction
+                // This completely destroys the MediaCodecVideoRenderer safely, keeping the network buffer intact.
+                if (currentInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER) {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] TRACK KILLER - Disabling video track")
+                    val currentParams = _exoPlayer?.trackSelectionParameters
+                    if (currentParams != null) {
+                        _exoPlayer?.trackSelectionParameters = currentParams
+                            .buildUpon()
+                            .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
+                            .build()
+                    } else {
+                        Log.w(PlayerRuntimeController.TAG, "[AFR LATE] TRACK KILLER - trackSelectionParameters is null, skipping")
+                    }
+                }
+
+                // Capture display mode BEFORE the switch to detect if it actually changed
+                val initialDisplayModeId = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                    withContext(Dispatchers.Main) {
+                        activity.window?.decorView?.display?.mode?.modeId
+                    }
+                } else {
+                    null
+                }
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Initial display mode ID: $initialDisplayModeId")
+
+                val prefer23976Near24 = fps in 23.95f..24.12f
+                val targetFrameRate = com.nuvio.tv.core.player.FrameRateUtils.refineFrameRateForDisplay(
+                    activity = activity,
+                    detectedFps = com.nuvio.tv.core.player.FrameRateUtils.snapToStandardRate(fps),
+                    prefer23976Near24 = (prefer23976ProbeBias ?: prefer23976Near24)
+                )
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Target frame rate: $targetFrameRate (prefer23976=$prefer23976Near24)")
+
+                // 2. SWITCH: Execute HDMI handshake
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Calling matchFrameRateAndWait")
+                val result = com.nuvio.tv.core.player.FrameRateUtils.matchFrameRateAndWait(
+                    activity = activity,
+                    frameRate = targetFrameRate,
+                    videoWidth = width,
+                    videoHeight = height,
+                    resolutionMatchingEnabled = settings.resolutionMatchingEnabled
+                )
+
+                // 3. RECOVERY: Delay for HDMI sync
+                if (result != null) {
+                    switchedDisplayMode = initialDisplayModeId != null &&
+                        initialDisplayModeId != result.appliedMode.modeId
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Display mode switched=$switchedDisplayMode, new mode ID: ${result.appliedMode.modeId}")
+
+                    if (switchedDisplayMode) {
+                        delay(1000) // Protective delay for HDMI sync
+                    }
+
+                    // TRACK KILLER: Re-enable video track to force MediaCodec recreation with new refresh rate
+                    // Re-enabling the video track forces ExoPlayer to allocate a BRAND NEW MediaCodec.
+                    // Since the display is now at the correct target Hz, the DV handshake will succeed.
+                    if (currentInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER) {
+                        Log.d(PlayerRuntimeController.TAG, "[AFR LATE] TRACK KILLER - Re-enabling video track")
+                        delay(200) // Brief stabilization wait
+                        val currentParams = _exoPlayer?.trackSelectionParameters
+                        if (currentParams != null) {
+                            _exoPlayer?.trackSelectionParameters = currentParams
+                                .buildUpon()
+                                .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
+                                .build()
+                        } else {
+                            Log.w(PlayerRuntimeController.TAG, "[AFR LATE] TRACK KILLER - trackSelectionParameters is null, skipping re-enable")
+                        }
+                    }
+
+                    _uiState.update {
+                        it.copy(
+                            detectedFrameRateRaw = fps,
+                            detectedFrameRate = targetFrameRate,
+                            detectedFrameRateSource = FrameRateSource.TRACK,
+                            displayModeInfo = DisplayModeInfo(
+                                width = result.appliedMode.physicalWidth,
+                                height = result.appliedMode.physicalHeight,
+                                refreshRate = result.appliedMode.refreshRate
+                            ),
+                            showDisplayModeInfo = true
+                        )
+                    }
+                } else {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] matchFrameRateAndWait returned null")
+                }
+            } finally {
+                // FINALLY BLOCK: Guaranteed to run even if coroutine is cancelled or fails
+
+                // 1. Re-enable Video Track (Triggers DV Handshake)
+                if (currentInternalPlayerEngine == InternalPlayerEngine.EXOPLAYER) {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - Re-enabling video track")
+                    val currentParams = _exoPlayer?.trackSelectionParameters
+                    if (currentParams != null) {
+                        _exoPlayer?.trackSelectionParameters = currentParams
+                            .buildUpon()
+                            .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
+                            .build()
+                    }
+                }
+
+                // 2. Restore Audio (always restore to 1.0 since ExoPlayer volume is always at max)
+                Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - Restoring audio volume to 1.0")
+                _exoPlayer?.volume = 1f
+
+                // 3. Seek and Resume (if player is still valid and mode actually changed)
+                if (switchedDisplayMode) {
+                    val duration = currentPlaybackDurationMs()
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - Duration=$duration, will seek=$duration>0")
+                    if (duration > 0L) {
+                        Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - SEEK to ${maxOf(0L, resumePos - 500L)}")
+                        seekPlaybackTo(maxOf(0L, resumePos - 500L))
+                    } else {
+                        Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - SKIP seek (live stream or unknown duration)")
+                    }
+                } else {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - No display mode change, skipping seek")
+                }
+
+                if (wasPlaying) {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - RESUME playback")
+                    setPlaybackPaused(false)
+                } else {
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - Not resuming (was not playing)")
+                }
+
+                // 4. Hide Loading Overlay (inside finally to ensure it happens after state restoration)
+                if (waitingForLateAfrSwitch) {
+                    waitingForLateAfrSwitch = false
+                    Log.d(PlayerRuntimeController.TAG, "[AFR LATE] FINALLY - Hiding loading overlay after display switch")
+                    _uiState.update {
+                        it.copy(
+                            showLoadingOverlay = false,
+                            loadingMessage = null,
+                            loadingProgress = if (it.loadingProgress != null) 1f else null
+                        )
+                    }
+                }
+            }
+        } finally {
+            lateAfrInProgress = false
+            // Restore audio if Late AFR was skipped
+            _exoPlayer?.volume = 1f
+            // Reset waiting flag if Late AFR failed or was skipped
+            if (waitingForLateAfrSwitch) {
+                waitingForLateAfrSwitch = false
+                Log.w(PlayerRuntimeController.TAG, "[AFR LATE] Late AFR failed/skipped, hiding loading overlay")
+                _uiState.update {
+                    it.copy(
+                        showLoadingOverlay = false,
+                        loadingMessage = null,
+                        loadingProgress = if (it.loadingProgress != null) 1f else null
+                    )
+                }
+            }
+            Log.d(PlayerRuntimeController.TAG, "[AFR LATE] Completed")
+        }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -164,6 +164,7 @@ fun PlaybackSettingsContent(
     var showReuseLastLinkCacheDialog by remember { mutableStateOf(false) }
     var showPlayerPreferenceDialog by remember { mutableStateOf(false) }
     var showInternalPlayerEngineDialog by remember { mutableStateOf(false) }
+    var showLateAfrDialog by remember { mutableStateOf(false) }
     var showP2pConsentDialog by remember { mutableStateOf(false) }
 
     fun dismissAllDialogs() {
@@ -187,6 +188,7 @@ fun PlaybackSettingsContent(
         showReuseLastLinkCacheDialog = false
         showPlayerPreferenceDialog = false
         showInternalPlayerEngineDialog = false
+        showLateAfrDialog = false
         showP2pConsentDialog = false
     }
 
@@ -215,6 +217,7 @@ fun PlaybackSettingsContent(
                 trailerSettings = trailerSettings,
                 onShowPlayerPreferenceDialog = { openDialog { showPlayerPreferenceDialog = true } },
                 onShowInternalPlayerEngineDialog = { openDialog { showInternalPlayerEngineDialog = true } },
+                onShowLateAfrDialog = { openDialog { showLateAfrDialog = true } },
                 onShowAudioLanguageDialog = { openDialog { showAudioLanguageDialog = true } },
                 onShowSecondaryAudioLanguageDialog = { openDialog { showSecondaryAudioLanguageDialog = true } },
                 onShowAudioOutputChannelsDialog = { openDialog { showAudioOutputChannelsDialog = true } },
@@ -275,6 +278,7 @@ fun PlaybackSettingsContent(
                     coroutineScope.launch { viewModel.setAutoSkipSegmentTypeEnabled(segmentType, enabled) }
                 },
                 onSetFrameRateMatchingMode = { mode -> coroutineScope.launch { viewModel.setFrameRateMatchingMode(mode) } },
+                onSetExoPlayerAfrMode = { mode -> coroutineScope.launch { viewModel.setExoPlayerAfrMode(mode) } },
                 onSetResolutionMatchingEnabled = { enabled ->
                     coroutineScope.launch { viewModel.setResolutionMatchingEnabled(enabled) }
                 },
@@ -301,6 +305,7 @@ fun PlaybackSettingsContent(
                 },
                 onSetTunnelingEnabled = { enabled -> coroutineScope.launch { viewModel.setTunnelingEnabled(enabled) } },
                 onSetMapDV7ToHevc = { enabled -> coroutineScope.launch { viewModel.setMapDV7ToHevc(enabled) } },
+                onSetMpvHardwareDecodeMode = { mode -> coroutineScope.launch { viewModel.setMpvHardwareDecodeMode(mode) } },
                 onSetSubtitleSize = { newSize -> coroutineScope.launch { viewModel.setSubtitleSize(newSize) } },
                 onSetSubtitleVerticalOffset = { newOffset -> coroutineScope.launch { viewModel.setSubtitleVerticalOffset(newOffset) } },
                 onSetSubtitleBold = { bold -> coroutineScope.launch { viewModel.setSubtitleBold(bold) } },
@@ -331,6 +336,7 @@ fun PlaybackSettingsContent(
         enabledPluginNames = enabledPluginNames,
         showPlayerPreferenceDialog = showPlayerPreferenceDialog,
         showInternalPlayerEngineDialog = showInternalPlayerEngineDialog,
+        showLateAfrDialog = showLateAfrDialog,
         showLanguageDialog = showLanguageDialog,
         showSecondaryLanguageDialog = showSecondaryLanguageDialog,
         showSubtitleStartupModeDialog = showSubtitleStartupModeDialog,
@@ -357,6 +363,10 @@ fun PlaybackSettingsContent(
             coroutineScope.launch { viewModel.setInternalPlayerEngine(engine) }
         },
         onDismissInternalPlayerEngineDialog = ::dismissAllDialogs,
+        onSetExoPlayerAfrMode = { mode ->
+            coroutineScope.launch { viewModel.setExoPlayerAfrMode(mode) }
+        },
+        onDismissLateAfrDialog = ::dismissAllDialogs,
         onSetSubtitlePreferredLanguage = { language ->
             coroutineScope.launch { viewModel.setSubtitlePreferredLanguage(language ?: "none") }
         },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -65,8 +65,10 @@ import androidx.tv.material3.Text
 import com.nuvio.tv.data.local.AddonSubtitleStartupMode
 import com.nuvio.tv.data.local.AudioOutputChannels
 import com.nuvio.tv.data.local.AutoSkipSegmentType
+import com.nuvio.tv.data.local.ExoPlayerAfrMode
 import com.nuvio.tv.data.local.FrameRateMatchingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
+import com.nuvio.tv.data.local.MpvHardwareDecodeMode
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.TrailerSettings
@@ -106,6 +108,7 @@ internal fun PlaybackSettingsSections(
     trailerSettings: TrailerSettings,
     onShowPlayerPreferenceDialog: () -> Unit,
     onShowInternalPlayerEngineDialog: () -> Unit,
+    onShowLateAfrDialog: () -> Unit,
     onShowAudioLanguageDialog: () -> Unit,
     onShowSecondaryAudioLanguageDialog: () -> Unit,
     onShowAudioOutputChannelsDialog: () -> Unit,
@@ -142,6 +145,7 @@ internal fun PlaybackSettingsSections(
     onSetParentalGuideEnabled: (Boolean) -> Unit,
     onSetAutoSkipSegmentTypeEnabled: (AutoSkipSegmentType, Boolean) -> Unit,
     onSetFrameRateMatchingMode: (FrameRateMatchingMode) -> Unit,
+    onSetExoPlayerAfrMode: (ExoPlayerAfrMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
     onDisableAfrAndResolution: () -> Unit,
     onDisableAfrOnly: () -> Unit,
@@ -154,6 +158,7 @@ internal fun PlaybackSettingsSections(
     onSetRememberAudioDelayPerDevice: (Boolean) -> Unit,
     onSetTunnelingEnabled: (Boolean) -> Unit,
     onSetMapDV7ToHevc: (Boolean) -> Unit,
+    onSetMpvHardwareDecodeMode: (MpvHardwareDecodeMode) -> Unit,
     onSetSubtitleSize: (Int) -> Unit,
     onSetSubtitleVerticalOffset: (Int) -> Unit,
     onSetSubtitleBold: (Boolean) -> Unit,
@@ -210,9 +215,9 @@ internal fun PlaybackSettingsSections(
         }
     }
     val showAfrWarning = playerSettings.frameRateMatchingMode != FrameRateMatchingMode.OFF ||
-        (playerSettings.resolutionMatchingEnabled &&
-            displayCapabilities.apiSupported &&
-            !displayCapabilities.supportsResolutionSwitching)
+            (playerSettings.resolutionMatchingEnabled &&
+                    displayCapabilities.apiSupported &&
+                    !displayCapabilities.supportsResolutionSwitching)
 
     val strAfrOff = stringResource(R.string.playback_afr_off)
     val strAfrOnStart = stringResource(R.string.playback_afr_on_start)
@@ -444,11 +449,14 @@ internal fun PlaybackSettingsSections(
                 item(key = "general_afr_options") {
                     FrameRateMatchingModeOptions(
                         selectedMode = playerSettings.frameRateMatchingMode,
+                        exoPlayerAfrMode = playerSettings.exoPlayerAfrMode,
                         resolutionMatchingEnabled = playerSettings.resolutionMatchingEnabled,
                         resolutionSwitchingSupported = !displayCapabilities.apiSupported ||
                             displayCapabilities.supportsResolutionSwitching,
                         onSelect = onSetFrameRateMatchingMode,
+                        onSetExoPlayerAfrMode = onSetExoPlayerAfrMode,
                         onSetResolutionMatchingEnabled = onSetResolutionMatchingEnabled,
+                        onShowLateAfrDialog = onShowLateAfrDialog,
                         onFocused = { focusedSection = PlaybackSection.GENERAL },
                         enabled = !generalUi.isExternalPlayer
                     )
@@ -691,10 +699,13 @@ private fun PlaybackSectionHeader(
 @Composable
 private fun FrameRateMatchingModeOptions(
     selectedMode: FrameRateMatchingMode,
+    exoPlayerAfrMode: ExoPlayerAfrMode,
     resolutionMatchingEnabled: Boolean,
     resolutionSwitchingSupported: Boolean,
     onSelect: (FrameRateMatchingMode) -> Unit,
+    onSetExoPlayerAfrMode: (ExoPlayerAfrMode) -> Unit,
     onSetResolutionMatchingEnabled: (Boolean) -> Unit,
+    onShowLateAfrDialog: () -> Unit,
     onFocused: () -> Unit,
     enabled: Boolean
 ) {
@@ -730,8 +741,6 @@ private fun FrameRateMatchingModeOptions(
             enabled = enabled
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-
         ToggleSettingsItem(
             icon = Icons.Default.Image,
             title = stringResource(R.string.playback_resolution_matching),
@@ -746,6 +755,25 @@ private fun FrameRateMatchingModeOptions(
             titleTrailingIcon = if (resolutionMatchingEnabled && !resolutionSwitchingSupported) Icons.Default.Warning else null,
             titleTrailingIconTint = Color(0xFFFFB74D)
         )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Late AFR Configuration (ExoPlayer only)
+        if (selectedMode != FrameRateMatchingMode.OFF) {
+            NavigationSettingsItem(
+                icon = Icons.Default.Info,
+                title = stringResource(R.string.playback_exoplayer_late_afr),
+                subtitle = stringResource(
+                    when (exoPlayerAfrMode) {
+                        ExoPlayerAfrMode.LATE_ONLY -> R.string.playback_exoplayer_late_afr_enabled_sub
+                        ExoPlayerAfrMode.PREFLIGHT_ONLY -> R.string.playback_exoplayer_late_afr_disabled_sub
+                    }
+                ),
+                onClick = onShowLateAfrDialog,
+                onFocused = onFocused,
+                enabled = enabled
+            )
+        }
     }
 }
 
@@ -883,6 +911,7 @@ internal fun PlaybackSettingsDialogsHost(
     enabledPluginNames: List<String>,
     showPlayerPreferenceDialog: Boolean,
     showInternalPlayerEngineDialog: Boolean,
+    showLateAfrDialog: Boolean,
     showLanguageDialog: Boolean,
     showSecondaryLanguageDialog: Boolean,
     showSubtitleStartupModeDialog: Boolean,
@@ -905,6 +934,8 @@ internal fun PlaybackSettingsDialogsHost(
     onDismissPlayerPreferenceDialog: () -> Unit,
     onSetInternalPlayerEngine: (InternalPlayerEngine) -> Unit,
     onDismissInternalPlayerEngineDialog: () -> Unit,
+    onSetExoPlayerAfrMode: (ExoPlayerAfrMode) -> Unit,
+    onDismissLateAfrDialog: () -> Unit,
     onSetSubtitlePreferredLanguage: (String?) -> Unit,
     onSetSubtitleSecondaryLanguage: (String?) -> Unit,
     onSetAddonSubtitleStartupMode: (AddonSubtitleStartupMode) -> Unit,
@@ -961,6 +992,17 @@ internal fun PlaybackSettingsDialogsHost(
                 onDismissInternalPlayerEngineDialog()
             },
             onDismiss = onDismissInternalPlayerEngineDialog
+        )
+    }
+
+    if (showLateAfrDialog) {
+        ExoPlayerLateAfrDialog(
+            currentMode = playerSettings.exoPlayerAfrMode,
+            onModeSelected = { mode ->
+                onSetExoPlayerAfrMode(mode)
+                onDismissLateAfrDialog()
+            },
+            onDismiss = onDismissLateAfrDialog
         )
     }
 
@@ -1092,5 +1134,35 @@ private fun InternalPlayerEngineDialog(
         onDismiss = onDismiss,
         width = 420.dp,
         maxHeight = 320.dp
+    )
+}
+
+@Composable
+private fun ExoPlayerLateAfrDialog(
+    currentMode: ExoPlayerAfrMode,
+    onModeSelected: (ExoPlayerAfrMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val options = listOf(
+        SettingsPickerOption(
+            ExoPlayerAfrMode.LATE_ONLY,
+            stringResource(R.string.playback_exoplayer_late_afr_enabled),
+            stringResource(R.string.playback_exoplayer_late_afr_enabled_sub)
+        ),
+        SettingsPickerOption(
+            ExoPlayerAfrMode.PREFLIGHT_ONLY,
+            stringResource(R.string.playback_exoplayer_late_afr_disabled),
+            stringResource(R.string.playback_exoplayer_late_afr_disabled_sub)
+        )
+    )
+
+    SettingsSingleChoiceDialog(
+        title = stringResource(R.string.playback_exoplayer_late_afr),
+        options = options,
+        selectedValue = currentMode,
+        onOptionSelected = onModeSelected,
+        onDismiss = onDismiss,
+        width = 420.dp,
+        maxHeight = 280.dp
     )
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.FrameRateMatchingMode
+import com.nuvio.tv.data.local.ExoPlayerAfrMode
 import com.nuvio.tv.data.local.NextEpisodeThresholdMode
 import com.nuvio.tv.data.local.StreamAutoPlayMode
 import com.nuvio.tv.data.local.StreamAutoPlaySource
@@ -154,6 +155,10 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     suspend fun setFrameRateMatchingMode(mode: FrameRateMatchingMode) {
         playerSettingsDataStore.setFrameRateMatchingMode(mode)
+    }
+
+    suspend fun setExoPlayerAfrMode(mode: ExoPlayerAfrMode) {
+        playerSettingsDataStore.setExoPlayerAfrMode(mode)
     }
 
     suspend fun setResolutionMatchingEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,12 @@
     <string name="playback_afr_on_start_sub">Switch when playback starts.</string>
     <string name="playback_afr_on_start_stop">On start/stop</string>
     <string name="playback_afr_on_start_stop_sub">Switch on start and restore on stop.</string>
+    <string name="playback_exoplayer_late_afr">Late AFR (ExoPlayer only)</string>
+    <string name="playback_exoplayer_late_afr_sub">Detect frame rate during playback for faster start</string>
+    <string name="playback_exoplayer_late_afr_enabled">Enabled</string>
+    <string name="playback_exoplayer_late_afr_enabled_sub">Use dynamic FPS detection during playback</string>
+    <string name="playback_exoplayer_late_afr_disabled">Disabled</string>
+    <string name="playback_exoplayer_late_afr_disabled_sub">Use preflight probe only</string>
     <string name="playback_resolution_matching">Resolution matching</string>
     <string name="playback_resolution_matching_sub">Allow display mode changes to match video resolution.</string>
     <string name="playback_resolution_matching_unsupported_sub">Display reports only one resolution; matching may have no effect.</string>
@@ -605,6 +611,7 @@
     <string name="playback_player_auto_desc">ExoPlayer for Movies &amp; TV Shows · MPV for Anime</string>
     <string name="playback_engine_exoplayer_desc">Best compatibility with current Nuvio features.</string>
     <string name="playback_engine_mvplayer_desc">Uses libmpv with Nuvio OSD controls. Experimental.</string>
+    <string name="obtaining_frame_rate">Detecting frame rate...</string>
 
     <!-- PlaybackAudioSettings -->
     <string name="audio_trailer_section">Trailer</string>


### PR DESCRIPTION
## Summary

Implemented Late AFR (Late Automatic Frame Rate) feature for ExoPlayer, a new option that allows users to choose between "Late Only" (detect frame rate during playback) and "Preflight Only" (detect frame rate before playback) modes. Added DynamicFpsCalculator for runtime FPS detection using ExoPlayer's VideoFrameMetadataListener. Integrated Late AFR option within the AFR settings section with modal dialog UI following the existing player selection dialog pattern.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Late AFR provides an alternative frame rate detection method that avoids blocking UI during preflight for certain media formats. This is a new feature that gives users more control over how frame rate detection is performed for ExoPlayer.

## Issue or approval

Partial fixes #2043 

## Reproduction steps

1. Navigate to Settings > Playback
2. Enable Frame Rate Matching (not OFF)
3. Select "Late AFR" menu item within the AFR section (new option)
4. Choose between "Late Only" or "Preflight Only" modes in the modal dialog
5. Play content to verify frame rate detection works in selected mode

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Components implemented (new feature):
- ExoPlayerLateAfrDialog composable with LATE_ONLY and PREFLIGHT_ONLY options
- DynamicFpsCalculator for runtime FPS detection using VideoFrameMetadataListener
- Integration in PlayerRuntimeControllerInitialization.kt with onRenderedFirstFrame callback
- triggerLateAfr function in PlayerRuntimeControllerPlaybackEvents.kt for display mode switching
- NavigationSettingsItem for Late AFR within AFR settings section
- State management in PlaybackSettingsScreen.kt

## Testing

UI Testing:
- Dialog opens correctly when Late AFR menu item is selected within AFR section
- Mode switching between "Late Only" and "Preflight Only" works
- UI styling matches player selection dialog pattern
- Late AFR option only appears when Frame Rate Matching is enabled (not OFF)

Functionality Testing:
- DynamicFpsCalculator correctly collects timestamps from VideoFrameMetadataListener during playback
- FPS calculation triggers after collecting 35 frames (5 ignored + 30 collected)
- Display mode switching triggers after FPS calculation in Late Only mode
- Preflight Only mode skips DynamicFpsCalculator and uses preflight detection
- Silent Start (audio muted) works correctly during FPS calculation in Late Only mode
- Audio volume restored after display mode switch completes
- Loading overlay shows "Detecting frame rate..." during FPS calculation
- Loading overlay hides after Late AFR switch completes
- Frame rate snapping to standard rates (23.976, 24, 25, 29.97, 30, 50, 59.94, 60) works correctly
- Timeout mechanism (5 seconds) triggers if FPS calculation fails
- VideoFrameMetadataListener properly detached after FPS calculation to prevent CPU overhead

## Screenshots / Video
<img width="638" height="377" alt="Screenshot 2026-05-24 alle 14 16 58" src="https://github.com/user-attachments/assets/b18671da-6b3e-42eb-afb0-061fb5767a85" />
<img width="638" height="377" alt="Screenshot 2026-05-24 alle 14 17 10" src="https://github.com/user-attachments/assets/3ed42938-b7ab-4c9c-bdae-e949dab88c32" />


## Breaking changes
None. Classic preflight remains available to prevent regressions.

## Linked issues

#2043 
