### PR TITLE
fix(library): localize Trakt library titles via TMDB (#2846)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -57,6 +57,49 @@ class TmdbMetadataService(
     private val entityHeaderCache = ConcurrentHashMap<String, TmdbEntityHeader>()
     private val entityRailCache = ConcurrentHashMap<String, List<MetaPreview>>()
     private val entityBrowseCache = ConcurrentHashMap<String, TmdbEntityBrowseData>()
+    private val localizedTitleCache = ConcurrentHashMap<String, String>()
+
+    /**
+     * Lightweight title-only fetch for Trakt-sourced library rows that otherwise
+     * stay English. Skips the network call when the target language is English.
+     */
+    suspend fun fetchLocalizedTitle(
+        tmdbId: Int,
+        contentType: ContentType,
+        language: String
+    ): String? = withContext(ioDispatcher) {
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        if (normalizedLanguage.equals("en", ignoreCase = true) ||
+            normalizedLanguage.startsWith("en-", ignoreCase = true)
+        ) {
+            return@withContext null
+        }
+
+        val cacheKey = "$tmdbId:${contentType.name}:$normalizedLanguage:title"
+        localizedTitleCache[cacheKey]?.let { return@withContext it }
+
+        val tmdbType = when (contentType) {
+            ContentType.SERIES, ContentType.TV -> "tv"
+            else -> "movie"
+        }
+
+        try {
+            val details = when (tmdbType) {
+                "tv" -> tmdbApi.getTvDetails(tmdbId, TMDB_API_KEY, normalizedLanguage).body()
+                else -> tmdbApi.getMovieDetails(tmdbId, TMDB_API_KEY, normalizedLanguage).body()
+            }
+            val title = (details?.title ?: details?.name)?.trim()?.takeIf { it.isNotBlank() }
+            if (title != null) {
+                localizedTitleCache[cacheKey] = title
+            }
+            title
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch localized title for tmdb:$tmdbId: ${e.message}")
+            null
+        }
+    }
 
     suspend fun fetchEnrichment(
         tmdbId: String,

--- a/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLanguage.kt
+++ b/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLanguage.kt
@@ -1,0 +1,33 @@
+package com.nuvio.tv.core.trakt
+
+import com.nuvio.tv.LocaleCache
+import java.util.Locale
+
+/**
+ * Resolves the app interface language for localizing Trakt-sourced library titles.
+ * Trakt's API returns English titles; we map them via TMDB using this language.
+ */
+object TraktMetadataLanguage {
+
+    fun resolveInterfaceLanguage(localeTag: String = LocaleCache.localeTag): String {
+        val tag = localeTag.trim()
+            .takeIf { it.isNotBlank() && it != LocaleCache.UNSET }
+            ?: Locale.getDefault().toLanguageTag()
+        return normalizeLanguage(tag)
+    }
+
+    fun isEnglish(language: String): Boolean {
+        val code = language.trim().substringBefore("-").lowercase(Locale.US)
+        return code == "en"
+    }
+
+    private fun normalizeLanguage(language: String): String {
+        val raw = language.trim().replace('_', '-').takeIf { it.isNotBlank() } ?: return "en"
+        val parts = raw.split("-")
+        return if (parts.size == 2) {
+            "${parts[0].lowercase(Locale.US)}-${parts[1].uppercase(Locale.US)}"
+        } else {
+            raw.lowercase(Locale.US)
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLocalizationService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/trakt/TraktMetadataLocalizationService.kt
@@ -1,0 +1,55 @@
+package com.nuvio.tv.core.trakt
+
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.data.repository.parseContentIds
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibraryEntry
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Localizes Trakt library entry titles via TMDB using the app interface language.
+ * No-op when the UI language is English or when no TMDB id is available.
+ */
+@Singleton
+class TraktMetadataLocalizationService @Inject constructor(
+    private val tmdbMetadataService: TmdbMetadataService
+) {
+    suspend fun localizeLibraryEntries(entries: List<LibraryEntry>): List<LibraryEntry> {
+        if (entries.isEmpty()) return entries
+        val language = TraktMetadataLanguage.resolveInterfaceLanguage()
+        if (TraktMetadataLanguage.isEnglish(language)) return entries
+        return localizeLibraryEntries(entries, language)
+    }
+
+    private suspend fun localizeLibraryEntries(
+        entries: List<LibraryEntry>,
+        language: String
+    ): List<LibraryEntry> = coroutineScope {
+        val semaphore = Semaphore(LOCALIZATION_CONCURRENCY)
+        entries.map { entry ->
+            async {
+                val tmdbId = entry.tmdbId ?: parseContentIds(entry.id).tmdb ?: return@async entry
+                val contentType = ContentType.fromString(entry.type)
+                val localizedTitle = semaphore.withPermit {
+                    tmdbMetadataService.fetchLocalizedTitle(
+                        tmdbId = tmdbId,
+                        contentType = contentType,
+                        language = language
+                    )
+                } ?: return@async entry
+                if (localizedTitle.equals(entry.name, ignoreCase = true)) entry
+                else entry.copy(name = localizedTitle)
+            }
+        }.awaitAll()
+    }
+
+    companion object {
+        private const val LOCALIZATION_CONCURRENCY = 6
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.data.repository
 import android.content.Context
 import com.nuvio.tv.R
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.trakt.TraktMetadataLocalizationService
 import com.nuvio.tv.core.trakt.traktBestBackdropUrl
 import com.nuvio.tv.core.trakt.traktBestLogoUrl
 import com.nuvio.tv.core.trakt.traktBestPosterUrl
@@ -48,7 +49,8 @@ class TraktLibraryService @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val traktApi: TraktApi,
     private val traktAuthService: TraktAuthService,
-    private val profileManager: ProfileManager
+    private val profileManager: ProfileManager,
+    private val traktMetadataLocalizationService: TraktMetadataLocalizationService
 ) {
     private data class Snapshot(
         val listTabs: List<LibraryListTab> = emptyList(),
@@ -480,16 +482,22 @@ class TraktLibraryService @Inject constructor(
             entry.copy(listKeys = membership[key].orEmpty())
         }.sortedByDescending { it.listedAt }
 
+        // Trakt returns English titles; map display names to the app interface
+        // language via TMDB so Library matches non-English UI (#2846).
+        val localizedAllEntries = traktMetadataLocalizationService.localizeLibraryEntries(allEntries)
+        val localizedById = localizedAllEntries.associateBy { contentKey(it.id, it.type) }
+
         val entriesByList = rawEntriesByList.mapValues { (_, entries) ->
             entries.map { entry ->
-                entry.copy(listKeys = membership[contentKey(entry.id, entry.type)].orEmpty())
+                val withLists = entry.copy(listKeys = membership[contentKey(entry.id, entry.type)].orEmpty())
+                localizedById[contentKey(withLists.id, withLists.type)] ?: withLists
             }
         }
 
         return Snapshot(
             listTabs = tabs,
             entriesByList = entriesByList,
-            allEntries = allEntries,
+            allEntries = localizedAllEntries,
             membershipByContent = membership.mapValues { it.value.toSet() },
             updatedAtMs = System.currentTimeMillis()
         )

--- a/app/src/test/java/com/nuvio/tv/core/trakt/TraktMetadataLanguageTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/trakt/TraktMetadataLanguageTest.kt
@@ -1,0 +1,37 @@
+package com.nuvio.tv.core.trakt
+
+import com.nuvio.tv.LocaleCache
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TraktMetadataLanguageTest {
+
+    @Test
+    fun isEnglish_matchesBareAndRegionalCodes() {
+        assertTrue(TraktMetadataLanguage.isEnglish("en"))
+        assertTrue(TraktMetadataLanguage.isEnglish("en-US"))
+        assertTrue(TraktMetadataLanguage.isEnglish("EN-gb"))
+        assertFalse(TraktMetadataLanguage.isEnglish("he"))
+        assertFalse(TraktMetadataLanguage.isEnglish("he-IL"))
+        assertFalse(TraktMetadataLanguage.isEnglish("fr"))
+    }
+
+    @Test
+    fun resolveInterfaceLanguage_usesExplicitLocaleTag() {
+        assertEquals("he", TraktMetadataLanguage.resolveInterfaceLanguage("he"))
+        assertEquals("he-IL", TraktMetadataLanguage.resolveInterfaceLanguage("he-il"))
+        assertEquals("pt-BR", TraktMetadataLanguage.resolveInterfaceLanguage("pt_br"))
+        assertEquals("fr-FR", TraktMetadataLanguage.resolveInterfaceLanguage("fr-FR"))
+    }
+
+    @Test
+    fun resolveInterfaceLanguage_ignoresUnsetSentinel() {
+        // When the user has not chosen an app language, fall back to system locale
+        // rather than the internal UNSET sentinel string.
+        val resolved = TraktMetadataLanguage.resolveInterfaceLanguage(LocaleCache.UNSET)
+        assertFalse(resolved.equals(LocaleCache.UNSET, ignoreCase = true))
+        assertTrue(resolved.isNotBlank())
+    }
+}


### PR DESCRIPTION
## Summary

When Trakt is connected, Library list titles no longer stay English-only. Trakt-sourced entries are localized through TMDB using the app interface language so Hebrew (and other non-English) UI users keep localized names in Library.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Trakt's API returns English titles. With Library source mode set to Trakt (default after connecting), the entire Library tab switched to English titles while the UI language stayed Hebrew. Disconnecting Trakt restored localized names from the local/metadata path. Connecting Trakt should not override the selected metadata language for titles.

## Issue or approval

Fixes #2846

## Reproduction steps

1. Set the app interface language to Hebrew (or any non-English language).
2. Keep Trakt disconnected and open Library — titles appear localized.
3. Connect Trakt (Library source uses Trakt).
4. Before fix: Library titles switch to English while UI stays Hebrew.
5. After fix: Library titles are localized via TMDB for entries that have a TMDB id.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Library titles only when Library is served from Trakt (`TraktLibraryService` snapshot build).
- No new Trakt settings row (unlike closed #2012); language always follows the app interface locale.
- Does not change posters, descriptions, genres, More like this, Simkl library, or local Library source mode.
- Entries without a TMDB id keep the original Trakt English title (safe fallback).
- English UI: no extra TMDB title requests.

## Testing

- Logic review of snapshot build: after membership merge, all entries pass through `TraktMetadataLocalizationService.localizeLibraryEntries`.
- Confirmed Trakt list/watchlist calls use `extended=full,images`, so `tmdbId` is typically present for localization.
- Unit tests: `TraktMetadataLanguageTest` covers English detection, locale-tag normalization (e.g. `he`, `pt_br` → `pt-BR`), and UNSET sentinel fallback.
- Did not run on-device Hebrew Trakt session in this environment; CI `fullDebug` build should compile the new DI constructor arg and TMDB title helper.

## Screenshots / Video

Not a UI change (display strings only; no layout/components).

## Breaking changes

None.

## Linked issues

Fixes #2846