### PR TITLE
fix(trakt): decouple watched badges from WatchProgressSource

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.data.local.WatchProgressSource
+import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.domain.model.WatchProgress
@@ -281,6 +282,21 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     private suspend fun shouldUseTraktProgress(): Boolean = useTraktProgressFlow().first()
+
+    @OptIn(FlowPreview::class)
+    private fun traktWatchedDataAvailableFlow(): Flow<Boolean> {
+        return combine(
+            traktAuthDataStore.isEffectivelyAuthenticated,
+            traktSettingsDataStore.librarySourceMode,
+            traktSettingsDataStore.watchProgressSource
+        ) { isAuth, libraryMode, source ->
+            isAuth && (libraryMode == LibrarySourceMode.TRAKT || source == WatchProgressSource.TRAKT)
+        }.distinctUntilChanged()
+    }
+
+    private suspend fun shouldUseTraktWatchedData(): Boolean = traktWatchedDataAvailableFlow().first()
+
+    override suspend fun isTraktWatchedDataActive(): Boolean = shouldUseTraktWatchedData()
 
     private suspend fun hasEffectiveTraktConnection(): Boolean =
         traktAuthDataStore.isEffectivelyAuthenticated.first()
@@ -593,9 +609,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
 
     @OptIn(FlowPreview::class)
     override fun observeWatchedMovieIds(): Flow<Set<String>> {
-        return useTraktProgressFlow()
-            .flatMapLatest { useTraktProgress ->
-                if (useTraktProgress) {
+        return traktWatchedDataAvailableFlow()
+            .flatMapLatest { useTraktWatchedData ->
+                if (useTraktWatchedData) {
                     traktProgressService.observeAllWatchedMovieIds()
                 } else {
                     combine(
@@ -631,7 +647,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
      * For Nuvio sync: from watchedItemsPreferences.
      */
     override suspend fun getWatchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> {
-        return if (shouldUseTraktProgress()) {
+        return if (shouldUseTraktWatchedData()) {
             val traktEpisodes = traktProgressService.getWatchedShowEpisodes()
             val localEpisodes = watchedItemsPreferences.allItems.first()
                 .filter { it.season != null && it.episode != null }
@@ -657,7 +673,7 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getShowIdSiblings(): Map<String, Set<String>> {
-        return if (shouldUseTraktProgress()) {
+        return if (shouldUseTraktWatchedData()) {
             traktProgressService.getShowIdSiblings()
         } else {
             emptyMap()
@@ -665,9 +681,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
     }
 
     override fun isWatched(contentId: String, videoId: String?, season: Int?, episode: Int?): Flow<Boolean> {
-        return useTraktProgressFlow()
-            .flatMapLatest { useTraktProgress ->
-                if (!useTraktProgress) {
+        return traktWatchedDataAvailableFlow()
+            .flatMapLatest { useTraktWatchedData ->
+                if (!useTraktWatchedData) {
                     val progressFlow = if (season != null && episode != null) {
                         watchProgressPreferences.getEpisodeProgress(contentId, season, episode)
                     } else {

--- a/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/WatchProgressRepository.kt
@@ -135,4 +135,12 @@ interface WatchProgressRepository {
      * Returns true if Trakt is both configured AND authenticated as the active progress source.
      */
     suspend fun isTraktProgressActive(): Boolean
+
+    /**
+     * Returns true if Trakt watched data should be used for badges and watched-status display.
+     * Factors in both LibrarySourceMode (TRAKT) and WatchProgressSource (TRAKT),
+     * so that Trakt-watched badges still appear when LibrarySourceMode = TRAKT
+     * even if WatchProgressSource = NUVIO_SYNC.
+     */
+    suspend fun isTraktWatchedDataActive(): Boolean
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -466,7 +466,7 @@ class MetaDetailsViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             val isTraktActive = try {
-                watchProgressRepository.isTraktProgressActive()
+                watchProgressRepository.isTraktWatchedDataActive()
             } catch (_: Exception) { false }
             if (!isTraktActive) return@launch
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -995,7 +995,7 @@ internal fun HomeViewModel.reconcilePosterStatusObserversPipeline(rows: List<Cat
             ) { fullyWatched, watchedItems ->
                 fullyWatched to watchedItems
             }.collectLatest { (fullyWatched, watchedItems) ->
-                val effectiveFullyWatched = if (watchProgressRepository.isTraktProgressActive()) {
+                val effectiveFullyWatched = if (watchProgressRepository.isTraktWatchedDataActive()) {
                     fullyWatched
                 } else {
                     reconcileFullyWatchedFromLocalItems(


### PR DESCRIPTION
## Summary

When `LibrarySourceMode = TRAKT` + `WatchProgressSource = NUVIO_SYNC`, watched-status badges (movie watched icons, series fully-watched badges, episode checkmarks) silently lost Trakt data, making the library appear as if it was in Nuvio/LOCAL mode — even though the Settings UI correctly showed `LibrarySourceMode = TRAKT` and library content came from Trakt.

Root cause: `WatchProgressRepositoryImpl.useTraktProgressFlow()` gates every watched-status query solely on `watchProgressSource == TRAKT && isAuthenticated`. Switching Watch Progress to NUVIO_SYNC caused all badge queries to drop Trakt data.

Fix: introduced `traktWatchedDataAvailableFlow()` that factors in **both** `LibrarySourceMode` **and** `WatchProgressSource`. Badge/display methods (`observeWatchedMovieIds`, `getWatchedShowEpisodes`, `isWatched`, `getShowIdSiblings`) use the relaxed gate. CW pipeline and write-side methods keep the strict `useTraktProgressFlow()`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users who set `LibrarySourceMode = TRAKT` + `WatchProgressSource = NUVIO_SYNC` — a recommended combo due to Trakt instability — expected library badges to reflect Trakt watched state (since the Library is from Trakt). Instead, badges only reflected Nuvio data, making Trakt-watched series appear unwatched. The Library Source setting was being silently ignored by the badge layer.

## Issue or approval

No linked issue — discovered during UX testing of the Trakt + Nuvio Sync combo.

## Reproduction steps

1. Go to Settings → Trakt
2. Verify Trakt is connected and authenticated
3. Set **Library Source** = Trakt
4. Set **Watch Progress Source** to Nuvio Sync
5. Open the Library screen
6. Observe a movie that is watched on Trakt but not in Nuvio — the movie badge shows **unwatched** (regression)
7. Open a series detail where all episodes are watched on Trakt — badge shows **incomplete** (regression)

## UI / behavior impact

| Library Source | Watch Progress | Library Content | Badges Before | Badges After |
|---|---|---|---|---|
| Trakt | Trakt | Trakt | ✅ Trakt | ✅ Trakt |
| Trakt | Nuvio Sync | Trakt | ❌ Nuvio | ✅ Trakt |
| Nuvio | Trakt | Nuvio | ✅ Nuvio | ✅ Nuvio |
| Nuvio | Nuvio Sync | Nuvio | ✅ Nuvio | ✅ Nuvio |

- [ ] No UI change
- [x] Behavior changed (badges now respect LibrarySourceMode)
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- Only watched-status display queries are affected. The CW pipeline, progress writes, and remote sync continue to use `WatchProgressSource` as before.
- `isTraktProgressActive()` (strict gate) is preserved for CW pipeline and PlayerRuntimeController.
- New `isTraktWatchedDataActive()` method added to the repository interface for external consumers.
- No refactors, cleanups, or drive-by changes.

## Testing

- [ ] Movie watched badge in Library shows Trakt-watched movies when Library=Trakt + Progress=NuvioSync
- [ ] Series fully-watched badges appear in library/home screens
- [ ] Episode checkmarks in detail screen reflect Trakt data
- [ ] No regression: Library=Local + any Progress still shows Nuvio-only badges
- [ ] No regression: All-Trakt combo (both sources = Trakt) works identically

## Screenshots / Video

N/A — no visual UI changes, only badge data source routing.

## Breaking changes

None. 4 files changed, 34 insertions(+), 10 deletions(-). No API surface or data contracts modified.

## Linked issues

No linked issue.