### PR TITLE
Fix: Multi-provider debrid cache checking

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamPresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DebridStreamPresentation.kt
@@ -52,7 +52,9 @@ class DebridStreamPresentation @Inject constructor(
 
     private fun Stream.isInactiveResolverStream(settings: DebridSettings): Boolean {
         val streamProviderId = DebridProviders.byId(clientResolve?.service)?.id ?: return false
-        val activeProviderId = settings.activeResolverProviderId ?: return false
-        return isDirectDebrid() && streamProviderId != activeProviderId
+        if (!isDirectDebrid()) return false
+        // Only hide streams from providers the user hasn't configured,
+        // not from non-preferred providers. All configured providers should be visible.
+        return settings.apiKeyFor(streamProviderId).isBlank()
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridResolver.kt
@@ -122,10 +122,12 @@ class DirectDebridResolver @Inject constructor(
         if (stream.needsLocalDebridResolve()) {
             return localTorrentResolveCredential(settings) != null
         }
-        if (!stream.isDirectDebrid() || stream.getStreamUrl() != null) return false
+        if (stream.getStreamUrl() != null) return false
+        if (!stream.isDirectDebrid()) return false
         val providerId = DebridProviders.byId(stream.clientResolve?.service)?.id ?: return false
-        return providerId == settings.activeResolverProviderId &&
-            settings.apiKeyFor(providerId).isNotBlank()
+        // Allow resolution for ANY configured provider, not just the active one.
+        // E.g. if TB is active but a stream is tagged for PM, resolve via PM.
+        return settings.apiKeyFor(providerId).isNotBlank()
     }
 
     private suspend fun getCachedResult(cacheKey: String): DirectDebridResolveResult.Success? =
@@ -177,7 +179,7 @@ class DirectDebridResolver @Inject constructor(
         val resolve = clientResolve ?: return null
         val providerId = DebridProviders.byId(resolve.service)?.id ?: return null
         val settings = dataStore.settings.first()
-        if (!settings.canResolvePlayableLinks || providerId != settings.activeResolverProviderId) return null
+        if (!settings.canResolvePlayableLinks) return null
         val apiKey = settings.apiKeyFor(providerId).trim().takeIf { it.isNotBlank() } ?: return null
         val identity = resolve.infoHash
             ?: resolve.magnetUri
@@ -202,7 +204,17 @@ class DirectDebridResolver @Inject constructor(
         episode: Int?
     ): DirectDebridResolveResult {
         val settings = dataStore.settings.first()
-        val account = localTorrentResolveCredential(settings) ?: return DirectDebridResolveResult.MissingApiKey
+        // Use the provider that confirmed the cache hit (from multi-provider check),
+        // falling back to the user's preferred provider.
+        val cachedProviderId = stream.debridCacheStatus
+            ?.takeIf { it.state == StreamDebridCacheState.CACHED }?.providerId
+        val account = if (cachedProviderId != null) {
+            DebridProviders.configuredResolverServices(settings)
+                .firstOrNull { it.provider.id == cachedProviderId }
+        } else {
+            null
+        } ?: localTorrentResolveCredential(settings)
+            ?: return DirectDebridResolveResult.MissingApiKey
         val hash = stream.infoHash?.trim()?.lowercase()
         if (stream.debridCacheStatus?.state == StreamDebridCacheState.NOT_CACHED) {
             return DirectDebridResolveResult.NotCached

--- a/app/src/main/java/com/nuvio/tv/core/debrid/LocalDebridAvailabilityService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/LocalDebridAvailabilityService.kt
@@ -5,6 +5,8 @@ import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.Stream
 import com.nuvio.tv.domain.model.StreamDebridCacheState
 import com.nuvio.tv.domain.model.StreamDebridCacheStatus
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,15 +17,17 @@ class LocalDebridAvailabilityService @Inject constructor(
     private val localDebridService: LocalDebridService
 ) {
     suspend fun markChecking(groups: List<AddonStreams>): List<AddonStreams> {
-        val account = cacheCheckAccount() ?: return groups
+        val accounts = cacheCheckAccounts()
+        if (accounts.isEmpty()) return groups
+        val primary = accounts.first()
         return groups.updateAvailabilityStatus { stream ->
             if (stream.localAvailabilityHash() == null || stream.debridCacheStatus?.state == StreamDebridCacheState.CACHED) {
                 stream
             } else {
                 stream.copy(
                     debridCacheStatus = StreamDebridCacheStatus(
-                        providerId = account.provider.id,
-                        providerName = account.provider.displayName,
+                        providerId = primary.provider.id,
+                        providerName = primary.provider.displayName,
                         state = StreamDebridCacheState.CHECKING
                     )
                 )
@@ -32,7 +36,11 @@ class LocalDebridAvailabilityService @Inject constructor(
     }
 
     suspend fun annotateCachedAvailability(groups: List<AddonStreams>): List<AddonStreams> {
-        val account = cacheCheckAccount() ?: return groups
+        val settings = dataStore.settings.first()
+        if (!settings.canResolvePlayableLinks) return groups
+        val accounts = cacheCheckAccounts()
+        if (accounts.isEmpty()) return groups
+
         val hashes = groups.flatMap { group ->
             group.streams.mapNotNull { stream ->
                 stream.localAvailabilityHash()
@@ -41,50 +49,79 @@ class LocalDebridAvailabilityService @Inject constructor(
         }.distinct()
         if (hashes.isEmpty()) return groups
 
-        val cached = localDebridService.checkCached(account = account, hashes = hashes)
-            ?: return groups.updateAvailabilityStatus { stream ->
-                val hash = stream.localAvailabilityHash()
-                if (hash == null) {
-                    stream
-                } else {
-                    stream.copy(
-                        debridCacheStatus = StreamDebridCacheStatus(
-                            providerId = account.provider.id,
-                            providerName = account.provider.displayName,
-                            state = StreamDebridCacheState.UNKNOWN
-                        )
+        // Check ALL configured providers in parallel instead of just the active one.
+        // This ensures torrents cached on ANY provider are shown, not just the preferred one.
+        val allResults = coroutineScope {
+            accounts.map { account ->
+                async {
+                    val cached = localDebridService.checkCached(account = account, hashes = hashes)
+                    account to (cached ?: emptyMap())
+                }
+            }.map { it.await() }
+        }
+
+        // Merge: prefer the user's active provider when multiple have the same hash
+        val preferredId = settings.activeResolverProviderId
+        val mergedCache = mutableMapOf<String, CacheHit>()
+        for ((account, cached) in allResults) {
+            for ((hash, item) in cached) {
+                val existing = mergedCache[hash]
+                if (existing == null || (account.provider.id == preferredId && existing.providerId != preferredId)) {
+                    mergedCache[hash] = CacheHit(
+                        providerId = account.provider.id,
+                        providerName = account.provider.displayName,
+                        item = item
                     )
                 }
             }
+        }
 
+        val fallbackAccount = accounts.first()
         return groups.updateAvailabilityStatus { stream ->
             val hash = stream.localAvailabilityHash() ?: return@updateAvailabilityStatus stream
             if (stream.debridCacheStatus?.state in FINAL_CACHE_STATES) return@updateAvailabilityStatus stream
-            val cachedItem = cached[hash]
+            val hit = mergedCache[hash]
             stream.copy(
                 debridCacheStatus = StreamDebridCacheStatus(
-                    providerId = account.provider.id,
-                    providerName = account.provider.displayName,
-                    state = if (cachedItem == null) StreamDebridCacheState.NOT_CACHED else StreamDebridCacheState.CACHED,
-                    cachedName = cachedItem?.name,
-                    cachedSize = cachedItem?.size
+                    providerId = hit?.providerId ?: fallbackAccount.provider.id,
+                    providerName = hit?.providerName ?: fallbackAccount.provider.displayName,
+                    state = if (hit != null) StreamDebridCacheState.CACHED else StreamDebridCacheState.NOT_CACHED,
+                    cachedName = hit?.item?.name,
+                    cachedSize = hit?.item?.size
                 )
             )
         }
     }
 
     suspend fun isCached(hash: String): Boolean? {
-        val account = cacheCheckAccount() ?: return null
-        return localDebridService.isCached(account, hash)
+        val accounts = cacheCheckAccounts()
+        if (accounts.isEmpty()) return null
+        // Cached on ANY provider means cached
+        for (account in accounts) {
+            val result = localDebridService.isCached(account, hash)
+            if (result == true) return true
+        }
+        return false
     }
 
-    private suspend fun cacheCheckAccount(): DebridServiceCredential? {
+    /**
+     * Returns ALL configured providers with cache-check capability,
+     * not just the active/preferred one. This is the core of the fix:
+     * when TB + PM are both configured, both get checked in parallel.
+     */
+    private suspend fun cacheCheckAccounts(): List<DebridServiceCredential> {
         val settings = dataStore.settings.first()
-        if (!settings.canResolvePlayableLinks) return null
-        return settings.activeResolverCredential
-            ?.takeIf { credential -> credential.provider.supports(DebridProviderCapability.LocalTorrentCacheCheck) }
+        if (!settings.canResolvePlayableLinks) return emptyList()
+        return DebridProviders.configuredServices(settings)
+            .filter { it.provider.supports(DebridProviderCapability.LocalTorrentCacheCheck) }
     }
 }
+
+private data class CacheHit(
+    val providerId: String,
+    val providerName: String,
+    val item: LocalDebridCachedItem
+)
 
 private val FINAL_CACHE_STATES = setOf(
     StreamDebridCacheState.CACHED,


### PR DESCRIPTION
## Summary

When multiple debrid providers are configured (e.g. TorBox + Premiumize), the app only cache-checks torrents against the single "active/preferred" provider. If that provider doesn't have a torrent cached, it's marked NOT_CACHED and hidden — even if another configured provider has it cached and ready to play.

**Symptoms:**
- User has TorBox + Premiumize configured, TorBox is preferred
- A torrent is cached on Premiumize but not TorBox
- App marks it NOT_CACHED (only checked TorBox) → stream is hidden
- User sees fewer playable streams than expected

## Changes

### LocalDebridAvailabilityService.kt
- `cacheCheckAccount()` (single) → `cacheCheckAccounts()` (all configured providers with LocalTorrentCacheCheck)
- `annotateCachedAvailability()` checks all providers in parallel via `coroutineScope { async {} }`
- Merges results: cached on ANY provider = CACHED, prefers activeResolver when tied
- `isCached()` returns true if ANY provider has it

### DirectDebridResolver.kt
- `shouldResolveToPlayableStream()`: allows resolution for any provider with a configured API key (was restricted to activeResolverProviderId)
- `resolveLocalTorrentStream()`: uses the provider that confirmed the cache hit
- Cache key no longer gated by activeResolverProviderId

### DebridStreamPresentation.kt
- `isInactiveResolverStream()`: hides streams from unconfigured providers only, not non-preferred ones

## Backwards Compatibility
Single-provider users see identical behavior.

## Test Plan
- [ ] Configure TorBox + Premiumize, set TorBox as preferred
- [ ] Open a title cached on Premiumize but not TorBox
- [ ] Verify stream shows as cached and resolves via Premiumize
- [ ] Verify single-provider setup still works