### PR TITLE
fix(home): restore Continue Watching focus after remove (#2853)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -221,6 +221,7 @@ fun ModernHomeContent(
     var initialAutoSelectedKey by remember { mutableStateOf<String?>(null) }
     val pendingRowFocusKey = remember { mutableStateOf<String?>(null) }
     val pendingRowFocusIndex = remember { mutableStateOf<Int?>(null) }
+    val pendingRowFocusItemKey = remember { mutableStateOf<String?>(null) }
     val pendingRowFocusNonce = remember { mutableIntStateOf(0) }
     val restoredFromSavedState = remember { mutableStateOf(false) }
     val heroItem = remember {
@@ -388,6 +389,7 @@ fun ModernHomeContent(
                     ?: resolvedRow.items.firstOrNull()?.heroPreview
                 pendingRowFocusKey.value = resolvedRow.key
                 pendingRowFocusIndex.value = resolvedIndex
+                pendingRowFocusItemKey.value = resolvedRow.items.getOrNull(resolvedIndex)?.key
                 pendingRowFocusNonce.intValue++
                 restoredFromSavedState.value = true
                 return@LaunchedEffect
@@ -420,6 +422,7 @@ fun ModernHomeContent(
                 initialAutoSelectedKey = resolvedActive.key
                 pendingRowFocusKey.value = resolvedActive.key
                 pendingRowFocusIndex.value = resolvedIndex
+                pendingRowFocusItemKey.value = resolvedActive.items.getOrNull(resolvedIndex)?.key
                 pendingRowFocusNonce.intValue++
             }
         }
@@ -1019,6 +1022,7 @@ fun ModernHomeContent(
                 {
                     pendingRowFocusKey.value = null
                     pendingRowFocusIndex.value = null
+                    pendingRowFocusItemKey.value = null
                 }
             }
             val onRowItemFocusedInternalLambda = remember(onRowItemFocusedPassedDown) {
@@ -1094,6 +1098,7 @@ fun ModernHomeContent(
                 continueWatchingCornerRadius = uiState.posterCardCornerRadiusDp.dp,
                 pendingRowFocusKey = pendingRowFocusKey,
                 pendingRowFocusIndex = pendingRowFocusIndex,
+                pendingRowFocusItemKey = pendingRowFocusItemKey,
                 pendingRowFocusNonce = pendingRowFocusNonce,
                 onPendingRowFocusCleared = onPendingRowFocusClearedLambda,
                 onActiveRowKeyChange = onActiveRowKeyChangeLambda,
@@ -1120,10 +1125,22 @@ fun ModernHomeContent(
             item = selectedOptionsItem,
             onDismiss = { optionsItem.value = null },
             onRemove = {
-                val targetIndex = if (uiState.continueWatchingItems.size <= 1) null
-                else (lastFocusedContinueWatchingIndex.intValue).coerceAtMost(uiState.continueWatchingItems.size - 2).coerceAtLeast(0)
-                pendingRowFocusKey.value = if (targetIndex != null) "continue_watching" else null
-                pendingRowFocusIndex.value = targetIndex
+                val focusTarget = continueWatchingRemovalFocusTarget(
+                    items = uiState.continueWatchingItems,
+                    removedItem = selectedOptionsItem,
+                    lastFocusedIndex = lastFocusedContinueWatchingIndex.intValue
+                )
+                pendingRowFocusKey.value = if (focusTarget.index != null) "continue_watching" else null
+                pendingRowFocusIndex.value = focusTarget.index
+                pendingRowFocusItemKey.value = focusTarget.itemKey
+                // Point row focus bookkeeping at the post-removal slot before the dialog
+                // dismisses, so focusRestorer does not restore onto the deleted card.
+                focusTarget.index?.let { targetIndex ->
+                    lastFocusedContinueWatchingIndex.intValue = targetIndex
+                    focusedItemByRow[MODERN_CONTINUE_WATCHING_ROW_KEY] = targetIndex
+                    focusHolder.activeItemIndex = targetIndex
+                    activeItemIndex.intValue = targetIndex
+                }
                 pendingRowFocusNonce.intValue++
                 onRemoveContinueWatching(
                     selectedOptionsItem.contentId(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -1125,10 +1125,17 @@ fun ModernHomeContent(
             item = selectedOptionsItem,
             onDismiss = { optionsItem.value = null },
             onRemove = {
+                // Prefer the options dialog's item over lastFocused — they can drift if
+                // focus moved while the dialog was open.
+                val selectedKey = continueWatchingItemKey(selectedOptionsItem)
+                val selectedIndex = uiState.continueWatchingItems.indexOfFirst {
+                    continueWatchingItemKey(it) == selectedKey
+                }
                 val focusTarget = continueWatchingRemovalFocusTarget(
                     items = uiState.continueWatchingItems,
                     removedItem = selectedOptionsItem,
-                    lastFocusedIndex = lastFocusedContinueWatchingIndex.intValue
+                    lastFocusedIndex = selectedIndex.takeIf { it >= 0 }
+                        ?: lastFocusedContinueWatchingIndex.intValue
                 )
                 pendingRowFocusKey.value = if (focusTarget.index != null) "continue_watching" else null
                 pendingRowFocusIndex.value = focusTarget.index

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeModels.kt
@@ -572,6 +572,42 @@ internal fun continueWatchingItemKey(item: ContinueWatchingItem): String {
     }
 }
 
+internal data class ContinueWatchingRemovalFocusTarget(
+    val index: Int?,
+    val itemKey: String?
+)
+
+/**
+ * Finds the card that should receive focus after a Continue Watching card is removed.
+ *
+ * The key is resolved from the list before removal, while the index is the position
+ * that card will have after removal. Keeping both lets the focus request survive the
+ * list diff instead of being claimed by the card that is about to disappear.
+ */
+internal fun continueWatchingRemovalFocusTarget(
+    items: List<ContinueWatchingItem>,
+    removedItem: ContinueWatchingItem,
+    lastFocusedIndex: Int
+): ContinueWatchingRemovalFocusTarget {
+    if (items.size <= 1) return ContinueWatchingRemovalFocusTarget(index = null, itemKey = null)
+
+    val removedIndex = items.indexOfFirst { item ->
+        continueWatchingItemKey(item) == continueWatchingItemKey(removedItem)
+    }
+    val currentIndex = if (removedIndex >= 0) removedIndex else lastFocusedIndex
+    val targetIndex = currentIndex.coerceIn(0, items.size - 2)
+    val sourceIndex = if (removedIndex >= 0 && targetIndex >= removedIndex) {
+        targetIndex + 1
+    } else {
+        targetIndex
+    }
+
+    return ContinueWatchingRemovalFocusTarget(
+        index = targetIndex,
+        itemKey = items.getOrNull(sourceIndex)?.let(::continueWatchingItemKey)
+    )
+}
+
 internal fun catalogRowKey(row: CatalogRow): String {
     return row.stableKey()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -161,6 +161,12 @@ private fun ModernContinueWatchingRowItem(
     payload: ModernPayload.ContinueWatching,
     requester: FocusRequester,
     isTargetItem: Boolean = false,
+    /**
+     * True only while a post-remove (or restore) pending focus request targets this card.
+     * Must not be true for ordinary "currently focused row index" — that would re-steal
+     * focus when the user deliberately leaves the row (e.g. D-pad left to the sidebar).
+     */
+    isPendingFocusTarget: Boolean = false,
     cardWidth: Dp,
     imageHeight: Dp,
     blurUnwatchedEpisodes: Boolean,
@@ -191,10 +197,11 @@ private fun ModernContinueWatchingRowItem(
         if (!isCardFocused || focusEventId != targetEventId) return@LaunchedEffect
     }
 
-    // Re-request when focus is lost while this card is still the intended target
-    // (e.g. options dialog closed onto a card that is about to be removed).
-    LaunchedEffect(item, isTargetItem, isCardFocused) {
-        if (isTargetItem && !isCardFocused) {
+    // Only re-request for an in-flight pending target (after remove / restore).
+    // Using plain isTargetItem here trapped focus on the sole remaining CW card and
+    // blocked leaving to the sidebar (see #2853 review).
+    LaunchedEffect(item, isPendingFocusTarget, isCardFocused) {
+        if (isPendingFocusTarget && !isCardFocused) {
             repeat(3) {
                 withFrameNanos { }
                 if (runCatching { requester.requestFocus() }.isSuccess) return@LaunchedEffect
@@ -930,6 +937,20 @@ internal fun ModernRowSection(
                     // pending card may claim target status. Otherwise the pre-removal
                     // "current" index (still pointing at the deleted card) races with
                     // the intended successor and focus lands randomly — worse in RTL.
+                    val isPendingFocusTarget by remember(row.key, index, item.key) {
+                        derivedStateOf {
+                            pendingRowFocusKey.value == row.key &&
+                                if (pendingRowFocusItemKey.value != null) {
+                                    pendingRowFocusItemKey.value == item.key
+                                } else {
+                                    (pendingRowFocusIndex.value ?: 0) == index
+                                }
+                        }
+                    }
+                    // While a pending focus request is active for this row, only the
+                    // pending card may claim target status. Otherwise the pre-removal
+                    // "current" index (still pointing at the deleted card) races with
+                    // the intended successor and focus lands randomly — worse in RTL.
                     val isTargetItem by remember(row.key, index, item.key) {
                         derivedStateOf {
                             val isPendingRow = pendingRowFocusKey.value == row.key
@@ -953,6 +974,7 @@ internal fun ModernRowSection(
                                 payload = payload,
                                 requester = requester,
                                 isTargetItem = isTargetItem,
+                                isPendingFocusTarget = isPendingFocusTarget,
                                 cardWidth = continueWatchingCardWidth,
                                 imageHeight = continueWatchingCardHeight,
                                 blurUnwatchedEpisodes = blurUnwatchedEpisodes,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.Brush
@@ -190,9 +191,14 @@ private fun ModernContinueWatchingRowItem(
         if (!isCardFocused || focusEventId != targetEventId) return@LaunchedEffect
     }
 
-    LaunchedEffect(isTargetItem) {
+    // Re-request when focus is lost while this card is still the intended target
+    // (e.g. options dialog closed onto a card that is about to be removed).
+    LaunchedEffect(item, isTargetItem, isCardFocused) {
         if (isTargetItem && !isCardFocused) {
-            runCatching { requester.requestFocus() }
+            repeat(3) {
+                withFrameNanos { }
+                if (runCatching { requester.requestFocus() }.isSuccess) return@LaunchedEffect
+            }
         }
     }
 
@@ -438,6 +444,7 @@ internal fun ModernRowSection(
     loadMoreRequestedTotals: StableRef<MutableMap<String, Int>>,
     pendingRowFocusKey: State<String?>,
     pendingRowFocusIndex: State<Int?>,
+    pendingRowFocusItemKey: State<String?>,
     pendingRowFocusNonce: State<Int>,
     onPendingRowFocusCleared: () -> Unit,
     onRowItemFocused: (String, Int, Boolean) -> Unit,
@@ -475,7 +482,7 @@ internal fun ModernRowSection(
     onBackdropInteraction: () -> Unit,
     onExpandedCatalogFocusKeyChange: (String?) -> Unit,
     sharedPlaceholderShimmerOffsetState: State<Float>,
-    itemFocusRequesters: StableRef<MutableMap<Int, FocusRequester>> = StableRef(mutableMapOf())
+    itemFocusRequesters: StableRef<MutableMap<String, FocusRequester>> = StableRef(mutableMapOf())
 ) {
     // Unwrap StableRef wrappers
     @Suppress("NAME_SHADOWING") val focusedItemByRow = focusedItemByRow.value
@@ -871,9 +878,18 @@ internal fun ModernRowSection(
                     .recompositionHighlighter()
                     .focusRequester(rowFocusRequester)
                     .focusRestorer {
+                        // Prefer an in-flight pending target (e.g. after CW remove) so the
+                        // restorer does not briefly re-focus the card that is disappearing.
+                        val pendingKey = if (pendingRowFocusKey.value == row.key) {
+                            pendingRowFocusItemKey.value
+                        } else {
+                            null
+                        }
                         val savedIdx = rowFocusedIndex.value
-                        itemFocusRequesters[savedIdx]
-                            ?: itemFocusRequesters[0]
+                        val savedKey = row.items.list.getOrNull(savedIdx)?.key
+                        pendingKey?.let(itemFocusRequesters::get)
+                            ?: savedKey?.let(itemFocusRequesters::get)
+                            ?: row.items.list.firstOrNull()?.key?.let(itemFocusRequesters::get)
                             ?: FocusRequester.Default
                     }
                     .focusGroup(),
@@ -891,12 +907,18 @@ internal fun ModernRowSection(
                         }
                     }
                 ) { index, item ->
-                    val requester = itemFocusRequesters.getOrPut(index) { FocusRequester() }
+                    val requester = itemFocusRequesters.getOrPut(item.key) { FocusRequester() }
                     val isContinueWatchingRow = row.key == MODERN_CONTINUE_WATCHING_ROW_KEY || row.key == MODERN_UPCOMING_ROW_KEY
-                    val onFocused = remember(row.key, index, isContinueWatchingRow) {
+                    val onFocused = remember(row.key, index, item.key, isContinueWatchingRow) {
                         {
                             onRowItemFocused(row.key, index, isContinueWatchingRow)
-                            if (pendingRowFocusKey.value == row.key && (pendingRowFocusIndex.value ?: 0) == index) {
+                            val isPendingTarget = pendingRowFocusKey.value == row.key &&
+                                if (pendingRowFocusItemKey.value != null) {
+                                    pendingRowFocusItemKey.value == item.key
+                                } else {
+                                    (pendingRowFocusIndex.value ?: 0) == index
+                                }
+                            if (isPendingTarget) {
                                 onPendingRowFocusCleared()
                             }
                         }
@@ -904,13 +926,24 @@ internal fun ModernRowSection(
 
                     // Use derivedStateOf so only the ONE item that becomes/loses
                     // target status recomposes — not all items in all visible rows.
-                    val isTargetItem by remember(row.key, index) {
+                    // While a pending focus request is active for this row, only the
+                    // pending card may claim target status. Otherwise the pre-removal
+                    // "current" index (still pointing at the deleted card) races with
+                    // the intended successor and focus lands randomly — worse in RTL.
+                    val isTargetItem by remember(row.key, index, item.key) {
                         derivedStateOf {
-                            val isPending = pendingRowFocusKey.value == row.key &&
-                                (pendingRowFocusIndex.value ?: 0) == index
-                            val isCurrent = isActiveRow() &&
-                                rowFocusedIndex.value == index
-                            isPending || isCurrent
+                            val isPendingRow = pendingRowFocusKey.value == row.key
+                            val isPending = isPendingRow &&
+                                if (pendingRowFocusItemKey.value != null) {
+                                    pendingRowFocusItemKey.value == item.key
+                                } else {
+                                    (pendingRowFocusIndex.value ?: 0) == index
+                                }
+                            if (isPendingRow) {
+                                isPending
+                            } else {
+                                isActiveRow() && rowFocusedIndex.value == index
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
@@ -127,6 +127,7 @@ internal fun ModernHomeRowsList(
     continueWatchingCornerRadius: Dp,
     pendingRowFocusKey: State<String?>,
     pendingRowFocusIndex: State<Int?>,
+    pendingRowFocusItemKey: State<String?>,
     pendingRowFocusNonce: State<Int>,
     onPendingRowFocusCleared: () -> Unit,
     onActiveRowKeyChange: (String?) -> Unit,
@@ -153,7 +154,7 @@ internal fun ModernHomeRowsList(
     val latestOnActiveItemIndexChange = rememberUpdatedState(onActiveItemIndexChange)
 
     val rowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
-    val stableItemFocusRequestersByRow = remember { mutableMapOf<String, StableRef<MutableMap<Int, FocusRequester>>>() }
+    val stableItemFocusRequestersByRow = remember { mutableMapOf<String, StableRef<MutableMap<String, FocusRequester>>>() }
 
     val density = LocalDensity.current
     val context = LocalContext.current
@@ -431,6 +432,7 @@ internal fun ModernHomeRowsList(
                     loadMoreRequestedTotals = loadMoreRequestedTotals,
                     pendingRowFocusKey = pendingRowFocusKey,
                     pendingRowFocusIndex = pendingRowFocusIndex,
+                    pendingRowFocusItemKey = pendingRowFocusItemKey,
                     pendingRowFocusNonce = pendingRowFocusNonce,
                     onPendingRowFocusCleared = onPendingRowFocusCleared,
                     onRowItemFocused = stableOnRowItemFocused,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomeModelsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomeModelsTest.kt
@@ -48,6 +48,35 @@ class ModernHomeModelsTest {
         assertNull(target.itemKey)
     }
 
+    @Test
+    fun `removing the first item targets the former second item at index 0`() {
+        val items = (0..4).map(::inProgress)
+
+        val target = continueWatchingRemovalFocusTarget(
+            items = items,
+            removedItem = items[0],
+            lastFocusedIndex = 0
+        )
+
+        // Same visual slot: next card slides into index 0.
+        assertEquals(0, target.index)
+        assertEquals(continueWatchingItemKey(items[1]), target.itemKey)
+    }
+
+    @Test
+    fun `removing penultimate item targets the last item`() {
+        val items = (0..4).map(::inProgress)
+
+        val target = continueWatchingRemovalFocusTarget(
+            items = items,
+            removedItem = items[3],
+            lastFocusedIndex = 3
+        )
+
+        assertEquals(3, target.index)
+        assertEquals(continueWatchingItemKey(items[4]), target.itemKey)
+    }
+
     private fun inProgress(index: Int) = ContinueWatchingItem.InProgress(
         progress = WatchProgress(
             contentId = "show-$index",

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomeModelsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomeModelsTest.kt
@@ -1,0 +1,68 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ModernHomeModelsTest {
+    @Test
+    fun `removing a middle item targets the card that shifts into its slot`() {
+        val items = (0..9).map(::inProgress)
+
+        val target = continueWatchingRemovalFocusTarget(
+            items = items,
+            removedItem = items[6],
+            lastFocusedIndex = 6
+        )
+
+        assertEquals(6, target.index)
+        assertEquals(continueWatchingItemKey(items[7]), target.itemKey)
+    }
+
+    @Test
+    fun `removing the last item targets the new last card`() {
+        val items = (0..9).map(::inProgress)
+
+        val target = continueWatchingRemovalFocusTarget(
+            items = items,
+            removedItem = items[9],
+            lastFocusedIndex = 9
+        )
+
+        assertEquals(8, target.index)
+        assertEquals(continueWatchingItemKey(items[8]), target.itemKey)
+    }
+
+    @Test
+    fun `removing the only item has no focus target`() {
+        val item = inProgress(0)
+
+        val target = continueWatchingRemovalFocusTarget(
+            items = listOf(item),
+            removedItem = item,
+            lastFocusedIndex = 0
+        )
+
+        assertNull(target.index)
+        assertNull(target.itemKey)
+    }
+
+    private fun inProgress(index: Int) = ContinueWatchingItem.InProgress(
+        progress = WatchProgress(
+            contentId = "show-$index",
+            contentType = "series",
+            name = "Show $index",
+            poster = null,
+            backdrop = null,
+            logo = null,
+            videoId = "video-$index",
+            season = 1,
+            episode = index + 1,
+            episodeTitle = null,
+            position = 100L,
+            duration = 1_000L,
+            lastWatched = index.toLong()
+        )
+    )
+}


### PR DESCRIPTION
## Summary

Fixes focus landing randomly (or staying on a deleted card) after removing an item from Continue Watching on Modern Home, especially with RTL layouts.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

After long-press → Remove on a Continue Watching card, focus restoration raced between the card that was about to disappear (still the “current” index) and the intended successor. With RTL and a longer row this frequently left focus on a random card or a disposed node instead of the item that shifted into the removed slot.

## Issue or approval

Fixes #2853

## Reproduction steps

1. Add at least ten items to Continue Watching.
2. Use RTL layout (Hebrew/Arabic).
3. Open Home in Modern View.
4. Long-press about the seventh Continue Watching item and choose Remove.
5. Observe focus: it should land on the card that takes the removed slot (or the new last card if the last item was removed), not randomly / not on the deleted item.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only Modern Home Continue Watching remove-focus path.
- Does not change remove semantics, CW data pipeline, Classic/Grid CW sections, or visual styling beyond focus restoration behavior.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — passed
- `./gradlew :app:testFullDebugUnitTest --tests 'com.nuvio.tv.ui.screens.home.ModernHomeModelsTest'` — passed
- Manual TV RTL check not run in this environment; logic covered by pure target-selection unit tests plus compile of focus wiring.

## Screenshots / Video

Not a visual redesign; focus-only behavior fix after remove. Device verification recommended on Android TV with RTL + ≥10 CW items.

## Breaking changes

None.

## Linked issues

Fixes #2853