### PR TITLE
fix(modern-home): scroll left when expanded card overflows leading edge (#2794)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -796,12 +796,23 @@ internal fun ModernRowSection(
                         ?: return@collect
                     val viewportEnd = layoutInfo.viewportEndOffset
                     val itemEndExpanded = itemInfo.offset + expandedCardWidthPx
+                    val leadingEdge = itemInfo.offset
+                    val parentStartOffsetPx = with(density) { rowStartPadding.roundToPx() }
+                    val viewportStart = layoutInfo.viewportStartOffset // usually 0
                     if (itemEndExpanded > viewportEnd) {
                         // Scroll just enough to reveal the trailing edge plus a small margin.
                         // Flag prevents isBackdropExpandedLambda from collapsing during this scroll.
                         val overshoot = itemEndExpanded - viewportEnd + with(density) { 15.dp.roundToPx() }
                         isExpansionScrollActive = true
                         rowListState.animateScrollBy(overshoot.toFloat())
+                        isExpansionScrollActive = false
+                    } else if (leadingEdge < viewportStart + parentStartOffsetPx) {
+                        // Leading edge overflow: the expanded item has been pushed off-screen
+                        // on the left (e.g. after scrolling right for a previous item's expansion).
+                        // Scroll left to restore the leading edge to the start padding.
+                        val undershoot = parentStartOffsetPx - leadingEdge + with(density) { 15.dp.roundToPx() }
+                        isExpansionScrollActive = true
+                        rowListState.animateScrollBy(-undershoot.toFloat())
                         isExpansionScrollActive = false
                     }
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -789,31 +789,42 @@ internal fun ModernRowSection(
                     if (expandedIndex < 0) return@collect
                     // Small delay so the item is still in visible layout info
                     delay(50)
-                    // Calculate overshoot using the known final expanded width rather than
-                    // the mid-animation layout size which underestimates the trailing edge.
-                    val layoutInfo = rowListState.layoutInfo
-                    val itemInfo = layoutInfo.visibleItemsInfo.firstOrNull { it.index == expandedIndex }
-                        ?: return@collect
-                    val viewportEnd = layoutInfo.viewportEndOffset
-                    val itemEndExpanded = itemInfo.offset + expandedCardWidthPx
-                    val leadingEdge = itemInfo.offset
+                    // Re-evaluate after each scroll: focus bring-into-view, the card-width
+                    // animation, and our own scroll animation can otherwise race and leave
+                    // either edge clipped after the first snapshot.
                     val parentStartOffsetPx = with(density) { rowStartPadding.roundToPx() }
-                    val viewportStart = layoutInfo.viewportStartOffset // usually 0
-                    if (itemEndExpanded > viewportEnd) {
-                        // Scroll just enough to reveal the trailing edge plus a small margin.
-                        // Flag prevents isBackdropExpandedLambda from collapsing during this scroll.
-                        val overshoot = itemEndExpanded - viewportEnd + with(density) { 15.dp.roundToPx() }
+                    val edgeMarginPx = with(density) { 15.dp.roundToPx() }
+                    var attempt = 0
+                    while (attempt < 3) {
+                        val layoutInfo = rowListState.layoutInfo
+                        val itemInfo = layoutInfo.visibleItemsInfo.firstOrNull { it.index == expandedIndex }
+                            ?: break
+                        val viewportStart = layoutInfo.viewportStartOffset
+                        val viewportEnd = layoutInfo.viewportEndOffset
+                        val itemEndExpanded = itemInfo.offset + expandedCardWidthPx
+                        val leadingLimit = viewportStart + parentStartOffsetPx
+                        val scrollDelta = when {
+                            itemEndExpanded > viewportEnd -> {
+                                // Scroll just enough to reveal the trailing edge plus a small margin.
+                                itemEndExpanded - viewportEnd + edgeMarginPx
+                            }
+                            itemInfo.offset < leadingLimit -> {
+                                // Scroll back to the leading edge plus the same small margin.
+                                itemInfo.offset - leadingLimit - edgeMarginPx
+                            }
+                            else -> 0
+                        }
+                        if (scrollDelta == 0) break
+
+                        // Always clear the guard, including when another scroll cancels this one.
                         isExpansionScrollActive = true
-                        rowListState.animateScrollBy(overshoot.toFloat())
-                        isExpansionScrollActive = false
-                    } else if (leadingEdge < viewportStart + parentStartOffsetPx) {
-                        // Leading edge overflow: the expanded item has been pushed off-screen
-                        // on the left (e.g. after scrolling right for a previous item's expansion).
-                        // Scroll left to restore the leading edge to the start padding.
-                        val undershoot = parentStartOffsetPx - leadingEdge + with(density) { 15.dp.roundToPx() }
-                        isExpansionScrollActive = true
-                        rowListState.animateScrollBy(-undershoot.toFloat())
-                        isExpansionScrollActive = false
+                        try {
+                            rowListState.animateScrollBy(scrollDelta.toFloat())
+                        } finally {
+                            isExpansionScrollActive = false
+                        }
+                        attempt++
+                        if (attempt < 3) delay(50)
                     }
                 }
         }


### PR DESCRIPTION
## Summary

Expanded Cards in Modern Home layout are sometimes clipped at the left or right edge of the screen. The existing code includes a right-edge (trailing) overflow scroll that tries to reveal the trailing edge when a card expands, but it doesn't always work — and the left edge had no protection at all.

This PR makes the existing expansion scroll correction handle **both leading and trailing overflow**. It re-reads layout state after each correction (up to three attempts) so focus bring-into-view, width animation, and scroll animation are less likely to leave an expanded card clipped.

## PR type

- [x] Critical bug fix

## Why

Reported by multiple users (#2794) — Expanded Cards get clipped at screen edges in collections with FOLLOW_LAYOUT. The right-edge overflow had partial handling, but left-edge was entirely missing.

## Issue or approval

Fixes #2794

## Reproduction steps

1. Set collection view to FOLLOW_LAYOUT with Modern Home layout
2. Open a collection with a short scrollable row
3. Navigate to the last item so the expanded card triggers a right scroll
4. Navigate back to the first item
5. **Before fix**: First item's expanded card is clipped on the left
6. **After fix**: Card is scrolled back into full view

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] No UI change

## Screenshots / Video

Not a UI change

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR fits the current PR policy: critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to the issues.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `ModernHomeRows.kt`.
- Keeps the existing local scroll-correction approach; no `BringIntoViewSpec` or layout architecture rewrite.
- Rechecks both edges after each correction, with a maximum of three attempts.

## Testing

- GitHub Actions `PR Full Debug Build` — passed on the current head.
- Static review of positive (trailing) and negative (leading) scroll deltas and cancellation cleanup.
- Still needs reporter/device verification for the original animation/timing reproduction; this limitation is intentionally explicit.

## Breaking changes

None.

## Linked issues

Fixes #2794