### PR TITLE
fix(continue-watching): drop next-up cards for already-watched episodes (#2840)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ContinueWatchingNextUpReconciliation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ContinueWatchingNextUpReconciliation.kt
@@ -6,6 +6,66 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
+/**
+ * Whether a Continue Watching next-up card should be dropped because it no longer
+ * points at a valid next episode.
+ *
+ * Drops when:
+ * - The displayed episode is not strictly after the current completed seed
+ *   (e.g. stale disk cache still showing the season finale after it was watched).
+ * - Furthest-episode mode is on and the displayed episode is already watched
+ *   (seed lagging behind exact history / watched marks).
+ *
+ * Rewatch mode ([preferFurthestEpisode] = false) still drops not-after-seed cards
+ * but allows already-watched next episodes so sequential rewatch can continue.
+ */
+internal fun shouldDropNextUpAgainstProgress(
+    nextSeason: Int?,
+    nextEpisode: Int?,
+    currentSeedSeason: Int?,
+    currentSeedEpisode: Int?,
+    watchedEpisodes: Set<Pair<Int, Int>>,
+    preferFurthestEpisode: Boolean
+): Boolean {
+    if (nextSeason == null || nextEpisode == null) return false
+
+    if (currentSeedSeason != null && currentSeedEpisode != null) {
+        val notAfterSeed = nextSeason < currentSeedSeason ||
+            (nextSeason == currentSeedSeason && nextEpisode <= currentSeedEpisode)
+        if (notAfterSeed) return true
+    }
+
+    if (preferFurthestEpisode && (nextSeason to nextEpisode) in watchedEpisodes) {
+        return true
+    }
+    return false
+}
+
+/**
+ * Lookup watched episode pairs for a content id, including any known sibling ids
+ * (IMDB ↔ TMDB) when [showIdSiblings] is available.
+ */
+internal fun watchedEpisodesForContentId(
+    contentId: String,
+    watchedByContentId: Map<String, Set<Pair<Int, Int>>>,
+    showIdSiblings: Map<String, Set<String>> = emptyMap()
+): Set<Pair<Int, Int>> {
+    if (contentId.isBlank()) return emptySet()
+    val ids = buildSet {
+        add(contentId)
+        showIdSiblings[contentId]
+            ?.asSequence()
+            ?.filter { sibling -> sibling.isNotBlank() && sibling != "__ambiguous__" }
+            ?.forEach { sibling -> add(sibling) }
+    }
+    if (ids.isEmpty()) return emptySet()
+    return buildSet {
+        for (id in ids) {
+            watchedByContentId[id]?.let { addAll(it) }
+        }
+    }
+}
+
 internal fun reconcileConclusiveNextUpItems(
     currentItems: List<ContinueWatchingItem>,
     resolvedItems: List<ContinueWatchingItem.NextUp>,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -367,6 +367,18 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     }
                     nextUpDeferred.await() to inProgressDeferred.await()
                 }
+                // Exact watched history used to drop stale next-up cards that still
+                // point at an already-watched episode (or at/before the current seed).
+                val allWatchedEpisodes = if (snapshot.hasLoadedRemoteProgress) {
+                    watchProgressRepository.getWatchedShowEpisodes()
+                } else {
+                    emptyMap()
+                }
+                val showIdSiblingsForNextUp = if (snapshot.hasLoadedRemoteProgress) {
+                    watchProgressRepository.getShowIdSiblings()
+                } else {
+                    emptyMap()
+                }
                 // Build enrichment lookup from cached snapshots (replaces old CwEnrichmentEntry)
                 val cachedEnrichmentFromInProgress = cachedInProgress.associateBy { it.contentId }
                 val cachedEnrichmentFromNextUp = cachedNextUp.associateBy { it.contentId }
@@ -501,11 +513,22 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                         if (freshHasAired && cached.contentId !in activeSeedContentIds) return@mapNotNull null
                     }
                     val currentSeed = currentSeedByContentId[cached.contentId]
-                    if (currentSeed != null && cached.seedSeason != null && cached.seedEpisode != null) {
-                        val (curSeason, curEpisode) = currentSeed
-                        val seedAdvanced = curSeason > cached.seedSeason ||
-                            (curSeason == cached.seedSeason && curEpisode > cached.seedEpisode)
-                        if (seedAdvanced) return@mapNotNull null
+                    val watchedForContent = watchedEpisodesForContentId(
+                        contentId = cached.contentId,
+                        watchedByContentId = allWatchedEpisodes,
+                        showIdSiblings = showIdSiblingsForNextUp
+                    )
+                    if (
+                        shouldDropNextUpAgainstProgress(
+                            nextSeason = cached.season,
+                            nextEpisode = cached.episode,
+                            currentSeedSeason = currentSeed?.first,
+                            currentSeedEpisode = currentSeed?.second,
+                            watchedEpisodes = watchedForContent,
+                            preferFurthestEpisode = nextUpFromFurthestEpisode
+                        )
+                    ) {
+                        return@mapNotNull null
                     }
                     ContinueWatchingItem.NextUp(
                         info = NextUpInfo(
@@ -603,6 +626,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     dismissedNextUp = dismissedNextUp,
                     showUnairedNextUp = showUnairedNextUp,
                     nextUpFromFurthestEpisode = nextUpFromFurthestEpisode,
+                    watchedByContentId = allWatchedEpisodes,
+                    showIdSiblings = showIdSiblingsForNextUp,
                     debug = debug,
                     onPartialUpdate = { partialNextUpItems ->
                         partialPublishMutex.withLock {
@@ -667,10 +692,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                 val allWatchedItems = watchProgressRepository.watchedItems.first()
                 // --- Async badge evaluation ---
                 // Resolve meta for all series with watched episodes and evaluate badges.
-                // Uses getWatchedShowEpisodes() as the single source of truth.
+                // Uses the watched snapshot loaded earlier in this cycle.
                 launch(Dispatchers.IO) {
-                    val allWatchedEpisodes = watchProgressRepository.getWatchedShowEpisodes()
-
                     // Skip badge evaluation if watched episodes haven't changed since
                     // last cycle (e.g. position save triggered pipeline restart).
                     val currentKeys = allWatchedEpisodes.keys
@@ -682,7 +705,9 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                     }
                     cwLastBadgeEpisodeKeys = currentKeys.toSet()
 
-                    val showIdSiblings = watchProgressRepository.getShowIdSiblings()
+                    val showIdSiblings = showIdSiblingsForNextUp.ifEmpty {
+                        watchProgressRepository.getShowIdSiblings()
+                    }
                     cwLastShowIdSiblings = showIdSiblings
 
                     // Deduplicate IDs using Trakt's sibling mapping (IMDB ↔ TMDB from
@@ -828,9 +853,16 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                         kotlinx.coroutines.yield()
                                         continue
                                     }
+                                    val watchedForContent = watchedEpisodesForContentId(
+                                        contentId = seed.contentId,
+                                        watchedByContentId = allWatchedEpisodes,
+                                        showIdSiblings = showIdSiblingsForNextUp
+                                    )
                                     val item = buildNextUpItem(
                                         progress = seed,
-                                        showUnairedNextUp = showUnairedNextUp
+                                        showUnairedNextUp = showUnairedNextUp,
+                                        preferFurthestEpisode = nextUpFromFurthestEpisode,
+                                        watchedEpisodes = watchedForContent
                                     ).also { resolved ->
                                         logSimklAsyncNextUpResolution(
                                             seed = seed,
@@ -1357,6 +1389,8 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
     dismissedNextUp: Set<String>,
     showUnairedNextUp: Boolean,
     nextUpFromFurthestEpisode: Boolean = true,
+    watchedByContentId: Map<String, Set<Pair<Int, Int>>> = emptyMap(),
+    showIdSiblings: Map<String, Set<String>> = emptyMap(),
     debug: CwDebugSession? = null,
     onPartialUpdate: suspend (List<ContinueWatchingItem.NextUp>) -> Unit = {}
 ): List<ContinueWatchingItem.NextUp> = coroutineScope {
@@ -1462,9 +1496,16 @@ private suspend fun HomeViewModel.buildLightweightNextUpItems(
                 // Remap seed from Trakt numbering to addon numbering (for anime).
                 // Done here (after filters) so only ~5-10 seeds are remapped, not all 189.
                 val remappedProgress = watchProgressRepository.prepareNextUpSeed(progress)
+                val watchedForContent = watchedEpisodesForContentId(
+                    contentId = remappedProgress.contentId,
+                    watchedByContentId = watchedByContentId,
+                    showIdSiblings = showIdSiblings
+                )
                 val nextUp = buildNextUpItem(
                     progress = remappedProgress,
                     showUnairedNextUp = showUnairedNextUp,
+                    preferFurthestEpisode = nextUpFromFurthestEpisode,
+                    watchedEpisodes = watchedForContent,
                     debug = debug
                 ) ?: run {
                     // If meta was not available (network error, addon timeout),
@@ -1735,17 +1776,22 @@ internal fun splitUpcomingItems(
 private suspend fun HomeViewModel.buildNextUpItem(
     progress: WatchProgress,
     showUnairedNextUp: Boolean,
+    preferFurthestEpisode: Boolean = true,
+    watchedEpisodes: Set<Pair<Int, Int>> = emptySet(),
     debug: CwDebugSession? = null
 ): ContinueWatchingItem.NextUp? {
     debug?.recordNextUpAttempt(progress)
     if (shouldTraceNextUpSeries(progress)) {
         logNextUpDecision(
-            "build-start ${progress.toNextUpTraceString()} showUnaired=$showUnairedNextUp"
+            "build-start ${progress.toNextUpTraceString()} showUnaired=$showUnairedNextUp " +
+                "preferFurthest=$preferFurthestEpisode watched=${watchedEpisodes.size}"
         )
     }
     val nextUp = findNextUpEpisodeFromMetaSeed(
         progress = progress,
         showUnairedNextUp = showUnairedNextUp,
+        preferFurthestEpisode = preferFurthestEpisode,
+        watchedEpisodes = watchedEpisodes,
         debug = debug
     ) ?: run {
         // Populate badge episode cache from meta that was already resolved by
@@ -1787,6 +1833,24 @@ private suspend fun HomeViewModel.buildNextUpItem(
         }
         return null
     }
+    if (
+        shouldDropNextUpAgainstProgress(
+            nextSeason = nextUp.season,
+            nextEpisode = nextUp.episode,
+            currentSeedSeason = progress.season,
+            currentSeedEpisode = progress.episode,
+            watchedEpisodes = watchedEpisodes,
+            preferFurthestEpisode = preferFurthestEpisode
+        )
+    ) {
+        logNextUpDecision(
+            "drop contentId=${progress.contentId} name=${progress.name} " +
+                "reason=resolved-next-already-watched-or-not-after-seed " +
+                "seed=${progress.season}x${progress.episode} next=${nextUp.season}x${nextUp.episode}"
+        )
+        return null
+    }
+
     val seedMeta = resolveMetaForProgress(progress, cwMetaCache, debug)
 
     val name = progress.name.trim().takeIf { it.isNotEmpty() }
@@ -1928,7 +1992,12 @@ private suspend fun HomeViewModel.enrichNextUpItem(
     } else null
 
     val meta = resolveMetaForProgress(progressSeed, metaCache, debug) ?: return@coroutineScope item
-    val video = resolveNextUpVideoFromMeta(progressSeed, meta)
+    // Prefer keeping the already-selected next-up coordinates during enrichment so a
+    // lagging seed cannot re-resolve back onto a watched episode. Look up the exact
+    // video when possible; fall back to seed-based next only if missing.
+    val video = meta.videos.firstOrNull { candidate ->
+        candidate.season == item.info.season && candidate.episode == item.info.episode
+    } ?: resolveNextUpVideoFromMeta(progressSeed, meta)
 
     val tmdbData = if (shouldEnrichTmdb) {
         val earlyTmdbId = tmdbIdDeferred?.await()
@@ -2007,6 +2076,8 @@ private suspend fun HomeViewModel.enrichNextUpItem(
 private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
     progress: WatchProgress,
     showUnairedNextUp: Boolean,
+    preferFurthestEpisode: Boolean = true,
+    watchedEpisodes: Set<Pair<Int, Int>> = emptySet(),
     debug: CwDebugSession? = null
 ): NextUpResolution? {
     val startedAtMs = SystemClock.elapsedRealtime()
@@ -2015,27 +2086,42 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         if (cwNextUpResolutionCache.containsKey(cacheKey)) {
             val cached = cwNextUpResolutionCache[cacheKey]
             if (cached != null) {
-                debug?.recordNextUpCacheHit(
-                    progress = progress,
-                    resolved = true,
-                    showUnairedNextUp = showUnairedNextUp
+                // Positive cache can go stale when the user marks the resolved
+                // episode watched without advancing the seed (batch mark / lagging history).
+                val staleAgainstWatched = shouldDropNextUpAgainstProgress(
+                    nextSeason = cached.season,
+                    nextEpisode = cached.episode,
+                    currentSeedSeason = progress.season,
+                    currentSeedEpisode = progress.episode,
+                    watchedEpisodes = watchedEpisodes,
+                    preferFurthestEpisode = preferFurthestEpisode
                 )
-                // Recompute hasAired from the release date so a resolution cached
-                // while the episode was still unaired does not stay stuck as
-                // "unaired" after the episode drops (same-session / same-day).
-                val freshHasAired = hasEpisodeAired(cached.released, fallback = cached.hasAired)
-                if (freshHasAired == cached.hasAired) return cached
-                val refreshed = cached.copy(
-                    hasAired = freshHasAired,
-                    airDateLabel = if (freshHasAired) {
-                        null
-                    } else {
-                        cached.airDateLabel
-                            ?: cached.released?.let(::parseEpisodeReleaseDate)?.let(::formatEpisodeAirDateLabel)
-                    }
-                )
-                cwNextUpResolutionCache[cacheKey] = refreshed
-                return refreshed
+                if (staleAgainstWatched) {
+                    cwNextUpResolutionCache.remove(cacheKey)
+                    cwNextUpNegativeCacheTimestamps.remove(cacheKey)
+                } else {
+                    debug?.recordNextUpCacheHit(
+                        progress = progress,
+                        resolved = true,
+                        showUnairedNextUp = showUnairedNextUp
+                    )
+                    // Recompute hasAired from the release date so a resolution cached
+                    // while the episode was still unaired does not stay stuck as
+                    // "unaired" after the episode drops (same-session / same-day).
+                    val freshHasAired = hasEpisodeAired(cached.released, fallback = cached.hasAired)
+                    if (freshHasAired == cached.hasAired) return cached
+                    val refreshed = cached.copy(
+                        hasAired = freshHasAired,
+                        airDateLabel = if (freshHasAired) {
+                            null
+                        } else {
+                            cached.airDateLabel
+                                ?: cached.released?.let(::parseEpisodeReleaseDate)?.let(::formatEpisodeAirDateLabel)
+                        }
+                    )
+                    cwNextUpResolutionCache[cacheKey] = refreshed
+                    return refreshed
+                }
             }
             // Negative cache entry — check TTL
             val negativeCachedAt = cwNextUpNegativeCacheTimestamps[cacheKey]
@@ -2089,7 +2175,13 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
         }
         return null
     }
-    val nextVideo = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp)
+    val nextVideo = resolveNextUpVideoFromMeta(
+        progress = progress,
+        meta = meta,
+        showUnairedNextUp = showUnairedNextUp,
+        watchedEpisodes = watchedEpisodes,
+        preferFurthestEpisode = preferFurthestEpisode
+    )
     if (nextVideo == null) {
         debug?.recordNextUpResult(
             progress = progress,
@@ -2147,14 +2239,22 @@ private suspend fun HomeViewModel.findNextUpEpisodeFromMetaSeed(
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary
-): CwVideoSummary? = resolveNextUpVideoFromMeta(progress, meta, showUnairedNextUp = true)
+): CwVideoSummary? = resolveNextUpVideoFromMeta(
+    progress = progress,
+    meta = meta,
+    showUnairedNextUp = true,
+    watchedEpisodes = emptySet(),
+    preferFurthestEpisode = true
+)
 
 private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 
 private fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
-    showUnairedNextUp: Boolean
+    showUnairedNextUp: Boolean,
+    watchedEpisodes: Set<Pair<Int, Int>> = emptySet(),
+    preferFurthestEpisode: Boolean = true
 ): CwVideoSummary? {
     val episodes = meta.videos
         .filter { video ->
@@ -2204,6 +2304,18 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        val season = video.season
+        val episode = video.episode
+        // Furthest mode: skip episodes already present in exact watched history so a
+        // lagging seed cannot advertise a finished episode as next-up.
+        if (
+            preferFurthestEpisode &&
+            season != null &&
+            episode != null &&
+            (season to episode) in watchedEpisodes
+        ) {
+            return@firstOrNull false
+        }
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingNextUpReconciliationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingNextUpReconciliationTest.kt
@@ -8,6 +8,86 @@ import org.junit.Test
 
 class ContinueWatchingNextUpReconciliationTest {
     @Test
+    fun `drops next up when displayed episode is not after current seed`() {
+        assertTrue(
+            shouldDropNextUpAgainstProgress(
+                nextSeason = 1,
+                nextEpisode = 8,
+                currentSeedSeason = 1,
+                currentSeedEpisode = 8,
+                watchedEpisodes = setOf(1 to 8),
+                preferFurthestEpisode = true
+            )
+        )
+        assertTrue(
+            shouldDropNextUpAgainstProgress(
+                nextSeason = 1,
+                nextEpisode = 7,
+                currentSeedSeason = 1,
+                currentSeedEpisode = 8,
+                watchedEpisodes = emptySet(),
+                preferFurthestEpisode = false
+            )
+        )
+    }
+
+    @Test
+    fun `drops next up when furthest mode and episode is already watched`() {
+        assertTrue(
+            shouldDropNextUpAgainstProgress(
+                nextSeason = 1,
+                nextEpisode = 3,
+                currentSeedSeason = 1,
+                currentSeedEpisode = 2,
+                watchedEpisodes = setOf(1 to 1, 1 to 2, 1 to 3),
+                preferFurthestEpisode = true
+            )
+        )
+    }
+
+    @Test
+    fun `rewatch mode keeps watched next episode after the seed`() {
+        assertFalse(
+            shouldDropNextUpAgainstProgress(
+                nextSeason = 1,
+                nextEpisode = 3,
+                currentSeedSeason = 1,
+                currentSeedEpisode = 2,
+                watchedEpisodes = setOf(1 to 1, 1 to 2, 1 to 3),
+                preferFurthestEpisode = false
+            )
+        )
+    }
+
+    @Test
+    fun `keeps unwatched next up after the seed`() {
+        assertFalse(
+            shouldDropNextUpAgainstProgress(
+                nextSeason = 1,
+                nextEpisode = 4,
+                currentSeedSeason = 1,
+                currentSeedEpisode = 3,
+                watchedEpisodes = setOf(1 to 1, 1 to 2, 1 to 3),
+                preferFurthestEpisode = true
+            )
+        )
+    }
+
+    @Test
+    fun `watched episodes lookup includes sibling content ids`() {
+        val watched = mapOf(
+            "tt123" to setOf(1 to 1, 1 to 2),
+            "tmdb:9" to setOf(1 to 3)
+        )
+        val siblings = mapOf("tt123" to setOf("tmdb:9"))
+
+        assertEquals(
+            setOf(1 to 1, 1 to 2, 1 to 3),
+            watchedEpisodesForContentId("tt123", watched, siblings)
+        )
+    }
+
+    @Test
     fun `transient resolution failure retains the existing next up`() {
         val existing = nextUp("series", season = 1, episode = 2, seedSeason = 1, seedEpisode = 1)
 


### PR DESCRIPTION
## Summary

Continue Watching no longer shows a "Next Up" card for an episode that is already marked watched (for example a finished season finale with a checkmark). Stale next-up cache/resolution entries that are not strictly after the current seed are dropped, and furthest-episode mode skips already-watched episodes when resolving the true next episode.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Users could finish a series finale and still see that same episode as Continue Watching "Next Up" while the fully-watched tick was also shown. That happens when the next-up seed lags exact watched history or a disk/in-memory next-up cache is not advanced after the episode is completed.

## Issue or approval

Fixes #2840

## Reproduction steps

1. Watch a series through the finale (or mark the last episode watched).
2. Return to Home Continue Watching.
3. Observe the series still listed as "Next Up" for the already-watched finale (often with the watched checkmark).
4. Expected after fix: no next-up card for that finished episode; if further unwatched episodes exist, furthest mode advances past already-watched ones.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change rewatch mode (`next up from furthest episode` off): sequential rewatch may still surface previously watched next episodes after the seed.
- Does not change fully-watched badge evaluation rules beyond dropping invalid next-up cards.
- No UI layout/visual polish changes.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.home.ContinueWatchingNextUpReconciliationTest" --tests "com.nuvio.tv.ui.screens.home.SimklContinueWatchingDiagnosticsTest"` — PASSED
- `./gradlew :app:compileFullDebugKotlin` — PASSED (as part of unit test task)
- Manual device verification of Continue Watching after finishing a finale not run in this environment; pure rules cover the drop conditions used by the pipeline.

## Screenshots / Video

Not a UI change (behavior-only Continue Watching correctness).

## Breaking changes

None.

## Linked issues

Fixes #2840