### PR TITLE
fix(trakt): refresh tokens automatically before expiry (#2687)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -23,6 +23,7 @@ import com.nuvio.tv.core.sync.StartupSyncService
 import com.nuvio.tv.core.sync.androidtv.AndroidTvChannelSyncService
 import com.nuvio.tv.core.network.IPv4FirstDns
 import com.nuvio.tv.data.local.SentrySettingsDataStore
+import com.nuvio.tv.data.repository.TraktAuthService
 import com.nuvio.tv.data.simkl.SimklAnimeIdPreferenceHolder
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.Cookie
@@ -39,6 +40,7 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
     @Inject lateinit var androidTvChannelSyncService: AndroidTvChannelSyncService
     @Inject lateinit var sentrySettingsDataStore: SentrySettingsDataStore
     @Inject lateinit var simklAnimeIdPreferenceHolder: SimklAnimeIdPreferenceHolder
+    @Inject lateinit var traktAuthService: TraktAuthService
 
     companion object {
         /**
@@ -75,6 +77,7 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
         SentryInitializer.start(this, sentrySettingsDataStore)
         PluginRuntimeHooks.onApplicationCreate(this)
         androidTvChannelSyncService.start()
+        traktAuthService.startTokenRefreshScheduler()
         // Load locale synchronously so it's available before Activity.attachBaseContext.
         // SharedPreferences reads are fast (cached in memory after first access).
         val tag = getSharedPreferences("app_locale", Context.MODE_PRIVATE)

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktAuthService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.R
+import com.nuvio.tv.core.sync.TraktCredentialCleanupService
 import com.nuvio.tv.data.local.AuthSessionNoticeDataStore
 import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktAuthState
@@ -13,17 +14,39 @@ import com.nuvio.tv.data.remote.dto.trakt.TraktDeviceCodeResponseDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktDeviceTokenRequestDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktRefreshTokenRequestDto
 import com.nuvio.tv.data.remote.dto.trakt.TraktRevokeRequestDto
-import com.nuvio.tv.core.sync.TraktCredentialCleanupService
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import retrofit2.Response
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val TRAKT_REFRESH_LEEWAY_SECONDS = 60L
+private const val TRAKT_REFRESH_RETRY_DELAY_MS = 15 * 60_000L
+
+internal fun traktTokenRefreshDelayMillis(
+    state: TraktAuthState,
+    nowMillis: Long = System.currentTimeMillis()
+): Long? {
+    if (!state.isAuthenticated) return null
+    val createdAtSeconds = state.createdAt ?: return 0L
+    val expiresInSeconds = state.expiresIn ?: return 0L
+    val refreshAtMillis =
+        (createdAtSeconds + expiresInSeconds - TRAKT_REFRESH_LEEWAY_SECONDS) * 1000L
+    return (refreshAtMillis - nowMillis).coerceAtLeast(0L)
+}
 
 sealed interface TraktTokenPollResult {
     data object Pending : TraktTokenPollResult
@@ -43,9 +66,10 @@ class TraktAuthService @Inject constructor(
     private val authSessionNoticeDataStore: AuthSessionNoticeDataStore,
     private val traktCredentialCleanupService: TraktCredentialCleanupService
 ) {
-    private val refreshLeewaySeconds = 60L
     private val writeRequestMutex = Mutex()
     private val tokenRefreshMutex = Mutex()
+    private val tokenRefreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var tokenRefreshSchedulerJob: Job? = null
     private var lastWriteRequestAtMs = 0L
     private val minWriteIntervalMs = 1_000L
     private val transientRetryStatusCodes = setOf(502, 503, 504, 520, 521, 522)
@@ -121,6 +145,36 @@ class TraktAuthService @Inject constructor(
 
     fun hasRequiredCredentials(): Boolean {
         return BuildConfig.TRAKT_CLIENT_ID.isNotBlank() && BuildConfig.TRAKT_CLIENT_SECRET.isNotBlank()
+    }
+
+    /**
+     * Keeps the active profile's Trakt token fresh even when no Trakt API request
+     * happens around its expiry time. Authorized requests still retain their
+     * on-demand refresh as a fallback.
+     */
+    fun startTokenRefreshScheduler() {
+        if (tokenRefreshSchedulerJob?.isActive == true) return
+
+        tokenRefreshSchedulerJob = tokenRefreshScope.launch {
+            traktAuthDataStore.state.collectLatest { state ->
+                val refreshDelayMillis =
+                    traktTokenRefreshDelayMillis(state) ?: return@collectLatest
+                if (!hasRequiredCredentials()) return@collectLatest
+
+                delay(refreshDelayMillis)
+                while (true) {
+                    // Saving the new token emits a new auth state, which cancels this
+                    // collectLatest block. Finish the in-flight refresh bookkeeping first.
+                    val refreshed = withContext(NonCancellable) {
+                        refreshTokenIfNeeded(force = false)
+                    }
+                    if (refreshed) {
+                        return@collectLatest
+                    }
+                    delay(TRAKT_REFRESH_RETRY_DELAY_MS)
+                }
+            }
+        }
     }
 
     suspend fun getCurrentAuthState(): TraktAuthState = traktAuthDataStore.getCurrentState()
@@ -504,11 +558,7 @@ class TraktAuthService @Inject constructor(
     }
 
     private fun isTokenExpiredOrExpiring(state: TraktAuthState): Boolean {
-        val createdAt = state.createdAt ?: return true
-        val expiresIn = state.expiresIn ?: return true
-        val expiresAt = createdAt + expiresIn
-        val nowSeconds = System.currentTimeMillis() / 1000L
-        return nowSeconds >= (expiresAt - refreshLeewaySeconds)
+        return traktTokenRefreshDelayMillis(state) == 0L
     }
 
     private suspend fun delayForRetryAfter(

--- a/app/src/test/java/com/nuvio/tv/data/repository/TraktAuthServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/TraktAuthServiceTest.kt
@@ -11,11 +11,51 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Test
 import retrofit2.Response
 
 class TraktAuthServiceTest {
+    @Test
+    fun `token refresh delay schedules one minute before expiry`() {
+        val state = authenticatedState().copy(createdAt = 1_000L, expiresIn = 3_600)
+
+        assertEquals(
+            3_540_000L,
+            traktTokenRefreshDelayMillis(state = state, nowMillis = 1_000_000L)
+        )
+    }
+
+    @Test
+    fun `token refresh delay is immediate for expired or incomplete authenticated state`() {
+        assertEquals(
+            0L,
+            traktTokenRefreshDelayMillis(
+                state = authenticatedState().copy(createdAt = 1_000L, expiresIn = 3_600),
+                nowMillis = 4_600_000L
+            )
+        )
+        assertEquals(
+            0L,
+            traktTokenRefreshDelayMillis(
+                state = authenticatedState().copy(createdAt = null),
+                nowMillis = 1_000_000L
+            )
+        )
+    }
+
+    @Test
+    fun `token refresh delay ignores unauthenticated state`() {
+        assertNull(
+            traktTokenRefreshDelayMillis(
+                state = TraktAuthState(),
+                nowMillis = 1_000_000L
+            )
+        )
+    }
+
     @Test
     fun `refresh token 400 clears credentials and prevents another refresh`() = runTest {
         val traktApi = mockk<TraktApi>()


### PR DESCRIPTION
## Summary

Automatically refreshes the active profile's Trakt access token before its local 24-hour lifetime expires, even when no Trakt API request happens near expiry.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Trakt token lifetime is intentionally normalized to 24 hours, but refresh was only triggered lazily by a later authorized Trakt request. If the app stayed open or served cached data, the Settings countdown reached `0s` without any refresh attempt and the session could require a manual login.

The application now observes the active profile's auth state, schedules refresh one minute before expiry, and retries transient failures every 15 minutes. Existing request-time refresh and its mutex remain the fallback and concurrency guard.

## Issue or approval

Fixes #2687

## Reproduction steps

1. Sign in to Trakt.
2. Keep the session active until its locally normalized 24-hour lifetime expires.
3. Open Settings → Trakt and observe the token refresh countdown.
4. **Before:** the countdown reaches `0s` and remains there; the user may need to authenticate again.
5. **After:** the token is refreshed automatically before the countdown reaches zero and the new expiry is persisted.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Active-profile Trakt access-token refresh scheduling only.
- No changes to OAuth payloads, the 24-hour lifetime normalization, login UI, sync behavior, or remote credential storage.
- No new app dependencies.

## Testing

- Added unit coverage for refresh timing one minute before expiry.
- Added unit coverage for expired tokens, incomplete authenticated state, and unauthenticated state.
- `git diff --check` passes.
- The targeted Gradle test was attempted locally after installing JDK 17, but project configuration also requires Android API 36/NDK/CMake and acceptance of the Android SDK license. The license was not accepted in this environment; CI is the full build/test verification path.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #2687
