### PR TITLE
fix(modern-home): ignore endward D-pad on last expanded card (#2506)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -210,6 +210,7 @@ private fun ModernCatalogRowItem(
     payload: ModernPayload,
     requester: FocusRequester,
     isTargetItem: Boolean = false,
+    isLastInRow: Boolean = false,
     useLandscapePosters: Boolean,
     showLabels: Boolean,
     placeholderShimmerOffsetState: State<Float>?,
@@ -363,6 +364,7 @@ private fun ModernCatalogRowItem(
         modifier = modifier,
         focusedPosterBackdropExpandEnabled = effectiveExpandEnabled,
         isBackdropExpanded = effectiveBackdropExpanded,
+        isLastInRow = isLastInRow,
         playTrailerInExpandedCard = playTrailerInExpandedCard,
         focusedPosterBackdropTrailerMuted = focusedPosterBackdropTrailerMuted,
         trailerPreviewUrl = trailerPreviewUrl,
@@ -922,6 +924,7 @@ internal fun ModernRowSection(
                                 payload = payload,
                                 requester = requester,
                                 isTargetItem = isTargetItem,
+                                isLastInRow = index == row.items.list.lastIndex,
                                 useLandscapePosters = useLandscapePosters,
                                 showLabels = showLabels,
                                 placeholderShimmerOffsetState = placeholderShimmerOffsetState,
@@ -976,6 +979,7 @@ private fun ModernCarouselCard(
     cardHeight: Dp,
     focusedPosterBackdropExpandEnabled: Boolean,
     isBackdropExpanded: Boolean,
+    isLastInRow: Boolean = false,
     playTrailerInExpandedCard: Boolean,
     focusedPosterBackdropTrailerMuted: Boolean,
     trailerPreviewUrl: String?,
@@ -996,6 +1000,7 @@ private fun ModernCarouselCard(
     val cardDepthStyle = LocalCardDepthStyle.current
     val context = LocalContext.current
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
     val expandedCardWidth = if (useLandscapeOverlayTreatment) {
         cardWidth
     } else {
@@ -1202,6 +1207,17 @@ private fun ModernCarouselCard(
                 .onPreviewKeyEvent { event ->
                     val native = event.nativeKeyEvent
                     if (native.action == AndroidKeyEvent.ACTION_DOWN) {
+                        // Endward D-pad on the last card has no target: consume the key without
+                        // resetting the expand timer so the card/trailer stays open (#2506).
+                        if (focusedPosterBackdropExpandEnabled &&
+                            shouldIgnoreDeadEndHorizontalKey(
+                                key = event.key,
+                                isLastInRow = isLastInRow,
+                                layoutDirection = layoutDirection
+                            )
+                        ) {
+                            return@onPreviewKeyEvent true
+                        }
                         if (focusedPosterBackdropExpandEnabled && shouldResetBackdropTimer(event.key)) {
                             onBackdropInteraction()
                         }
@@ -1432,6 +1448,25 @@ private fun shouldResetBackdropTimer(key: Key): Boolean {
         Key.Back -> true
         else -> false
     }
+}
+
+/**
+ * True when the user presses toward the end of a row on the last item.
+ * There is no next focus target, so the key should be ignored instead of
+ * resetting the expand timer and collapsing the card (#2506).
+ */
+internal fun shouldIgnoreDeadEndHorizontalKey(
+    key: Key,
+    isLastInRow: Boolean,
+    layoutDirection: LayoutDirection
+): Boolean {
+    if (!isLastInRow) return false
+    val towardEnd = if (layoutDirection == LayoutDirection.Rtl) {
+        Key.DirectionLeft
+    } else {
+        Key.DirectionRight
+    }
+    return key == towardEnd
 }
 
 private fun isSelectKey(keyCode: Int): Boolean {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
@@ -298,15 +298,33 @@ internal fun ModernHomeRowsList(
                         expandedCatalogFocusKey.value != null &&
                         activeRowKey.value == lastRowKey
                     ) return@onPreviewKeyEvent true
-                    val blockKey = if (layoutDirection == LayoutDirection.Rtl)
+                    val blockStartKey = if (layoutDirection == LayoutDirection.Rtl)
                         Key.DirectionRight else Key.DirectionLeft
+                    val blockEndKey = if (layoutDirection == LayoutDirection.Rtl)
+                        Key.DirectionLeft else Key.DirectionRight
                     if (blockLeftOnFirstExpandedItem &&
                         event.type == KeyEventType.KeyDown &&
-                        event.key == blockKey &&
+                        event.key == blockStartKey &&
                         effectiveExpandEnabled &&
                         expandedCatalogFocusKey.value != null &&
                         activeItemIndex.value == 0
                     ) return@onPreviewKeyEvent true
+                    // Last expanded card: ignore endward D-pad so the card does not collapse
+                    // and re-expand with no navigation target (#2506).
+                    if (event.type == KeyEventType.KeyDown &&
+                        event.key == blockEndKey &&
+                        effectiveExpandEnabled &&
+                        expandedCatalogFocusKey.value != null
+                    ) {
+                        val activeKey = activeRowKey.value
+                        val lastIndex = carouselRows.list
+                            .firstOrNull { it.key == activeKey }
+                            ?.items?.list?.lastIndex
+                            ?: -1
+                        if (lastIndex >= 0 && activeItemIndex.value == lastIndex) {
+                            return@onPreviewKeyEvent true
+                        }
+                    }
                     false
                 }
                 .dpadVerticalFastScroll(

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/DeadEndHorizontalKeyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/DeadEndHorizontalKeyTest.kt
@@ -1,0 +1,71 @@
+package com.nuvio.tv.ui.screens.home
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.unit.LayoutDirection
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeadEndHorizontalKeyTest {
+
+    @Test
+    fun `ltr last item ignores right only`() {
+        assertTrue(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionRight,
+                isLastInRow = true,
+                layoutDirection = LayoutDirection.Ltr
+            )
+        )
+        assertFalse(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionLeft,
+                isLastInRow = true,
+                layoutDirection = LayoutDirection.Ltr
+            )
+        )
+        assertFalse(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionUp,
+                isLastInRow = true,
+                layoutDirection = LayoutDirection.Ltr
+            )
+        )
+    }
+
+    @Test
+    fun `rtl last item ignores left only`() {
+        assertTrue(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionLeft,
+                isLastInRow = true,
+                layoutDirection = LayoutDirection.Rtl
+            )
+        )
+        assertFalse(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionRight,
+                isLastInRow = true,
+                layoutDirection = LayoutDirection.Rtl
+            )
+        )
+    }
+
+    @Test
+    fun `non-last item never ignores horizontal keys`() {
+        assertFalse(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionRight,
+                isLastInRow = false,
+                layoutDirection = LayoutDirection.Ltr
+            )
+        )
+        assertFalse(
+            shouldIgnoreDeadEndHorizontalKey(
+                key = Key.DirectionLeft,
+                isLastInRow = false,
+                layoutDirection = LayoutDirection.Rtl
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Ignores endward D-pad input (Right in LTR, Left in RTL) on the last expanded catalog card so the poster stays open instead of collapsing and re-expanding with no navigation target.

## PR type

- [x] Critical bug fix

## Why

When focus is on the last item in a Modern Home / FOLLOW_LAYOUT row and the Expanded Card is open, pressing Right:

1. Resets the expand timer via `onBackdropInteraction()` (collapses immediately)
2. Finds no next focus target, so focus stays on the same card
3. The expand delay fires again and re-opens the card, restarting trailer playback

Existing edge guards already consume Up on the first row, Down on the last row, and (in collections) startward on the first item. The last-item endward case was missing.

## Issue or approval

Fixes #2506

## Reproduction steps

1. Open Home with Modern layout (or a collection using FOLLOW_LAYOUT)
2. Navigate to the last item in any catalog row
3. Wait for the Expanded Card to appear
4. Press Right on the D-pad

Before: card collapses (and may flicker collapse/expand on repeated presses).  
After: input is ignored; card stays expanded.

## UI / behavior impact

- [x] UI changed only to fix a documented focus/navigation glitch
- Mid-row Right still collapses/moves focus as before
- RTL: endward is Left

## Policy check

- [x] Critical bug fix with linked GitHub issue
- [x] Minimal and focused on the reported glitch
- [x] No feature work, redesign, or drive-by refactors
- [x] No new dependencies
- [x] RTL-aware

## Scope boundaries

- Modern Home / shared modern row key handling only
- Does not change Classic home ContentCard path

## Testing

- Unit tests: `DeadEndHorizontalKeyTest` (LTR/RTL last-item vs mid-row)
- Matches existing edge-consume pattern for Up/Down/first-item in `ModernHomeRowsList`
- Child card consumes endward dead-end before the expand timer reset runs (preview key order)

## Screenshots / Video

Focus/navigation glitch only. Before: last expanded card collapses on Right. After: Right is ignored and the expanded card remains open.

## Breaking changes

None.

## Linked issues

Fixes #2506