### PR TITLE
Remember playback speed per show

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TrackPreferenceDataStore.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.local
 
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.nuvio.tv.core.profile.ProfileManager
@@ -30,6 +31,7 @@ class TrackPreferenceDataStore @Inject constructor(
         // one episode is not blindly reapplied to the next episode where it is
         // almost certainly wrong.
         private const val SUB_DELAY_MS = "sub_delay_ms"
+        private const val PLAYBACK_SPEED = "playback_speed"
     }
 
     private fun store() = factory.get(profileManager.activeProfileId.value, FEATURE)
@@ -39,6 +41,9 @@ class TrackPreferenceDataStore @Inject constructor(
 
     private fun intKey(field: String, id: String) =
         intPreferencesKey("$field|$id")
+
+    private fun floatKey(field: String, id: String) =
+        floatPreferencesKey("$field|$id")
 
     suspend fun save(contentId: String, pref: PersistedTrackPreference) {
         store().edit { prefs ->
@@ -103,6 +108,17 @@ class TrackPreferenceDataStore @Inject constructor(
 
     suspend fun loadSubtitleDelayMs(videoId: String): Int? {
         return store().data.first()[intKey(SUB_DELAY_MS, videoId)]
+    }
+
+    suspend fun savePlaybackSpeed(contentId: String, speed: Float?) {
+        store().edit { prefs ->
+            val k = floatKey(PLAYBACK_SPEED, contentId)
+            if (speed != null && speed != 1f) prefs[k] = speed else prefs.remove(k)
+        }
+    }
+
+    suspend fun loadPlaybackSpeed(contentId: String): Float? {
+        return store().data.first()[floatKey(PLAYBACK_SPEED, contentId)]
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1322,6 +1322,9 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
                     showSubtitleDelayOverlay = false
                 )
             }
+            contentId?.takeIf { it.isNotBlank() }?.let { id ->
+                scope.launch { trackPreferenceDataStore.savePlaybackSpeed(id, event.speed) }
+            }
         }
         PlayerEvent.OnToggleControls -> {
             if (_uiState.value.showSubtitleTimingDialog) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerScrobble.kt
@@ -93,6 +93,11 @@ internal fun PlayerRuntimeController.preparePlaybackBeforeStart(
                     "subtitle=${persistedTrackPreference?.subtitle?.javaClass?.simpleName ?: "none"}"
             )
         }
+        contentId?.takeIf { it.isNotBlank() }?.let { id ->
+            trackPreferenceDataStore.loadPlaybackSpeed(id)?.let { speed ->
+                _uiState.update { it.copy(playbackSpeed = speed) }
+            }
+        }
         // Load saved watch progress BEFORE player init.
         // This eliminates the race condition where ExoPlayer's STATE_READY
         // callback fired before the DB read completed, causing the resume


### PR DESCRIPTION
## Summary

Playback speed is now remembered per show. When a speed is picked in the player it is persisted against the
`contentId` in `TrackPreferenceDataStore` (the same per-profile store already used for audio/subtitle track
preferences) and restored on the next playback of that show. `1.0x` clears the entry rather than storing it.

No UI, no setting, no new dependency. Three files, ~20 lines. Surgical fix.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Speed preference is per-show in practice (a viewer speeds up one series' dialogue-heavy episodes, not everything),
but currently it resets to 1.0x on every launch and has to be re-set for every episode.

## Issue or approval

Refs #3194 — "[Bug]: playback speed is not preserved/persistent" (open, labeled `bug`).

## Reproduction steps

Not a bug fix. Behavior comparison:

1. Play any episode of show A, set speed to 1.5x, exit the player.
2. Play another episode of show A.
   - Old: playback starts at 1.0x.
   - New: playback starts at 1.5x.
3. Play show B — starts at 1.0x, unaffected.
4. Set show A back to 1.0x — the stored entry is removed.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed:

- Issue #3194.
- No settings entry, toggle, or any other visible surface — the behavior is implicit.
- No global/default speed preference; scope is per-show only.
- Speed is keyed by `contentId`, deliberately not by `videoId`.
- No migration for existing installs; shows simply start at 1.0x until a speed is set once.
- No change to `PlaybackSpeedAwareAudioSink` or the speed dialog itself.

## Testing

Manual, on a physical **onn. 4K Plus Streaming (Android 14, armeabi-v7a)** via a `fullDebug` build installed with
`adb`:

- Set 1.5x on a series, left the player, replayed a different episode of the same series — restored at 1.5x, and
  the audio sink came up with the speed already applied (no 1.0x flash on start).
- Played an unrelated title — started at 1.0x.
- Reset to 1.0x and replayed — started at 1.0x, entry removed from the store.
- Verified across both the ExoPlayer and mpv engine paths, since both read `_uiState.value.playbackSpeed` at
  initialization.
- Restored value is applied before `initializePlayer()`, so it is picked up by the renderer factory rather than
  applied after playback has already begun.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Refs #3194
