### PR TITLE
fix(player): keep next-episode on the same addon source (#2756)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/StreamAutoPlaySelector.kt
@@ -55,7 +55,14 @@ object StreamAutoPlaySelector {
         selectedPlugins: Set<String>,
         preferredBingeGroup: String? = null,
         preferBingeGroupInSelection: Boolean = false,
-        bingeGroupOnly: Boolean = false
+        bingeGroupOnly: Boolean = false,
+        /**
+         * When set (typically the addon of the stream currently playing), prefer
+         * matching streams from that addon before falling back to the global
+         * ranking. Fixes next-episode jumping from e.g. "Torrentio TV" to
+         * "Torrentio" just because the latter is earlier in installed order.
+         */
+        preferredAddonName: String? = null
     ): Stream? {
         if (streams.isEmpty()) return null
 
@@ -80,7 +87,66 @@ object StreamAutoPlaySelector {
         }
         if (candidateStreams.isEmpty()) return null
 
-        // Binge group matching takes priority over mode — even in MANUAL mode,
+        // Priority for next-episode continuity (see #2756 / skoruppa notes on
+        // duplicated addons with identical binge groups):
+        // 1) same addon + same binge group
+        // 2) any addon with same binge group
+        // 3) same addon via normal mode (FIRST_STREAM / REGEX)
+        // 4) global mode fallback
+        val preferredAddon = preferredAddonName?.trim().orEmpty()
+        val sameAddonCandidates = if (preferredAddon.isNotEmpty()) {
+            candidateStreams.filter { it.addonName == preferredAddon }
+        } else {
+            emptyList()
+        }
+        val targetBingeGroup = preferredBingeGroup?.trim().orEmpty()
+        val bingeEnabled = preferBingeGroupInSelection && targetBingeGroup.isNotEmpty()
+
+        if (bingeEnabled) {
+            sameAddonCandidates.firstOrNull { stream ->
+                stream.behaviorHints?.bingeGroup == targetBingeGroup && isPlayable(stream)
+            }?.let { return it }
+
+            candidateStreams.firstOrNull { stream ->
+                stream.behaviorHints?.bingeGroup == targetBingeGroup && isPlayable(stream)
+            }?.let { return it }
+
+            // MANUAL + binge-only: do not invent a non-binge match.
+            if (bingeGroupOnly) return null
+        }
+
+        if (sameAddonCandidates.isNotEmpty()) {
+            selectFromCandidates(
+                candidateStreams = sameAddonCandidates,
+                mode = mode,
+                regexPattern = regexPattern,
+                preferredBingeGroup = null,
+                preferBingeGroupInSelection = false,
+                bingeGroupOnly = false
+            )?.let { return it }
+        }
+
+        return selectFromCandidates(
+            candidateStreams = candidateStreams,
+            mode = mode,
+            regexPattern = regexPattern,
+            preferredBingeGroup = if (bingeEnabled) null else preferredBingeGroup,
+            preferBingeGroupInSelection = if (bingeEnabled) false else preferBingeGroupInSelection,
+            bingeGroupOnly = bingeGroupOnly
+        )
+    }
+
+    private fun selectFromCandidates(
+        candidateStreams: List<Stream>,
+        mode: StreamAutoPlayMode,
+        regexPattern: String,
+        preferredBingeGroup: String?,
+        preferBingeGroupInSelection: Boolean,
+        bingeGroupOnly: Boolean
+    ): Stream? {
+        if (candidateStreams.isEmpty()) return null
+
+        // Binge group matching takes priority over mode - even in MANUAL mode,
         // a persisted binge group should auto-play without showing the picker.
         val targetBingeGroup = preferredBingeGroup?.trim().orEmpty()
         if (preferBingeGroupInSelection && targetBingeGroup.isNotEmpty()) {
@@ -89,7 +155,7 @@ object StreamAutoPlaySelector {
             }
             if (bingeGroupMatch != null) return bingeGroupMatch
             // When bingeGroupOnly is set (MANUAL mode with only binge-group
-            // preference enabled), don't fall back to a non-matching stream —
+            // preference enabled), don't fall back to a non-matching stream -
             // return null so the caller shows the stream picker instead.
             if (bingeGroupOnly) return null
         }
@@ -119,7 +185,7 @@ object StreamAutoPlaySelector {
                     Regex("\\b(${exclusionWords.joinToString("|")})\\b", RegexOption.IGNORE_CASE)
                 } else null
 
-                // 1. Build list of ALL regex‑matching streams
+                // 1. Build list of ALL regex-matching streams
                 val matchingStreams = candidateStreams.filter { stream ->
                     if (!isPlayable(stream)) return@filter false
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1585,6 +1585,11 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
             // finishes, so the waiting code below resumes without polling.
             val searchSettled = CompletableDeferred<Unit>()
 
+            // Keep next-episode on the same addon the user actually started with
+            // (e.g. "Torrentio TV" vs plain "Torrentio"). Without this, FIRST_STREAM
+            // falls through installed-addon order and silently switches sources.
+            val preferredAddonForNext = currentAddonName?.takeIf { it.isNotBlank() }
+
             fun trySelectStream(data: List<AddonStreams>): Stream? {
                 val orderedStreams = StreamAutoPlaySelector.orderAddonStreams(data, installedAddonOrder)
                 val allStreams = orderedStreams.flatMap { it.streams }
@@ -1602,7 +1607,8 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                         null
                     },
                     preferBingeGroupInSelection = playerSettings.streamAutoPlayPreferBingeGroupForNextEpisode,
-                    bingeGroupOnly = bingeGroupOnlyManualMode
+                    bingeGroupOnly = bingeGroupOnlyManualMode,
+                    preferredAddonName = preferredAddonForNext
                 )
             }
 
@@ -1620,7 +1626,8 @@ internal fun PlayerRuntimeController.playNextEpisode(userInitiated: Boolean = fa
                     selectedPlugins = effectiveSelectedPlugins,
                     preferredBingeGroup = currentStreamBingeGroup,
                     preferBingeGroupInSelection = true,
-                    bingeGroupOnly = true
+                    bingeGroupOnly = true,
+                    preferredAddonName = preferredAddonForNext
                 )
             }
 

--- a/app/src/test/java/com/nuvio/tv/core/player/StreamAutoPlaySelectorTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/StreamAutoPlaySelectorTest.kt
@@ -178,6 +178,128 @@ class StreamAutoPlaySelectorTest {
     }
 
     @Test
+    fun `preferredAddonName keeps next episode on same addon over installed order`() {
+        // Reproduces #2756: Torrentio is earlier in installed order than Torrentio TV,
+        // but the user started playback on Torrentio TV and next-episode must stay there.
+        val torrentio = stream(
+            addonName = "Torrentio",
+            url = "https://example.com/torrentio.m3u8",
+            name = "1080p"
+        )
+        val torrentioTv = stream(
+            addonName = "Torrentio TV",
+            url = "https://example.com/torrentio-tv.m3u8",
+            name = "1080p"
+        )
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(torrentio, torrentioTv),
+            mode = StreamAutoPlayMode.FIRST_STREAM,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = setOf("Torrentio", "Torrentio TV"),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredAddonName = "Torrentio TV"
+        )
+
+        assertEquals(torrentioTv, selected)
+    }
+
+    @Test
+    fun `preferredAddonName plus bingeGroup prefers same addon binge match`() {
+        val otherAddonSameBinge = stream(
+            addonName = "Torrentio",
+            url = "https://example.com/other.m3u8",
+            bingeGroup = "same-group"
+        )
+        val preferredAddonSameBinge = stream(
+            addonName = "Torrentio TV",
+            url = "https://example.com/preferred.m3u8",
+            bingeGroup = "same-group"
+        )
+        val preferredAddonOtherBinge = stream(
+            addonName = "Torrentio TV",
+            url = "https://example.com/other-binge.m3u8",
+            bingeGroup = "other-group"
+        )
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(otherAddonSameBinge, preferredAddonOtherBinge, preferredAddonSameBinge),
+            mode = StreamAutoPlayMode.FIRST_STREAM,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = setOf("Torrentio", "Torrentio TV"),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredBingeGroup = "same-group",
+            preferBingeGroupInSelection = true,
+            preferredAddonName = "Torrentio TV"
+        )
+
+        assertEquals(preferredAddonSameBinge, selected)
+    }
+
+    @Test
+    fun `preferredAddonName falls back when preferred addon has no playable stream`() {
+        val preferredUnplayable = stream(
+            addonName = "Torrentio TV",
+            name = "Not cached",
+            infoHash = "abc",
+            cacheState = StreamDebridCacheState.NOT_CACHED
+        )
+        val fallback = stream(
+            addonName = "Torrentio",
+            url = "https://example.com/fallback.m3u8",
+            name = "1080p"
+        )
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(preferredUnplayable, fallback),
+            mode = StreamAutoPlayMode.FIRST_STREAM,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = setOf("Torrentio", "Torrentio TV"),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredAddonName = "Torrentio TV"
+        )
+
+        assertEquals(fallback, selected)
+    }
+
+    @Test
+    fun `binge group on other addon wins over non-binge stream on preferred addon`() {
+        // Preferring the current addon must not override binge-group continuity when
+        // the preferred addon only has a different binge (or no binge) for this ep.
+        val preferredOtherBinge = stream(
+            addonName = "Torrentio TV",
+            url = "https://example.com/preferred-other.m3u8",
+            bingeGroup = "other-group"
+        )
+        val otherAddonTargetBinge = stream(
+            addonName = "Torrentio",
+            url = "https://example.com/torrentio-binge.m3u8",
+            bingeGroup = "same-group"
+        )
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(preferredOtherBinge, otherAddonTargetBinge),
+            mode = StreamAutoPlayMode.FIRST_STREAM,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = setOf("Torrentio", "Torrentio TV"),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredBingeGroup = "same-group",
+            preferBingeGroupInSelection = true,
+            preferredAddonName = "Torrentio TV"
+        )
+
+        assertEquals(otherAddonTargetBinge, selected)
+    }
+
+    @Test
     fun `manual mode auto-selects matching bingeGroup when prefer enabled`() {
         // Binge-group continuity is intentionally allowed in MANUAL mode so
         // next-episode / resume can skip the picker when a group was locked in.
@@ -200,6 +322,29 @@ class StreamAutoPlaySelectorTest {
         )
 
         assertEquals(matched, selected)
+    }
+
+    @Test
+    fun `manual mode stays manual without bingeGroup preference`() {
+        val matched = stream(
+            addonName = "AddonA",
+            url = "https://example.com/match.m3u8",
+            bingeGroup = "same-group"
+        )
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(matched),
+            mode = StreamAutoPlayMode.MANUAL,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = setOf("AddonA"),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredBingeGroup = "same-group",
+            preferBingeGroupInSelection = false
+        )
+
+        assertNull(selected)
     }
 
     @Test


### PR DESCRIPTION
## Summary

When auto-playing the next episode inside the player, prefer streams from the same addon that is currently playing (e.g. stay on **Torrentio TV** instead of jumping to **Torrentio** because it is earlier in the installed-addon order), while still honoring binge-group continuity.

## PR type

- [x] Critical bug fix

## Why

`playNextEpisode` auto-selects via `StreamAutoPlaySelector` using installed-addon order, optional binge-group preference, and global autoplay filters. It did **not** consider the addon of the stream the user actually started.

With both Torrentio and Torrentio TV installed (or the same addon mirrored with different debrid), FIRST_STREAM / ordered selection often returns the earlier addon. After next-episode autoplay, the source silently switches away from the addon the user chose even when binge groups match.

## Issue or approval

Fixes #2756

## Reproduction steps

1. Install both **Torrentio** and **Torrentio TV** (with debrid)
2. Open a series, pick a stream from **Torrentio TV**, start internal player
3. Trigger next episode / auto-play from inside the player
4. Before: next episode can resolve from **Torrentio**
5. After: next episode stays on **Torrentio TV** when that addon returns a matching/playable stream; binge-group still preferred when the preferred addon has no matching binge

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the autoplay stream selection logic used by in-player next-episode
- No new settings UI
- Selection priority:
  1. same addon + same binge group
  2. any addon with same binge group
  3. same addon via FIRST_STREAM / REGEX
  4. global mode fallback
- Stream-screen autoplay outside in-player next-episode is unchanged
- X-axis / stream-index preservation is **out of scope** (binge groups cover continuity per maintainer; #2778 closed)

## Testing

```
./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.player.StreamAutoPlaySelectorTest :app:compileFullDebugKotlin
```

**BUILD SUCCESSFUL**, including:

- preferred addon wins over installed order (Torrentio vs Torrentio TV)
- preferred addon + binge match on same addon
- fallback when preferred addon has no playable stream
- binge on another addon wins over non-binge stream on preferred addon
- existing MANUAL + binge-group behavior retained

Device smoke still recommended: start on Torrentio TV → next episode stays there when available.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2756