### PR TITLE
fix(plugin): raise plugin fetch response limit to 2MB (#1921)

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/FetchResponseBody.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/FetchResponseBody.kt
@@ -1,0 +1,38 @@
+package com.nuvio.tv.core.plugin
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.charset.Charset
+
+internal const val MAX_FETCH_RESPONSE_BYTES = 2 * 1024 * 1024
+internal const val MAX_FETCH_BODY_CHARS = 2 * 1024 * 1024
+
+internal data class BoundedReadResult(
+    val bytes: ByteArray,
+    val truncated: Boolean
+)
+
+internal fun decodeBodyToSafeString(bytes: ByteArray, charset: Charset): String {
+    val decoded = try {
+        String(bytes, charset)
+    } catch (_: Exception) {
+        String(bytes, Charsets.UTF_8)
+    }
+    return truncateString(decoded, MAX_FETCH_BODY_CHARS)
+}
+
+internal fun readAtMostBytes(stream: InputStream, maxBytes: Int): BoundedReadResult {
+    val out = ByteArrayOutputStream(minOf(maxBytes, 16 * 1024))
+    val buffer = ByteArray(8 * 1024)
+    var remaining = maxBytes
+
+    while (remaining > 0) {
+        val read = stream.read(buffer, 0, minOf(buffer.size, remaining))
+        if (read <= 0) break
+        out.write(buffer, 0, read)
+        remaining -= read
+    }
+
+    val truncated = remaining == 0 && stream.read() != -1
+    return BoundedReadResult(out.toByteArray(), truncated)
+}

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -38,8 +38,8 @@ import javax.inject.Singleton
 
 private const val TAG = "PluginRuntime"
 private const val PLUGIN_TIMEOUT_MS = 60_000L
-private const val MAX_FETCH_RESPONSE_BYTES = 1024 * 1024
-private const val MAX_FETCH_BODY_CHARS = 1024 * 1024
+private const val MAX_FETCH_RESPONSE_BYTES = 2 * 1024 * 1024
+private const val MAX_FETCH_BODY_CHARS = 2 * 1024 * 1024
 @Singleton
 class PluginRuntime @Inject constructor() {
 

--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -23,7 +23,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
-import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URL
 import java.util.Base64
@@ -38,8 +37,6 @@ import javax.inject.Singleton
 
 private const val TAG = "PluginRuntime"
 private const val PLUGIN_TIMEOUT_MS = 60_000L
-private const val MAX_FETCH_RESPONSE_BYTES = 2 * 1024 * 1024
-private const val MAX_FETCH_BODY_CHARS = 2 * 1024 * 1024
 @Singleton
 class PluginRuntime @Inject constructor() {
 
@@ -614,38 +611,6 @@ class PluginRuntime @Inject constructor() {
                 "headers" to emptyMap<String, String>()
             ))
         }
-    }
-
-    private data class BoundedReadResult(
-        val bytes: ByteArray,
-        val truncated: Boolean
-    )
-
-    private fun decodeBodyToSafeString(bytes: ByteArray, charset: java.nio.charset.Charset): String {
-        val decoded = try {
-            String(bytes, charset)
-        } catch (e: Exception) {
-            String(bytes, Charsets.UTF_8)
-        }
-        return truncateString(decoded, MAX_FETCH_BODY_CHARS)
-    }
-
-    private fun readAtMostBytes(stream: InputStream, maxBytes: Int): BoundedReadResult {
-        val out = ByteArrayOutputStream(minOf(maxBytes, 16 * 1024))
-        val buffer = ByteArray(8 * 1024)
-        var remaining = maxBytes
-        var truncated = false
-
-        while (remaining > 0) {
-            val read = stream.read(buffer, 0, minOf(buffer.size, remaining))
-            if (read <= 0) break
-            out.write(buffer, 0, read)
-            remaining -= read
-        }
-        if (remaining == 0) {
-            truncated = stream.read() != -1
-        }
-        return BoundedReadResult(out.toByteArray(), truncated)
     }
 
     private fun parseUrl(urlString: String): String {

--- a/app/src/testFull/java/com/nuvio/tv/core/plugin/FetchResponseBodyTest.kt
+++ b/app/src/testFull/java/com/nuvio/tv/core/plugin/FetchResponseBodyTest.kt
@@ -1,0 +1,31 @@
+package com.nuvio.tv.core.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FetchResponseBodyTest {
+
+    @Test
+    fun `response above one megabyte is preserved within production limit`() {
+        val payload = ByteArray(1024 * 1024 + 1) { 'a'.code.toByte() }
+
+        val result = readAtMostBytes(payload.inputStream(), MAX_FETCH_RESPONSE_BYTES)
+        val decoded = decodeBodyToSafeString(result.bytes, Charsets.UTF_8)
+
+        assertEquals(payload.size, result.bytes.size)
+        assertEquals(payload.size, decoded.length)
+        assertFalse(result.truncated)
+    }
+
+    @Test
+    fun `response above production limit is truncated and reported`() {
+        val payload = ByteArray(MAX_FETCH_RESPONSE_BYTES + 1) { 'a'.code.toByte() }
+
+        val result = readAtMostBytes(payload.inputStream(), MAX_FETCH_RESPONSE_BYTES)
+
+        assertEquals(MAX_FETCH_RESPONSE_BYTES, result.bytes.size)
+        assertTrue(result.truncated)
+    }
+}


### PR DESCRIPTION
## Summary

Raise plugin HTTP fetch response and decoded body caps from 1MB to 2MB so large plugin episode/metadata payloads are not truncated.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Plugins that bundle large episode lists/metadata in a single response hit `MAX_FETCH_RESPONSE_BYTES` and fail or return partial data on NuvioTV. The issue requested 2MB for parity with mobile/plugin needs; the limit had already moved to 1MB and still truncates large catalogs.

## Issue or approval

Fixes #1921

## Reproduction steps

1. Install a plugin whose metadata/episode endpoint returns a payload larger than 1MB (shows with many episodes).
2. Open a title that triggers that fetch on NuvioTV.
3. Observe truncated/failed plugin response before this change; after the change the full body is accepted up to 2MB.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The response/body limits are raised from 1 MB to 2 MB. The existing bounded-read and decode helpers are moved unchanged to `FetchResponseBody.kt` so the production boundary can be unit tested; no plugin fetch control-flow or network behavior changes.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.core.plugin.FetchResponseBodyTest" --tests "com.nuvio.tv.core.plugin.FetchResponseHeadersTest" :app:compileFullDebugKotlin` — **BUILD SUCCESSFUL**.
- Regression test proves a 1 MB + 1 byte ASCII response is preserved by both byte and decoded-character limits.
- Boundary test proves a 2 MB + 1 byte response is truncated to exactly 2 MB and reports `truncated = true`.

## Screenshots / Video

Not a UI change

## Breaking changes

None. Higher cap only; smaller responses unchanged.

## Linked issues

Fixes #1921