### PR TITLE
fix(tmdb): fall back to English episode titles when translation is missing (#2385)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -39,8 +39,20 @@ import kotlinx.coroutines.sync.withPermit
 private const val TAG = "TmdbMetadataService"
 private val TMDB_API_KEY = BuildConfig.TMDB_API_KEY
 private const val TMDB_TRAILER_FALLBACK_LANGUAGE = "en-US"
+private const val TMDB_EPISODE_FALLBACK_LANGUAGE = "en-US"
 private const val TMDB_SEASON_REQUEST_CONCURRENCY = 4
 private val YOUTUBE_VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
+/**
+ * TMDB placeholder when an episode has no real title for the requested language.
+ * Localizes the word ("Episode 1", "Odcinek 2", "Épisode 3", "Folge 4", "פרק 5", …)
+ * so detection must not be English-only.
+ */
+private val GENERIC_EPISODE_TITLE_REGEX = Regex(
+    """^[\p{L}\p{M}]+(?:['’ʼ][\p{L}\p{M}]+)?\s+0*(\d+)$""",
+    RegexOption.IGNORE_CASE
+)
+/** CJK-style placeholders such as "第1集" / "1集". */
+private val GENERIC_EPISODE_TITLE_CJK_REGEX = Regex("""^第?\s*0*(\d+)\s*集$""")
 
 @Singleton
 class TmdbMetadataService(
@@ -507,35 +519,15 @@ class TmdbMetadataService(
             return@withContext existing.await()
         }
         try {
-            val semaphore = Semaphore(TMDB_SEASON_REQUEST_CONCURRENCY)
-            val seasonResults = coroutineScope {
-                seasonNumbers.distinct().map { season ->
-                    async {
-                        semaphore.withPermit {
-                            try {
-                                val response = tmdbApi.getTvSeasonDetails(
-                                    numericId,
-                                    season,
-                                    TMDB_API_KEY,
-                                    normalizedLanguage
-                                )
-                                response.body()?.episodes.orEmpty().mapNotNull { episode ->
-                                    val episodeNumber = episode.episodeNumber ?: return@mapNotNull null
-                                    (season to episodeNumber) to episode.toEnrichment()
-                                }.toMap()
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Exception) {
-                                Log.w(TAG, "Failed to fetch TMDB season $season: ${e.message}")
-                                emptyMap()
-                            }
-                        }
-                    }
-                }.awaitAll()
-            }
-
-            val finalResult = buildMap {
-                seasonResults.forEach(::putAll)
+            val seasons = seasonNumbers.distinct()
+            val localized = fetchSeasonEpisodes(numericId, seasons, normalizedLanguage)
+            val finalResult = if (isEnglishTmdbLanguage(normalizedLanguage)) {
+                localized
+            } else {
+                // Merge only per-episode placeholder/blank fields with English; preserve real
+                // localized titles in partially translated seasons.
+                val english = fetchSeasonEpisodes(numericId, seasons, TMDB_EPISODE_FALLBACK_LANGUAGE)
+                mergeEpisodeEnrichmentWithFallback(preferred = localized, fallback = english)
             }
             if (finalResult.isNotEmpty()) {
                 episodeCache[cacheKey] = finalResult
@@ -550,6 +542,42 @@ class TmdbMetadataService(
                 requestDeferred.complete(emptyMap())
             }
             episodeInFlight.remove(cacheKey, requestDeferred)
+        }
+    }
+
+    private suspend fun fetchSeasonEpisodes(
+        numericId: Int,
+        seasonNumbers: List<Int>,
+        language: String
+    ): Map<Pair<Int, Int>, TmdbEpisodeEnrichment> {
+        val semaphore = Semaphore(TMDB_SEASON_REQUEST_CONCURRENCY)
+        val seasonResults = coroutineScope {
+            seasonNumbers.map { season ->
+                async {
+                    semaphore.withPermit {
+                        try {
+                            val response = tmdbApi.getTvSeasonDetails(
+                                numericId,
+                                season,
+                                TMDB_API_KEY,
+                                language
+                            )
+                            response.body()?.episodes.orEmpty().mapNotNull { episode ->
+                                val episodeNumber = episode.episodeNumber ?: return@mapNotNull null
+                                (season to episodeNumber) to episode.toEnrichment()
+                            }.toMap()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to fetch TMDB season $season ($language): ${e.message}")
+                            emptyMap()
+                        }
+                    }
+                }
+            }.awaitAll()
+        }
+        return buildMap {
+            seasonResults.forEach(::putAll)
         }
     }
 
@@ -1463,4 +1491,64 @@ private fun TmdbEpisode.toEnrichment(): TmdbEpisodeEnrichment {
         airDate = airDate,
         runtimeMinutes = runtime
     )
+}
+
+/** True when [language] is English (with or without a region). */
+internal fun isEnglishTmdbLanguage(language: String): Boolean =
+    language.trim().lowercase(Locale.US).startsWith("en")
+
+/**
+ * True when [title] is blank or a TMDB-style episode placeholder for [episodeNumber].
+ *
+ * TMDB localizes the placeholder word when a translation is missing. Matching only the
+ * English form leaves non-English locales stuck on a placeholder even when en-US has a title.
+ */
+internal fun isGenericEpisodeTitle(title: String?, episodeNumber: Int): Boolean {
+    if (title.isNullOrBlank()) return true
+    val trimmed = title.trim()
+    val parsed = GENERIC_EPISODE_TITLE_REGEX.matchEntire(trimmed)
+        ?.groupValues?.getOrNull(1)?.toIntOrNull()
+        ?: GENERIC_EPISODE_TITLE_CJK_REGEX.matchEntire(trimmed)
+            ?.groupValues?.getOrNull(1)?.toIntOrNull()
+        ?: return false
+    return parsed == episodeNumber
+}
+
+/**
+ * Picks the first real title, falling back to the first non-blank candidate.
+ * Candidates are supplied in caller-preference order: localized TMDB, English TMDB, addon.
+ */
+internal fun resolveEpisodeTitle(episodeNumber: Int?, vararg candidates: String?): String {
+    val ep = episodeNumber ?: 0
+    val nonBlank = candidates.mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }
+    return nonBlank.firstOrNull { !isGenericEpisodeTitle(it, ep) }
+        ?: nonBlank.firstOrNull()
+        ?: ""
+}
+
+/**
+ * Keeps localized metadata where available and resolves episode titles independently, since a
+ * locale may contain real titles for only some episodes in a season.
+ */
+internal fun mergeEpisodeEnrichmentWithFallback(
+    preferred: Map<Pair<Int, Int>, TmdbEpisodeEnrichment>,
+    fallback: Map<Pair<Int, Int>, TmdbEpisodeEnrichment>
+): Map<Pair<Int, Int>, TmdbEpisodeEnrichment> {
+    if (fallback.isEmpty()) return preferred
+    if (preferred.isEmpty()) return fallback
+    val keys = preferred.keys + fallback.keys
+    return keys.associateWith { key ->
+        val preferredEpisode = preferred[key]
+        val fallbackEpisode = fallback[key]
+        val title = resolveEpisodeTitle(key.second, preferredEpisode?.title, fallbackEpisode?.title)
+            .takeIf { it.isNotEmpty() }
+        TmdbEpisodeEnrichment(
+            title = title,
+            overview = preferredEpisode?.overview?.takeIf { it.isNotBlank() }
+                ?: fallbackEpisode?.overview?.takeIf { it.isNotBlank() },
+            thumbnail = preferredEpisode?.thumbnail ?: fallbackEpisode?.thumbnail,
+            airDate = preferredEpisode?.airDate ?: fallbackEpisode?.airDate,
+            runtimeMinutes = preferredEpisode?.runtimeMinutes ?: fallbackEpisode?.runtimeMinutes
+        )
+    }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -9,6 +9,7 @@ import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tmdb.TmdbMetadataService
 import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.core.tmdb.resolveEpisodeTitle
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
 import com.nuvio.tv.data.local.TraktAuthDataStore
@@ -1476,8 +1477,17 @@ class MetaDetailsViewModel @Inject constructor(
                     val key = if (video.season != null && video.episode != null) video.season to video.episode else null
                     val ep = key?.let { episodeMap[it] }
                     video.copy(
-                        title = if (settings.useEpisodes) ep?.title ?: video.title else video.title,
-                        overview = if (settings.useEpisodes) ep?.overview ?: video.overview else video.overview,
+                        title = if (settings.useEpisodes) {
+                            // Keep an addon title if TMDB has only a leftover placeholder.
+                            resolveEpisodeTitle(video.episode, ep?.title, video.title)
+                        } else {
+                            video.title
+                        },
+                        overview = if (settings.useEpisodes) {
+                            ep?.overview?.takeIf { it.isNotBlank() } ?: video.overview
+                        } else {
+                            video.overview
+                        },
                         released = selectEpisodeReleaseValue(
                             addonReleased = video.released,
                             tmdbAirDate = ep?.airDate,

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -226,6 +227,74 @@ class TmdbMetadataServiceTest {
         assertEquals(6, callCount.get())
         assertEquals(6, result.size)
         assertEquals("Season 6 premiere", result[6 to 1]?.title)
+    }
+
+    @Test
+    fun `isGenericEpisodeTitle recognizes localized placeholders`() {
+        assertTrue(isGenericEpisodeTitle("Episode 1", 1))
+        assertTrue(isGenericEpisodeTitle("Odcinek 2", 2))
+        assertTrue(isGenericEpisodeTitle("Épisode 3", 3))
+        assertTrue(isGenericEpisodeTitle("Folge 4", 4))
+        assertTrue(isGenericEpisodeTitle("פרק 5", 5))
+        assertTrue(isGenericEpisodeTitle("第1集", 1))
+        assertTrue(isGenericEpisodeTitle(null, 1))
+        assertFalse(isGenericEpisodeTitle("Pilot", 1))
+        assertFalse(isGenericEpisodeTitle("Episode 2", 1))
+    }
+
+    @Test
+    fun `episode fallback is per episode and preserves a real localized title`() {
+        val preferred = mapOf(
+            (1 to 1) to TmdbEpisodeEnrichment("Początek", "Polski opis", null, null, null),
+            (1 to 2) to TmdbEpisodeEnrichment("Odcinek 2", null, null, null, null)
+        )
+        val fallback = mapOf(
+            (1 to 1) to TmdbEpisodeEnrichment("Pilot", "English 1", "still-1", null, null),
+            (1 to 2) to TmdbEpisodeEnrichment("Cat's in the Bag...", "English 2", null, null, 48)
+        )
+
+        val merged = mergeEpisodeEnrichmentWithFallback(preferred, fallback)
+
+        assertEquals("Początek", merged[1 to 1]?.title)
+        assertEquals("Polski opis", merged[1 to 1]?.overview)
+        assertEquals("still-1", merged[1 to 1]?.thumbnail)
+        assertEquals("Cat's in the Bag...", merged[1 to 2]?.title)
+        assertEquals("English 2", merged[1 to 2]?.overview)
+        assertEquals(48, merged[1 to 2]?.runtimeMinutes)
+    }
+
+    @Test
+    fun `fetchEpisodeEnrichment falls back to English for localized placeholder`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getTvSeasonDetails(42, 1, any(), "pl-PL") } returns Response.success(
+            TmdbSeasonResponse(
+                seasonNumber = 1,
+                episodes = listOf(
+                    TmdbEpisode(episodeNumber = 1, name = "Odcinek 1", overview = null),
+                    TmdbEpisode(episodeNumber = 2, name = "Prawdziwy tytuł", overview = "Polski opis")
+                )
+            )
+        )
+        coEvery { api.getTvSeasonDetails(42, 1, any(), "en-US") } returns Response.success(
+            TmdbSeasonResponse(
+                seasonNumber = 1,
+                episodes = listOf(
+                    TmdbEpisode(episodeNumber = 1, name = "Pilot", overview = "English 1"),
+                    TmdbEpisode(episodeNumber = 2, name = "Cat's in the Bag...", overview = "English 2")
+                )
+            )
+        )
+
+        val result = TmdbMetadataService(api).fetchEpisodeEnrichment(
+            tmdbId = "42",
+            seasonNumbers = listOf(1),
+            language = "pl-PL"
+        )
+
+        assertEquals("Pilot", result[1 to 1]?.title)
+        assertEquals("English 1", result[1 to 1]?.overview)
+        assertEquals("Prawdziwy tytuł", result[1 to 2]?.title)
+        assertEquals("Polski opis", result[1 to 2]?.overview)
     }
 
     @Test


### PR DESCRIPTION
## Summary

When TMDB has no episode translation for the user's language, season enrichment often returns blank text or the generic `Episode N` placeholder. This overwrote better titles across details, Continue Watching, and player surfaces.

This PR:
1. Fetches English season data as a fallback whenever the preferred language is non-English
2. Merges per-episode fields so real localized titles win, then real English titles, and only then placeholders
3. Fills missing overview / still / air date / runtime from English
4. When applying enrichment in details, keeps a real addon title if TMDB still only has a placeholder

## PR type

- [x] Critical bug fix

## Why

Missing episode translations should fall back to English/original titles, not generic `Episode 1` / `Episode 2` labels. This matches existing trailer fallback behavior (`en-US`) and fixes the global localization gap reported in #2385.

## Issue or approval

Fixes #2385

## Reproduction steps

1. Set app / TMDB language to a non-English locale (e.g. Italian, Polish).
2. Open a TV show whose episodes lack translations for that language on TMDB.
3. Open the show details episode list (also check Continue Watching / player episode title).
4. Before: titles show `Episode N` (or localized equivalent of the generic placeholder).
5. After: titles show the English (or real addon) episode name when one exists; descriptions also fall back to English when localized overview is empty.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change movie/show-level title localization policy (existing `localizedTitle` nulling when equal to original remains).
- Does not change TMDB settings toggles or addon catalog parsing.
- Does not add UI chrome or settings.
- English preferred language still uses a single season fetch (no double network call).

## Testing

- `./gradlew :app:compileFullDebugKotlin` — **BUILD SUCCESSFUL** on the rebased branch.
- Added regression coverage for locale-aware placeholder detection, per-episode partial-season merging, and a mocked Polish (`pl-PL`) → English (`en-US`) fetch.
- The targeted unit-test task currently stops during test-source compilation because current `dev` has unrelated constructor/type errors in four existing test files. None of those files are changed by this PR; details are in the latest PR comment.
- `git diff --check` — clean.

## Screenshots / Video

Not a visual redesign — episode title/description text content only.

## Breaking changes

None.

## Linked issues

Fixes #2385