### PR TITLE
fix(search): clear failed catalog placeholders (#2917 follow-up)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -85,6 +85,7 @@ class SearchViewModel @Inject constructor(
     private var lastCompletedRequestKey: String? = null
     private var hasRenderedFirstCatalog = false
     private var pendingCatalogResponses = 0
+    private var catalogErrorMessage: String? = null
     private var revealBatchAfterNextDiscoverFetch = false
     private var hideUnreleasedContent = false
 
@@ -369,6 +370,7 @@ class SearchViewModel @Inject constructor(
         catalogOrder.clear()
         hasRenderedFirstCatalog = false
         pendingCatalogResponses = 0
+        catalogErrorMessage = null
     }
 
     private fun cancelSearchRun() {
@@ -567,7 +569,14 @@ class SearchViewModel @Inject constructor(
                     uiState.value.submittedQuery.trim() == query
                 ) {
                     lastCompletedRequestKey = requestKey
-                    _uiState.update { it.copy(isSearching = false) }
+                    val errorMessage = catalogErrorMessage
+                    val hasResults = catalogsMap.values.any { row -> row.items.isNotEmpty() }
+                    _uiState.update {
+                        it.copy(
+                            isSearching = false,
+                            error = if (hasResults) null else errorMessage
+                        )
+                    }
                     // Remembered once it has actually returned something, so backing out still
                     // saves what you typed while typos that match nothing never get recorded.
                     if (catalogsMap.values.any { row -> row.items.isNotEmpty() }) {
@@ -616,11 +625,32 @@ class SearchViewModel @Inject constructor(
                 }
                 is NetworkResult.Error -> {
                     if (!isCurrentSearch(generation, query)) return@collect
+                    val key = catalogKey(
+                        addonId = addon.id,
+                        addonBaseUrl = addon.baseUrl,
+                        type = catalog.apiType,
+                        catalogId = catalog.id
+                    )
+                    // Replace the skeleton with an empty completed row. Removing the map entry
+                    // would let updateCatalogRowsNow fall back to the old placeholder row.
+                    catalogsMap[key] = CatalogRow(
+                        addonId = addon.id,
+                        addonName = addon.displayName,
+                        addonBaseUrl = addon.baseUrl,
+                        catalogId = catalog.id,
+                        catalogName = catalog.name,
+                        type = ContentType.fromString(catalog.apiType),
+                        rawType = catalog.apiType,
+                        items = emptyList(),
+                        isLoading = false,
+                        hasMore = false,
+                        currentPage = 0,
+                        supportsSkip = supportsSkip,
+                        skipStep = skipStep,
+                        extraArgs = mapOf("search" to query)
+                    )
                     pendingCatalogResponses = (pendingCatalogResponses - 1).coerceAtLeast(0)
-                    // Ignore per-catalog errors unless we have nothing to show.
-                    if (catalogsMap.isEmpty()) {
-                        _uiState.update { it.copy(error = result.message ?: context.getString(com.nuvio.tv.R.string.search_error_failed)) }
-                    }
+                    catalogErrorMessage = catalogErrorMessage ?: result.message
                     scheduleCatalogRowsUpdate()
                 }
                 NetworkResult.Loading -> {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -14,6 +14,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.repository.WatchProgressRepository
 import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
 import io.mockk.every
@@ -34,6 +35,8 @@ import kotlinx.coroutines.test.runCurrent
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -89,6 +92,41 @@ class SearchViewModelConcurrencyTest {
         assertEquals(listOf("Deep Cover"), catalogRepository.queries.distinct())
     }
 
+    @Test
+    fun `failed catalog removes its placeholder while retaining successful results`() = runTest {
+        val addon = searchableAddon(catalogIds = listOf("success", "failure"))
+        val viewModel = newViewModel(
+            addonRepository = StaticAddonRepository(addon),
+            catalogRepository = SearchResultCatalogRepository(addon, failedCatalogIds = setOf("failure"))
+        )
+
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep Cover"))
+        viewModel.onEvent(SearchEvent.SubmitSearch)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSearching)
+        assertNull(viewModel.uiState.value.error)
+        assertEquals(listOf("success"), viewModel.uiState.value.catalogRows.map { it.catalogId })
+        assertTrue(viewModel.uiState.value.catalogRows.none { row -> row.isLoading })
+    }
+
+    @Test
+    fun `all failed catalogs clear placeholders and show a global error`() = runTest {
+        val addon = searchableAddon(catalogIds = listOf("failure"))
+        val viewModel = newViewModel(
+            addonRepository = StaticAddonRepository(addon),
+            catalogRepository = SearchResultCatalogRepository(addon, failedCatalogIds = setOf("failure"))
+        )
+
+        viewModel.onEvent(SearchEvent.QueryChanged("Deep Cover"))
+        viewModel.onEvent(SearchEvent.SubmitSearch)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSearching)
+        assertTrue(viewModel.uiState.value.catalogRows.isEmpty())
+        assertNotNull(viewModel.uiState.value.error)
+    }
+
     private fun newViewModel(
         addonRepository: AddonRepository,
         catalogRepository: CatalogRepository
@@ -112,9 +150,12 @@ class SearchViewModelConcurrencyTest {
         val watchedSeries = mockk<WatchedSeriesStateHolder>()
         every { watchedSeries.fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
 
+        val metaRepository = mockk<MetaRepository>(relaxed = true)
+
         return SearchViewModel(
             addonRepository = addonRepository,
             catalogRepository = catalogRepository,
+            metaRepository = metaRepository,
             layoutPreferenceDataStore = layoutPreferences,
             searchHistoryDataStore = history,
             watchProgressRepository = watchProgress,
@@ -136,6 +177,18 @@ class SearchViewModelConcurrencyTest {
             }
             emit(listOf(addon))
         }
+
+        override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> = error("unused")
+        override suspend fun addAddon(url: String) = error("unused")
+        override suspend fun removeAddon(url: String) = error("unused")
+        override suspend fun setAddonOrder(urls: List<String>) = error("unused")
+        override suspend fun setAddonEnabled(url: String, enabled: Boolean) = error("unused")
+    }
+
+    private class StaticAddonRepository(
+        private val addon: Addon
+    ) : AddonRepository {
+        override fun getInstalledAddons(): Flow<List<Addon>> = flowOf(listOf(addon))
 
         override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> = error("unused")
         override suspend fun addAddon(url: String) = error("unused")
@@ -192,13 +245,64 @@ class SearchViewModelConcurrencyTest {
         )
     }
 
-    private fun searchableAddon(): Addon {
-        val catalog = CatalogDescriptor(
+    private class SearchResultCatalogRepository(
+        private val addon: Addon,
+        private val failedCatalogIds: Set<String>
+    ) : CatalogRepository {
+        override fun getCatalog(
+            addonBaseUrl: String,
+            addonId: String,
+            addonName: String,
+            catalogId: String,
+            catalogName: String,
+            type: String,
+            skip: Int,
+            skipStep: Int,
+            extraArgs: Map<String, String>,
+            supportsSkip: Boolean
+        ): Flow<NetworkResult<CatalogRow>> = flow {
+            emit(NetworkResult.Loading)
+            if (catalogId in failedCatalogIds) {
+                emit(NetworkResult.Error("$catalogName failed"))
+            } else {
+                emit(NetworkResult.Success(row(catalogId, extraArgs.getValue("search"))))
+            }
+        }
+
+        private fun row(catalogId: String, query: String): CatalogRow = CatalogRow(
+            addonId = addon.id,
+            addonName = addon.displayName,
+            addonBaseUrl = addon.baseUrl,
+            catalogId = catalogId,
+            catalogName = addon.catalogs.first { it.id == catalogId }.name,
             type = ContentType.MOVIE,
-            id = "top",
-            name = "Top",
-            extra = listOf(CatalogExtra(name = "search"))
+            items = listOf(
+                MetaPreview(
+                    id = query,
+                    type = ContentType.MOVIE,
+                    name = query,
+                    poster = null,
+                    posterShape = PosterShape.POSTER,
+                    background = null,
+                    logo = null,
+                    description = null,
+                    releaseInfo = null,
+                    imdbRating = null,
+                    genres = emptyList()
+                )
+            )
         )
+    }
+
+    private fun searchableAddon(catalogIds: List<String> = listOf("top")): Addon {
+        val catalogs = catalogIds.map { id ->
+            CatalogDescriptor(
+                type = ContentType.MOVIE,
+                id = id,
+                name = id.replaceFirstChar(Char::uppercase),
+                extra = listOf(CatalogExtra(name = "search"))
+            )
+        }
         return Addon(
             id = "addon",
             name = "Addon",
@@ -206,7 +310,7 @@ class SearchViewModelConcurrencyTest {
             description = null,
             logo = null,
             baseUrl = "https://example.test",
-            catalogs = listOf(catalog),
+            catalogs = catalogs,
             types = listOf(ContentType.MOVIE),
             resources = emptyList()
         )


### PR DESCRIPTION
## Summary

Clear a search catalog's stale loading row when that catalog finishes with an error. Successful catalog results remain visible, and a global error is shown only when every catalog failed to return results.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Follow-up investigation of #2917 / #2938 found a second concrete completion bug. A catalog request already follows the finite production contract `Loading -> Success/Error`, but Search handled `Error` by decrementing its counter without replacing the catalog's placeholder. The renderer then recovered the old `isLoading` row, leaving shimmer on screen after the request had already failed.

The reporter's remaining case disappeared after reinstalling Cinemeta from its official source, which is consistent with an invalid/stale catalog configuration returning an error. This PR addresses that terminal-error path directly; it does not add a speculative request timeout.

## Issue or approval

Follow-up to #2917 and merged PR #2938.

## Reproduction steps

1. Start a search with two searchable catalogs.
2. Let one catalog return results and the other return `NetworkResult.Error` after `Loading`.
3. Before: the failed catalog's loading placeholder remains even though the search job completed.
4. After: the failed row disappears and the successful results remain without a global error.
5. If every catalog returns an error, all placeholders disappear, search settles, and the error state is shown.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No networking timeout, query encoding, addon synchronization, ranking, or catalog ordering changes. The previous speculative 30-second timeout draft #3017 was closed and is not included here.

## Testing

- Added mixed success + error coverage: the successful row remains, the failed placeholder is removed, `isSearching` becomes false, and no global error is shown.
- Added all-error coverage: rows are empty, `isSearching` becomes false, and the global error is present.
- `SearchViewModelConcurrencyTest`: **3 tests, 0 failures/errors**.
- `./gradlew :app:compileFullDebugKotlin`: **BUILD SUCCESSFUL**.
- `git diff --check`: clean.
- Current `dev` has four unrelated stale test fixtures (`Flow<TmdbSettings>` vs `StateFlow<TmdbSettings>`). For the targeted test run only, those mechanical fixture corrections were applied temporarily and then fully reverted before this commit.

## Screenshots / Video

Not a UI layout change; this removes a stale shimmer row after a terminal catalog error.

## Breaking changes

None.

## Linked issues

- Follow-up to #2917
- Follow-up to #2938