### PR TITLE
fix(auth): hide raw Supabase request details from login errors (#2536)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/auth/AuthManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/auth/AuthManager.kt
@@ -325,7 +325,7 @@ class AuthManager @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Sign up failed", e)
             diagnostics.finishFailure("signup_failed", AUTH_ENDPOINT_SIGNUP, e.authHttpStatus(), e)
-            Result.failure(e)
+            Result.failure(e.toPublicAuthFailure())
         }
     }
 
@@ -351,7 +351,7 @@ class AuthManager @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Sign in failed", e)
             diagnostics.finishFailure("password_login_failed", AUTH_ENDPOINT_PASSWORD, e.authHttpStatus(), e)
-            Result.failure(e)
+            Result.failure(e.toPublicAuthFailure())
         }
     }
 
@@ -792,7 +792,127 @@ private class AuthHttpException(
     val endpoint: String,
     val statusCode: Int,
     val responseBody: String
-) : Exception("Auth request failed endpoint=$endpoint status=$statusCode body=$responseBody")
+) : Exception(authHttpExceptionMessage(statusCode, responseBody))
+
+/**
+ * Keep [AuthHttpException.message] free of raw request/response dumps (endpoint, headers, bodies)
+ * while preserving known error markers so UI mapping can still classify failures.
+ */
+private fun authHttpExceptionMessage(statusCode: Int, responseBody: String): String {
+    val lower = responseBody.lowercase()
+    val marker = AUTH_ERROR_MARKERS.firstOrNull { lower.contains(it) }
+    return if (marker != null) {
+        "Auth request failed status=$statusCode $marker"
+    } else {
+        "Auth request failed status=$statusCode"
+    }
+}
+
+/** Markers extracted from auth/RPC bodies for classification — never the full payload. */
+private val AUTH_ERROR_MARKERS = listOf(
+    "invalid login credentials",
+    "invalid_credentials",
+    "email not confirmed",
+    "user already registered",
+    "invalid email",
+    "signup is disabled",
+    "too many requests",
+    "rate limit",
+    "incorrect pin",
+    "invalid pin",
+    "wrong pin",
+    "already linked",
+    "empty response",
+    "not authenticated",
+    "invalid_grant",
+    "invalid refresh token",
+    "refresh token is not valid",
+    "refresh token not found",
+    "refresh_token_not_found",
+    "session not found",
+    "session_not_found",
+    "invalid session",
+    "invalid token",
+    "could not find the function",
+    "gen_random_bytes",
+    "invalid tv login redirect base url",
+    "invalid device nonce",
+    "tv login",
+    "no sync code",
+    "cloudflare",
+    "cf-error-code",
+    "password should be",
+    "password is too short",
+    "password is too weak",
+    "weak password",
+)
+
+/**
+ * Exception returned from password login/signup Result.failure so UI/debug never receives
+ * raw Supabase/Ktor request dumps (URL, headers, apikey previews, User-Agent, etc.).
+ */
+private fun Throwable.toPublicAuthFailure(): Exception {
+    val authHttp = findCause<AuthHttpException>()
+    val haystack = buildString {
+        append(causeMessages())
+        if (authHttp != null) {
+            append(' ')
+            append(authHttp.responseBody)
+        }
+    }.lowercase()
+
+    val safeMessage = when {
+        haystack.contains("invalid login credentials") ||
+            haystack.contains("invalid_credentials") ||
+            haystack.contains("invalid_grant") ->
+            "Invalid login credentials"
+        haystack.contains("email not confirmed") ->
+            "Email not confirmed"
+        haystack.contains("user already registered") ->
+            "User already registered"
+        haystack.contains("invalid email") ->
+            "Invalid email"
+        haystack.contains("password") && (haystack.contains("short") || haystack.contains("at least")) ->
+            "Password is too short"
+        haystack.contains("password") && haystack.contains("weak") ->
+            "Password is too weak"
+        haystack.contains("signup is disabled") ->
+            "Signup is disabled"
+        haystack.contains("rate limit") || haystack.contains("too many requests") || authHttp?.statusCode == 429 ->
+            "Rate limit exceeded"
+        hasCause<UnknownHostException>() ->
+            "Unable to resolve host"
+        hasCause<SocketTimeoutException>() || hasCause<HttpRequestTimeoutException>() ->
+            "Connection timed out"
+        hasCause<ConnectException>() || hasCause<NoRouteToHostException>() ->
+            "Connection refused"
+        authHttp?.statusCode == 404 || haystack.contains("could not find") ->
+            "Service unavailable"
+        authHttp?.statusCode in 500..599 ->
+            "Service unavailable"
+        authHttp?.statusCode == 400 || haystack.contains("bad request") ->
+            "Bad request"
+        looksLikeRawAuthHttpDump(haystack) ->
+            "Authentication failed"
+        else ->
+            message?.takeIf { it.isNotBlank() && !looksLikeRawAuthHttpDump(it) }
+                ?: "Authentication failed"
+    }
+    // Do not attach the original cause: callers may surface exception.message / diagnosticSummary.
+    return Exception(safeMessage)
+}
+
+private fun looksLikeRawAuthHttpDump(text: String): Boolean {
+    val lower = text.lowercase()
+    return lower.contains("headers:") ||
+        lower.contains("http method") ||
+        lower.contains("x-client-info") ||
+        lower.contains("x-supabase-client") ||
+        lower.contains("apikey=") ||
+        lower.contains("grant_type=") ||
+        (lower.contains("authorization=") && lower.contains("bearer")) ||
+        (lower.contains("url:") && lower.contains("/auth/v1/"))
+}
 
 private fun Headers.toDiagnosticMap(): Map<String, String> =
     names().associateWith { name -> values(name).joinToString(", ") }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/account/AccountViewModel.kt
@@ -552,28 +552,24 @@ class AccountViewModel @Inject constructor(
     }
 
     private fun userFriendlyError(e: Throwable): String {
-        val raw = e.message ?: ""
-        val message = raw.lowercase()
-        val compactRaw = raw.bodySnippetForLog()
-        Log.w(TAG, "Raw error: $compactRaw")
+        // Match against the full cause chain so wrappers still classify correctly.
+        // Never return raw exception text — request dumps (headers, apikey, endpoints) must stay out of UI.
+        val message = e.diagnosticSummary().lowercase()
+        Log.w(TAG, "Raw error: ${e.diagnosticSummary().bodySnippetForLog()}")
 
         val resId = when {
             // PIN errors (from PG RAISE EXCEPTION or any wrapper)
             message.contains("incorrect pin") || message.contains("invalid pin") || message.contains("wrong pin") -> R.string.account_error_incorrect_pin
 
-            // Sync code errors
-            message.contains("expired") -> R.string.account_error_sync_code_expired
-            message.contains("invalid") && message.contains("code") -> R.string.account_error_invalid_sync_code
-            message.contains("not found") || message.contains("no sync code") -> R.string.account_error_sync_code_not_found
-            message.contains("already linked") -> R.string.account_error_device_already_linked
-            message.contains("empty response") -> R.string.account_error_generic_retry
-
-            // Auth errors
-            message.contains("invalid login credentials") -> R.string.account_error_invalid_credentials
+            // Auth errors first (before generic "invalid"+"code" which matches invalid_credentials JSON)
+            message.contains("invalid login credentials") ||
+                message.contains("invalid_credentials") ||
+                message.contains("invalid_grant") -> R.string.account_error_invalid_credentials
             message.contains("email not confirmed") -> R.string.account_error_email_not_confirmed
             message.contains("user already registered") -> R.string.account_error_email_already_registered
             message.contains("invalid email") -> R.string.account_error_invalid_email
-            message.contains("password") && message.contains("short") -> R.string.account_error_password_too_short
+            message.contains("password") && (message.contains("short") || message.contains("at least")) ->
+                R.string.account_error_password_too_short
             message.contains("password") && message.contains("weak") -> R.string.account_error_password_too_weak
             message.contains("signup is disabled") -> R.string.account_error_signup_disabled
             message.contains("rate limit") || message.contains("too many requests") -> R.string.account_error_rate_limited
@@ -589,6 +585,13 @@ class AccountViewModel @Inject constructor(
             message.contains("invalid device nonce") ->
                 R.string.account_error_qr_login_invalid_request
 
+            // Sync code errors
+            message.contains("expired") -> R.string.account_error_sync_code_expired
+            message.contains("invalid") && message.contains("code") -> R.string.account_error_invalid_sync_code
+            message.contains("not found") || message.contains("no sync code") -> R.string.account_error_sync_code_not_found
+            message.contains("already linked") -> R.string.account_error_device_already_linked
+            message.contains("empty response") -> R.string.account_error_generic_retry
+
             // Network errors
             message.contains("unable to resolve host") || message.contains("no address associated") -> R.string.account_error_no_internet
             message.contains("timeout") || message.contains("timed out") -> R.string.account_error_connection_timeout
@@ -601,7 +604,7 @@ class AccountViewModel @Inject constructor(
             message.contains("404") || message.contains("could not find") -> R.string.account_error_service_unavailable
             message.contains("400") || message.contains("bad request") -> R.string.account_error_invalid_request
 
-            // Fallback
+            // Fallback — never surface raw exception / request dump text
             else -> R.string.account_error_unexpected
         }
         return context.getString(resId)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebugSettingsViewModel.kt
@@ -104,12 +104,34 @@ class DebugSettingsViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             signInLoading = false,
-                            signInResult = if (result.isSuccess) context.getString(R.string.debug_signin_success) else context.getString(R.string.debug_generate_result_failed, result.exceptionOrNull()?.message ?: "")
+                            // AuthManager.signInWithEmail already returns a sanitized public message;
+                            // never fall back to dumping raw HTTP exception details into the UI.
+                            signInResult = if (result.isSuccess) {
+                                context.getString(R.string.debug_signin_success)
+                            } else {
+                                val safe = result.exceptionOrNull()?.message
+                                    ?.takeIf { it.isNotBlank() && !it.looksLikeRawAuthDebugDump() }
+                                    ?: context.getString(R.string.account_error_unexpected)
+                                context.getString(R.string.debug_generate_result_failed, safe)
+                            }
                         )
                     }
                 }
             }
         }
+    }
+
+    private fun String.looksLikeRawAuthDebugDump(): Boolean {
+        val lower = lowercase()
+        return lower.contains("headers:") ||
+            lower.contains("http method") ||
+            lower.contains("x-client-info") ||
+            lower.contains("x-supabase-client") ||
+            lower.contains("apikey=") ||
+            lower.contains("grant_type=") ||
+            (lower.contains("authorization=") && lower.contains("bearer")) ||
+            (lower.contains("url:") && lower.contains("/auth/v1/")) ||
+            (lower.contains("endpoint=") && lower.contains("body="))
     }
 
     private suspend fun generateRandomLibraryItems(count: Int) {


### PR DESCRIPTION
## Summary

Stop surfacing raw Supabase/HTTP request dumps (endpoints, grant_type, header previews, client metadata) in login error UI. Map failures to short public messages; keep diagnostics in logs only.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Invalid credentials could show raw HTTP exception text in the UI, including request internals. That is a security/UX defect: users should see a normal message (e.g. invalid credentials), not auth endpoint and header previews.

Note: the original report is from NuvioDesktop; this hardens the shared NuvioTV auth path (`AuthManager` / account + debug sign-in) that builds the same class of error strings.

## Issue or approval

Addresses #2536

## Reproduction steps

1. Open sign-in (or debug email/password sign-in where available).
2. Enter invalid email/password and submit.
3. Before: UI could show raw HTTP dump (URL, headers, grant_type, apikey/Authorization previews).
4. After: UI shows a short public error only; full diagnostics remain in Logcat.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Auth error message mapping only (`AuthManager`, `AccountViewModel`, `DebugSettingsViewModel`). No auth protocol or session logic redesign. Desktop-only repository may still need a separate follow-up if it has its own error formatter.

## Testing

- Traced invalid-login path: public failures no longer embed endpoint/body dumps; `userFriendlyError` never returns raw exception text.
- Credential markers classified before generic "invalid code" heuristics.
- Logic review only; no device run (CI fullDebug build).

## Screenshots / Video

Not a visual redesign — error string sanitization only. Screenshots optional after CI.

## Breaking changes

None for successful auth. Failure messages become shorter/safer.

## Linked issues

Addresses #2536