### PR TITLE
fix(library): restore Cloud item focus after direct playback (#2510)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -35,6 +36,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -42,6 +44,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -59,6 +62,9 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Border
@@ -91,9 +97,40 @@ import com.nuvio.tv.R
 
 private const val KEY_REPEAT_THROTTLE_MS = 80L
 
+/**
+ * Fixed full-span header slots before cloud items in the Library LazyVerticalGrid
+ * (title, Saved/Cloud tabs, provider/type selectors, search row).
+ * Used only to scroll the correct cloud row into composition for focus restore.
+ */
+private const val CLOUD_LIBRARY_GRID_HEADER_COUNT = 4
+
 private enum class LibraryViewMode {
     Saved,
     Cloud
+}
+
+private suspend fun requestCloudItemFocus(
+    restoreKey: String,
+    cloudItemIndexByKey: Map<String, Int>,
+    cloudFocusRequesters: Map<String, FocusRequester>,
+    gridState: LazyGridState
+): Boolean {
+    val listIndex = cloudItemIndexByKey[restoreKey] ?: return false
+    val restoreRequester = cloudFocusRequesters[restoreKey] ?: return false
+    val gridIndex = CLOUD_LIBRARY_GRID_HEADER_COUNT + listIndex
+    runCatching { gridState.scrollToItem(gridIndex) }
+    // Wait a couple of frames so the scrolled item is composed before requesting focus.
+    repeat(2) { withFrameNanos { } }
+    var focused = runCatching { restoreRequester.requestFocus() }.isSuccess
+    if (!focused) {
+        delay(16)
+        focused = runCatching { restoreRequester.requestFocus() }.isSuccess
+    }
+    if (!focused) {
+        delay(32)
+        focused = runCatching { restoreRequester.requestFocus() }.isSuccess
+    }
+    return focused
 }
 
 @Composable
@@ -131,6 +168,10 @@ fun LibraryScreen(
     val gridState = rememberLazyGridState()
     var pendingPrimaryFocus by remember { mutableStateOf(true) }
     var lastFocusedPosterKey by rememberSaveable { mutableStateOf<String?>(null) }
+    // Cloud items launch Player without a Detail page, so focus must be restored explicitly.
+    var lastFocusedCloudKey by rememberSaveable { mutableStateOf<String?>(null) }
+    var pendingCloudFocusRestore by rememberSaveable { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
     val visibleItemKeys = remember(uiState.visibleItems) {
         uiState.visibleItems.map { "${it.type}:${it.id}" }
     }
@@ -139,6 +180,15 @@ fun LibraryScreen(
     }
     val posterFocusRequesters = remember(visibleItemKeys) {
         visibleItemKeys.associateWith { FocusRequester() }
+    }
+    val visibleCloudKeys = remember(uiState.visibleCloudItems) {
+        uiState.visibleCloudItems.map { it.stableKey }
+    }
+    val cloudItemIndexByKey = remember(visibleCloudKeys) {
+        visibleCloudKeys.withIndex().associate { (index, key) -> key to index }
+    }
+    val cloudFocusRequesters = remember(visibleCloudKeys) {
+        visibleCloudKeys.associateWith { FocusRequester() }
     }
     val firstVisiblePosterKey = visibleItemKeys.firstOrNull()
     val posterCardStyle = PosterCardDefaults.Style
@@ -152,6 +202,58 @@ fun LibraryScreen(
     LaunchedEffect(uiState.isLoading) {
         if (uiState.isLoading) {
             pendingPrimaryFocus = true
+        }
+    }
+
+    // Returning from direct cloud playback (or app resume) must re-focus the played item.
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME && lastFocusedCloudKey != null) {
+                pendingCloudFocusRestore = true
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    // Keep focus pinned on the resolving row so async resolve cannot leave focus one item above.
+    // Skip while the multi-file picker is open so we do not steal focus from the dialog.
+    LaunchedEffect(uiState.resolvingCloudFileKey, activeCloudItem, viewMode, visibleCloudKeys) {
+        if (viewMode != LibraryViewMode.Cloud) return@LaunchedEffect
+        if (activeCloudItem != null) return@LaunchedEffect
+        val resolvingKey = uiState.resolvingCloudFileKey ?: return@LaunchedEffect
+        // resolve keys are "$itemStableKey:$fileStableKey" — match on "$key:" so "…:1" does not steal "…:10".
+        val restoreKey = visibleCloudKeys.firstOrNull { key ->
+            resolvingKey == key || resolvingKey.startsWith("$key:")
+        } ?: return@LaunchedEffect
+        requestCloudItemFocus(
+            restoreKey = restoreKey,
+            cloudItemIndexByKey = cloudItemIndexByKey,
+            cloudFocusRequesters = cloudFocusRequesters,
+            gridState = gridState
+        )
+    }
+
+    // One-shot restore after ON_RESUME. Clears when focus lands so search/filter updates
+    // do not keep re-stealing focus from the user.
+    LaunchedEffect(pendingCloudFocusRestore, viewMode, visibleCloudKeys) {
+        if (!pendingCloudFocusRestore) return@LaunchedEffect
+        if (viewMode != LibraryViewMode.Cloud) return@LaunchedEffect
+        val restoreKey = lastFocusedCloudKey ?: run {
+            pendingCloudFocusRestore = false
+            return@LaunchedEffect
+        }
+        if (restoreKey !in cloudItemIndexByKey) return@LaunchedEffect
+        val focused = requestCloudItemFocus(
+            restoreKey = restoreKey,
+            cloudItemIndexByKey = cloudItemIndexByKey,
+            cloudFocusRequesters = cloudFocusRequesters,
+            gridState = gridState
+        )
+        if (focused) {
+            pendingCloudFocusRestore = false
         }
     }
 
@@ -480,8 +582,15 @@ fun LibraryScreen(
             ) { item ->
                 CloudLibraryCard(
                     item = item,
-                    isResolving = uiState.resolvingCloudFileKey?.startsWith(item.stableKey) == true,
+                    isResolving = uiState.resolvingCloudFileKey?.let { key ->
+                        key == item.stableKey || key.startsWith("${item.stableKey}:")
+                    } == true,
+                    focusRequester = cloudFocusRequesters[item.stableKey],
+                    onFocused = {
+                        lastFocusedCloudKey = item.stableKey
+                    },
                     onClick = {
+                        lastFocusedCloudKey = item.stableKey
                         val playableFiles = item.playableFiles
                         when (playableFiles.size) {
                             0 -> viewModel.onCloudItemHasNoPlayableFiles()
@@ -541,6 +650,7 @@ fun LibraryScreen(
             item = item,
             resolvingFileKey = uiState.resolvingCloudFileKey,
             onPlay = { file ->
+                lastFocusedCloudKey = item.stableKey
                 viewModel.resolveCloudPlayback(item, file) { info ->
                     activeCloudItem = null
                     onCloudPlaybackResolved(info)
@@ -787,12 +897,19 @@ private fun CloudLibraryLoadingState() {
 private fun CloudLibraryCard(
     item: CloudLibraryItem,
     isResolving: Boolean,
+    focusRequester: FocusRequester? = null,
+    onFocused: () -> Unit = {},
     onClick: () -> Unit
 ) {
     val fileLine = cloudLibraryFileLine(item)
     Card(
         onClick = { if (!isResolving) onClick() },
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+            .onFocusChanged { focusState ->
+                if (focusState.isFocused) onFocused()
+            },
         shape = CardDefaults.shape(RoundedCornerShape(10.dp)),
         colors = CardDefaults.colors(
             containerColor = NuvioTheme.colors.BackgroundCard,


### PR DESCRIPTION
## Summary

Restore focus to the Cloud library item that was played after leaving the player. Cloud items launch Player directly (no Detail page) and previously lost focus, landing on the row above.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Cloud library cards had no focus tracking or restore path. Async playback resolve and the Player navigation stack clear focus; on return, the default focus search selects the previous full-width row, so the remote highlights the item above the one just played.

## Issue or approval

Fixes #2510

## Reproduction steps

1. Open Library → Cloud tab.
2. Focus any item other than the first.
3. Start playback (single-file item or multi-file picker).
4. Exit the player.
5. Observe which Cloud row has focus.

**Before:** focus is on the item immediately above the one played.  
**After:** focus is on the same item that was played.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only Cloud library focus restore in `LibraryScreen`.
- Does not change Saved library focus, playback resolve APIs, or Player navigation routes.
- No visual redesign of Cloud cards beyond attaching existing focus requester/onFocusChanged hooks.

## Testing

- Static review of `LibraryScreen` Cloud path against #2510 (direct Player launch, no Detail return focus).
- Verified restore path mirrors established patterns (`CatalogSeeAllScreen` ON_RESUME + `CastDetailScreen` pending restore).
- Confirmed resolve-key matching uses `"$stableKey:"` so ids like `…:1` do not match `…:10`.
- Confirmed multi-file picker path sets `lastFocusedCloudKey` and does not steal dialog focus while open.
- No device/emulator run in this environment; CI fullDebug build will compile the change.

## Screenshots / Video

Not a visual redesign — focus restore only. No screenshot required for remote focus behavior.

## Breaking changes

None.

## Linked issues

Fixes #2510