### PR TITLE
fix(library): stop Trakt sync from overwriting metadata addon artwork (#2753)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -712,9 +712,13 @@ class TraktLibraryService @Inject constructor(
             id = contentId,
             type = normalizedType,
             name = mediaTitle ?: contentId,
-            poster = images.traktBestPosterUrl(),
-            background = images.traktBestBackdropUrl(),
-            logo = images.traktBestLogoUrl(),
+            // Do NOT use Trakt-provided images for poster/background/logo.
+            // Let the configured metadata addon resolve artwork instead (#2753).
+            // Trakt's embedded images (Fanart.tv/TMDB) bypass the user's preferred
+            // addon (AIOMetadata → TVDB/BetterPosters), overwriting custom artwork.
+            poster = null,
+            background = null,
+            logo = null,
             description = overview?.takeIf { it.isNotBlank() },
             releaseInfo = mediaYear?.toString() ?: releaseDate?.take(4),
             imdbRating = rating?.toFloat(),


### PR DESCRIPTION
## Summary

Trakt-synced library items no longer overwrite artwork with Trakt's embedded images. The user's configured metadata addon (e.g. AIOMetadata with TVDB/BetterPosters) now resolves all artwork for Trakt items, same as manually added items.

## PR type

- [x] Critical bug fix

## Why

When a movie/show is added to the library via Trakt sync, its poster/artwork was set from Trakt's embedded images (`TraktImagesDto` from Fanart.tv/TMDB), completely bypassing the metadata addon configured by the user (AIOMetadata -> TVDB / BetterPosters).

Items added manually in-app correctly used the addon's artwork, but as soon as Trakt sync ran, the poster was overwritten with TMDB/Fanart versions.

`TraktLibraryService.mapListItem()` at lines 715-717 directly assigned poster/background/logo from `images.traktBestPosterUrl()` / `traktBestBackdropUrl()` / `traktBestLogoUrl()`, which select from Trakt's embedded Fanart.tv/TMDB image lists. This bypasses the metadata resolution pipeline entirely.

## Issue or approval

Fixes #2753

## Reproduction steps

1. Configure AIOMetadata with TVDB or BetterPosters as poster provider
2. Add a movie to Trakt watchlist
3. Sync library in NuvioTV
4. Observe: the poster shown is from TMDB (Trakt's embedded image), not from the configured metadata addon
5. With fix: the metadata addon resolves the artwork as expected

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `TraktLibraryService.kt` — `mapListItem()`: poster/background/logo now `null` instead of Trakt-provided images
- No changes to the metadata resolution pipeline, library sync logic, or Trakt API calls

## Testing

**Static analysis:**

1. `mapListItem()` now creates `LibraryEntry` with `poster = null, background = null, logo = null`
2. The metadata resolution pipeline handles these nulls exactly like manually added items
3. No code paths depend on Trakt-provided images being non-null in LibraryEntry

**Device smoke test:**
1. Configure AIOMetadata with TVDB or BetterPosters as poster provider
2. Add a movie to Trakt watchlist
3. Sync library in NuvioTV
4. Verify the poster shown is from AIOMetadata, not TMDB

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #2753
