### PR TITLE
fix(sync): persist 'group plugin providers by repository' to cloud sync

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -129,12 +129,26 @@ private val localOnlyPlayerProfileSettingsKeys = setOf(
     "migration_target_buffer_size_reduced_done"
 )
 
+private const val PLUGIN_SETTINGS_FEATURE = "plugin_settings"
+
+// Plugin repositories and scrapers are synced through PluginSyncService, not the
+// profile-settings blob, so they are excluded here. Only the user-facing display
+// preferences (e.g. "group plugin providers by repository") sync via profile
+// settings. See issue #2222.
+private val localOnlyPluginProfileSettingsKeys = setOf(
+    "repositories",
+    "scrapers",
+    "scraper_settings",
+    "plugins_enabled"
+)
+
 internal fun shouldExcludePreferenceFromProfileSettingsSync(feature: String, keyName: String): Boolean {
     return when {
         feature == "layout_settings" && keyName in catalogKeysExcludedFromProfileSettingsBlob -> true
         feature == "layout_settings" && keyName in localOnlyLayoutProfileSettingsKeys -> true
         feature == "layout_settings" && keyName == "search_discover_enabled" -> true
         feature == PLAYER_SETTINGS_FEATURE && keyName in localOnlyPlayerProfileSettingsKeys -> true
+        feature == PLUGIN_SETTINGS_FEATURE && keyName in localOnlyPluginProfileSettingsKeys -> true
         else -> false
     }
 }
@@ -169,7 +183,8 @@ class ProfileSettingsSyncService @Inject constructor(
         "trakt_settings",
         "debrid_settings",
         "animeskip_settings",
-        "track_preference"
+        "track_preference",
+        PLUGIN_SETTINGS_FEATURE
     )
 
     init {
@@ -486,6 +501,7 @@ class ProfileSettingsSyncService @Inject constructor(
         val keyNames = when (feature) {
             "layout_settings" -> catalogKeysExcludedFromProfileSettingsBlob + localOnlyLayoutProfileSettingsKeys
             PLAYER_SETTINGS_FEATURE -> localOnlyPlayerProfileSettingsKeys
+            PLUGIN_SETTINGS_FEATURE -> localOnlyPluginProfileSettingsKeys
             else -> emptySet()
         }
         if (keyNames.isEmpty()) return emptyMap()

--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -129,12 +129,12 @@ private val localOnlyPlayerProfileSettingsKeys = setOf(
     "migration_target_buffer_size_reduced_done"
 )
 
-private const val PLUGIN_SETTINGS_FEATURE = "plugin_settings"
+internal const val PLUGIN_SETTINGS_FEATURE = "plugin_settings"
 
 // Plugin repositories and scrapers are synced through PluginSyncService, not the
 // profile-settings blob, so they are excluded here. Only the user-facing display
 // preferences (e.g. "group plugin providers by repository") sync via profile
-// settings. See issue #2222.
+// settings.
 private val localOnlyPluginProfileSettingsKeys = setOf(
     "repositories",
     "scrapers",

--- a/app/src/test/java/com/nuvio/tv/core/sync/PluginSettingsSyncExclusionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/PluginSettingsSyncExclusionTest.kt
@@ -1,0 +1,41 @@
+package com.nuvio.tv.core.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PluginSettingsSyncExclusionTest {
+
+    @Test
+    fun `group by repository preference is synced via profile settings`() {
+        assertFalse(
+            shouldExcludePreferenceFromProfileSettingsSync(
+                feature = "plugin_settings",
+                keyName = "group_streams_by_repository"
+            )
+        )
+    }
+
+    @Test
+    fun `plugin repositories and scrapers stay local to profile settings sync`() {
+        listOf("repositories", "scrapers", "scraper_settings", "plugins_enabled").forEach { key ->
+            assertTrue(
+                "expected $key to be excluded from profile settings sync",
+                shouldExcludePreferenceFromProfileSettingsSync(
+                    feature = "plugin_settings",
+                    keyName = key
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `plugin exclusion does not leak into other features`() {
+        assertFalse(
+            shouldExcludePreferenceFromProfileSettingsSync(
+                feature = "theme_settings",
+                keyName = "repositories"
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/sync/PluginSettingsSyncExclusionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/sync/PluginSettingsSyncExclusionTest.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.sync
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -7,10 +8,17 @@ import org.junit.Test
 class PluginSettingsSyncExclusionTest {
 
     @Test
+    fun `plugin settings feature name matches the PluginDataStore wire value`() {
+        // The feature string doubles as the on-disk datastore name and the key
+        // in the remote settings blob; renaming it would orphan synced data.
+        assertEquals("plugin_settings", PLUGIN_SETTINGS_FEATURE)
+    }
+
+    @Test
     fun `group by repository preference is synced via profile settings`() {
         assertFalse(
             shouldExcludePreferenceFromProfileSettingsSync(
-                feature = "plugin_settings",
+                feature = PLUGIN_SETTINGS_FEATURE,
                 keyName = "group_streams_by_repository"
             )
         )
@@ -22,7 +30,7 @@ class PluginSettingsSyncExclusionTest {
             assertTrue(
                 "expected $key to be excluded from profile settings sync",
                 shouldExcludePreferenceFromProfileSettingsSync(
-                    feature = "plugin_settings",
+                    feature = PLUGIN_SETTINGS_FEATURE,
                     keyName = key
                 )
             )


### PR DESCRIPTION
## Summary

Fixes #2222. The "Group plugin providers by repository" toggle was lost after clearing app data and re-signing in, because it never synced to the user's cloud sync account.

## PR type

- [x] Critical bug fix

## Why

The `group_streams_by_repository` preference lives in the `plugin_settings` data store, which was not included in the profile-settings `syncedFeatures` list. As a result the toggle was never pushed to the cloud account and reverted to its default after a data clear + re-login.

## Issue or approval

Fixes #2222

## Reproduction steps

1. Settings → Plugins → enable "Group plugin providers by repository".
2. Force-stop the app and clear app data.
3. Reopen the app and sign in.
4. Navigate to Settings → Plugins: the toggle is off again.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Adds `plugin_settings` to the synced profile-settings features, but excludes plugin repositories, scrapers, scraper settings, and the master enable flag — those already sync through `PluginSyncService` and stay local to this path. Only the user-facing display preference syncs via profile settings.
- Export, import, and signature paths already route through the shared `shouldExcludePreferenceFromProfileSettingsSync` helper, so the exclusion is applied consistently. Migration is safe: an existing remote blob without `plugin_settings` is skipped (not cleared) on import, so no local plugin state is lost.

## Testing

`./gradlew :app:compileFullDebugKotlin` and `:app:compileFullDebugUnitTestKotlin` pass clean.

New `PluginSettingsSyncExclusionTest` verifies the group-by-repository key is synced and that repository/scraper state stays excluded, and that the exclusion does not leak into other features.

Note: the `AndroidUnitTest` runner cannot execute on my Windows environment (known Gradle `Type T not present` issue), so the tests are compile-verified against the codebase rather than executed here.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. The preference becomes profile-scoped (syncs across a profile's devices), which is the requested behavior.

## Linked issues

Fixes #2222