### PR TITLE
Add Android TV library calendar and recommendations

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -47,6 +47,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -746,6 +747,7 @@ class MainActivity : ComponentActivity() {
                             add(Screen.Home.route)
                             add(Screen.Search.route)
                             add(Screen.Library.route)
+                            add(Screen.Calendar.route)
                             add(Screen.Settings.route)
                             if (discoverLocation == DiscoverLocation.IN_SIDEBAR) {
                                 add(Screen.Discover.route)
@@ -757,12 +759,14 @@ class MainActivity : ComponentActivity() {
                     val strNavDiscover = stringResource(R.string.nav_discover)
                     val strNavSearch = stringResource(R.string.nav_search)
                     val strNavLibrary = stringResource(R.string.nav_library)
+                    val strNavCalendar = stringResource(R.string.nav_calendar)
                     val strNavSettings = stringResource(R.string.nav_settings)
                     val drawerItems = remember(
                         strNavHome,
                         strNavDiscover,
                         strNavSearch,
                         strNavLibrary,
+                        strNavCalendar,
                         strNavSettings,
                         discoverLocation
                     ) {
@@ -795,6 +799,13 @@ class MainActivity : ComponentActivity() {
                                     route = Screen.Library.route,
                                     label = strNavLibrary,
                                     iconRes = R.raw.sidebar_library
+                                )
+                            )
+                            add(
+                                DrawerItem(
+                                    route = Screen.Calendar.route,
+                                    label = strNavCalendar,
+                                    icon = Icons.Default.DateRange
                                 )
                             )
                             add(

--- a/app/src/main/java/com/nuvio/tv/core/calendar/CalendarEpisodeBuilder.kt
+++ b/app/src/main/java/com/nuvio/tv/core/calendar/CalendarEpisodeBuilder.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.core.calendar
+
+import com.nuvio.tv.data.remote.api.TmdbEpisode
+import com.nuvio.tv.domain.model.CalendarDay
+import com.nuvio.tv.domain.model.CalendarEpisode
+import com.nuvio.tv.domain.model.LibraryEntry
+import java.time.LocalDate
+
+object CalendarEpisodeBuilder {
+    fun build(
+        show: LibraryEntry,
+        tmdbId: Int,
+        seasonNumber: Int,
+        episodes: List<TmdbEpisode>,
+        today: LocalDate,
+        horizonDays: Long = 90
+    ): List<CalendarEpisode> {
+        val endDate = today.plusDays(horizonDays.coerceAtLeast(0))
+        return episodes.mapNotNull { episode ->
+            val episodeNumber = episode.episodeNumber ?: return@mapNotNull null
+            val airDate = runCatching { LocalDate.parse(episode.airDate) }.getOrNull()
+                ?: return@mapNotNull null
+            if (airDate < today || airDate > endDate) return@mapNotNull null
+            CalendarEpisode(
+                showId = show.id,
+                showTmdbId = tmdbId,
+                showName = show.name,
+                addonBaseUrl = show.addonBaseUrl,
+                poster = show.poster,
+                background = show.background,
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+                episodeName = episode.name?.takeIf(String::isNotBlank) ?: "Episode $episodeNumber",
+                overview = episode.overview?.takeIf(String::isNotBlank),
+                stillUrl = episode.stillPath?.let { "https://image.tmdb.org/t/p/w780$it" },
+                airDate = airDate
+            )
+        }.sortedWith(compareBy(CalendarEpisode::airDate, CalendarEpisode::showName, CalendarEpisode::episodeNumber))
+    }
+
+    fun groupByDay(episodes: List<CalendarEpisode>): List<CalendarDay> = episodes
+        .groupBy(CalendarEpisode::airDate)
+        .toSortedMap()
+        .map { (date, items) -> CalendarDay(date, items) }
+}

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -350,7 +350,17 @@ data class TmdbDetailsResponse(
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "last_air_date") val lastAirDate: String? = null,
     @Json(name = "status") val status: String? = null,
+    @Json(name = "next_episode_to_air") val nextEpisodeToAir: TmdbAiringEpisode? = null,
+    @Json(name = "last_episode_to_air") val lastEpisodeToAir: TmdbAiringEpisode? = null,
     @Json(name = "belongs_to_collection") val belongsToCollection: TmdbCollectionSummary? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TmdbAiringEpisode(
+    @Json(name = "season_number") val seasonNumber: Int? = null,
+    @Json(name = "episode_number") val episodeNumber: Int? = null,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "air_date") val airDate: String? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/nuvio/tv/data/repository/CalendarRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/CalendarRepository.kt
@@ -1,0 +1,109 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.core.calendar.CalendarEpisodeBuilder
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.domain.model.CalendarDay
+import com.nuvio.tv.domain.model.CalendarRecommendation
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.LibraryEntry
+import com.nuvio.tv.domain.repository.LibraryRepository
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+data class CalendarContent(
+    val days: List<CalendarDay>,
+    val recommendations: List<CalendarRecommendation>
+)
+
+@Singleton
+class CalendarRepository @Inject constructor(
+    private val libraryRepository: LibraryRepository,
+    private val tmdbApi: TmdbApi,
+    private val tmdbService: TmdbService,
+    private val tmdbMetadataService: TmdbMetadataService
+) {
+    suspend fun load(today: LocalDate = LocalDate.now()): CalendarContent {
+        val library = libraryRepository.libraryItems.first()
+        val shows = library.filter { it.type.equals("series", true) || it.type.equals("tv", true) }
+        val resolved = resolveShows(shows)
+        val days = loadEpisodes(resolved, today)
+        val recommendations = loadRecommendations(resolved, library)
+        return CalendarContent(days, recommendations)
+    }
+
+    private suspend fun resolveShows(shows: List<LibraryEntry>): List<Pair<LibraryEntry, Int>> = coroutineScope {
+        val semaphore = Semaphore(4)
+        shows.map { show ->
+            async {
+                semaphore.withPermit {
+                    val id = show.tmdbId ?: tmdbService.ensureTmdbId(show.imdbId ?: show.id, "series")?.toIntOrNull()
+                    id?.let { show to it }
+                }
+            }
+        }.awaitAll().filterNotNull()
+    }
+
+    private suspend fun loadEpisodes(
+        shows: List<Pair<LibraryEntry, Int>>,
+        today: LocalDate
+    ): List<CalendarDay> = coroutineScope {
+        val semaphore = Semaphore(4)
+        val episodes = shows.map { (show, tmdbId) ->
+            async {
+                semaphore.withPermit {
+                    runCatching {
+                        val details = tmdbApi.getTvDetails(tmdbId, BuildConfig.TMDB_API_KEY, "en-US").body()
+                        val season = details?.nextEpisodeToAir?.seasonNumber ?: return@runCatching emptyList()
+                        val seasonEpisodes = tmdbApi.getTvSeasonDetails(
+                            tmdbId, season, BuildConfig.TMDB_API_KEY, "en-US"
+                        ).body()?.episodes.orEmpty()
+                        CalendarEpisodeBuilder.build(show, tmdbId, season, seasonEpisodes, today)
+                    }.getOrDefault(emptyList())
+                }
+            }
+        }.awaitAll().flatten()
+        CalendarEpisodeBuilder.groupByDay(episodes)
+    }
+
+    private suspend fun loadRecommendations(
+        shows: List<Pair<LibraryEntry, Int>>,
+        library: List<LibraryEntry>
+    ): List<CalendarRecommendation> = coroutineScope {
+        val savedTmdbIds = library.mapNotNull { it.tmdbId }.toSet()
+        val semaphore = Semaphore(3)
+        val candidates = shows.take(8).map { (show, tmdbId) ->
+            async {
+                semaphore.withPermit {
+                    runCatching {
+                        tmdbMetadataService.fetchMoreLikeThis(tmdbId.toString(), ContentType.SERIES, maxItems = 10)
+                            .map { it to show.name }
+                    }.getOrDefault(emptyList())
+                }
+            }
+        }.awaitAll().flatten()
+
+        candidates
+            .filterNot { (item, _) -> item.id.removePrefix("tmdb:").toIntOrNull() in savedTmdbIds }
+            .groupBy { it.first.id }
+            .values
+            .map { matches ->
+                CalendarRecommendation(
+                    item = matches.first().first,
+                    recommendedBy = matches.map { it.second }.distinct().take(3),
+                    score = matches.size
+                )
+            }
+            .sortedWith(compareByDescending<CalendarRecommendation> { it.score }.thenBy { it.item.name })
+            .take(20)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/domain/model/CalendarModels.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/CalendarModels.kt
@@ -1,0 +1,28 @@
+package com.nuvio.tv.domain.model
+
+import java.time.LocalDate
+
+data class CalendarEpisode(
+    val showId: String,
+    val showTmdbId: Int,
+    val showName: String,
+    val addonBaseUrl: String?,
+    val poster: String?,
+    val background: String?,
+    val seasonNumber: Int,
+    val episodeNumber: Int,
+    val episodeName: String,
+    val overview: String?,
+    val stillUrl: String?,
+    val airDate: LocalDate
+) {
+    val videoId: String = "$showId:$seasonNumber:$episodeNumber"
+}
+
+data class CalendarDay(val date: LocalDate, val episodes: List<CalendarEpisode>)
+
+data class CalendarRecommendation(
+    val item: MetaPreview,
+    val recommendedBy: List<String>,
+    val score: Int
+)

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/NuvioNavHost.kt
@@ -26,6 +26,7 @@ import com.nuvio.tv.ui.screens.home.HomeScreen
 import com.nuvio.tv.ui.screens.addon.AddonManagerScreen
 import com.nuvio.tv.ui.screens.addon.CatalogOrderScreen
 import com.nuvio.tv.ui.screens.library.LibraryScreen
+import com.nuvio.tv.ui.screens.calendar.CalendarScreen
 import com.nuvio.tv.ui.screens.player.PlayerExitReason
 import com.nuvio.tv.ui.screens.player.PlayerScreen
 import com.nuvio.tv.ui.screens.plugin.PluginScreen
@@ -1052,6 +1053,25 @@ fun NuvioNavHost(
                             streamDescription = info.item.name
                         )
                     )
+                }
+            )
+        }
+
+        composable(Screen.Calendar.route) {
+            CalendarScreen(
+                onEpisodeClick = { episode ->
+                    navController.navigate(
+                        Screen.Detail.createRoute(
+                            episode.showId,
+                            "series",
+                            episode.addonBaseUrl,
+                            returnFocusSeason = episode.seasonNumber,
+                            returnFocusEpisode = episode.episodeNumber
+                        )
+                    )
+                },
+                onRecommendationClick = { recommendation ->
+                    navController.navigate(Screen.Detail.createRoute(recommendation.item.id, recommendation.item.apiType))
                 }
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/navigation/Screen.kt
@@ -132,6 +132,7 @@ sealed class Screen(val route: String) {
     data object Search : Screen("search")
     data object Discover : Screen("discover")
     data object Library : Screen("library")
+    data object Calendar : Screen("calendar")
     data object Settings : Screen("settings")
     data object Tracking : Screen("trakt")
     data object TmdbSettings : Screen("tmdb_settings")

--- a/app/src/main/java/com/nuvio/tv/ui/screens/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/calendar/CalendarScreen.kt
@@ -1,0 +1,106 @@
+package com.nuvio.tv.ui.screens.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.nuvio.tv.domain.model.CalendarEpisode
+import com.nuvio.tv.domain.model.CalendarRecommendation
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Composable
+fun CalendarScreen(
+    onEpisodeClick: (CalendarEpisode) -> Unit,
+    onRecommendationClick: (CalendarRecommendation) -> Unit,
+    viewModel: CalendarViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        when {
+            state.loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+            state.error != null -> Column(Modifier.align(Alignment.Center), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(state.error!!)
+                Text("Try again", Modifier.padding(top = 16.dp).clickable { viewModel.refresh() }, color = MaterialTheme.colorScheme.primary)
+            }
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(start = 56.dp, end = 32.dp, top = 32.dp, bottom = 48.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                item {
+                    Text("Calendar", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
+                    Text("New episodes from shows in your library", color = MaterialTheme.colorScheme.onBackground.copy(alpha = .7f))
+                }
+                if (state.days.isEmpty()) item { Text("No announced episodes in the next 90 days.") }
+                items(state.days, key = { it.date.toString() }) { day ->
+                    Text(day.date.calendarLabel(), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                    LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        items(day.episodes, key = { it.videoId }) { EpisodeCard(it) { onEpisodeClick(it) } }
+                    }
+                }
+                if (state.recommendations.isNotEmpty()) {
+                    item { Text("Because it’s in your library", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold) }
+                    item {
+                        LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                            items(state.recommendations, key = { it.item.id }) { recommendation ->
+                                RecommendationCard(recommendation) { onRecommendationClick(recommendation) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeCard(episode: CalendarEpisode, onClick: () -> Unit) {
+    Column(Modifier.width(300.dp).clip(RoundedCornerShape(12.dp)).clickable(onClick = onClick).padding(bottom = 10.dp)) {
+        AsyncImage(episode.stillUrl ?: episode.background ?: episode.poster, episode.episodeName, Modifier.fillMaxWidth().height(168.dp).clip(RoundedCornerShape(12.dp)), contentScale = ContentScale.Crop)
+        Text(episode.showName, Modifier.padding(top = 10.dp), fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text("S${episode.seasonNumber} E${episode.episodeNumber}  •  ${episode.episodeName}", maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onBackground.copy(alpha = .7f))
+    }
+}
+
+@Composable
+private fun RecommendationCard(recommendation: CalendarRecommendation, onClick: () -> Unit) {
+    Column(Modifier.width(150.dp).clip(RoundedCornerShape(12.dp)).clickable(onClick = onClick)) {
+        AsyncImage(recommendation.item.poster, recommendation.item.name, Modifier.fillMaxWidth().height(225.dp).clip(RoundedCornerShape(12.dp)), contentScale = ContentScale.Crop)
+        Text(recommendation.item.name, Modifier.padding(top = 8.dp), fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text("Like ${recommendation.recommendedBy.firstOrNull().orEmpty()}", maxLines = 1, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onBackground.copy(alpha = .65f))
+    }
+}
+
+private fun LocalDate.calendarLabel(): String = when (this) {
+    LocalDate.now() -> "Today"
+    LocalDate.now().plusDays(1) -> "Tomorrow"
+    else -> format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/calendar/CalendarViewModel.kt
@@ -1,0 +1,39 @@
+package com.nuvio.tv.ui.screens.calendar
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.repository.CalendarRepository
+import com.nuvio.tv.domain.model.CalendarDay
+import com.nuvio.tv.domain.model.CalendarRecommendation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class CalendarUiState(
+    val loading: Boolean = true,
+    val days: List<CalendarDay> = emptyList(),
+    val recommendations: List<CalendarRecommendation> = emptyList(),
+    val error: String? = null
+)
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(
+    private val repository: CalendarRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(CalendarUiState())
+    val uiState: StateFlow<CalendarUiState> = _uiState.asStateFlow()
+
+    init { refresh() }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(loading = true, error = null)
+            runCatching { repository.load() }
+                .onSuccess { _uiState.value = CalendarUiState(false, it.days, it.recommendations) }
+                .onFailure { _uiState.value = CalendarUiState(false, error = it.message ?: "Unable to load calendar") }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="nav_calendar">Calendar</string>
     <string name="app_name">Nuvio</string>
     <string name="tv_channel_continue_watching">Continue Watching</string>
     <string name="type_movie">Movie</string>

--- a/app/src/test/java/com/nuvio/tv/core/calendar/CalendarEpisodeBuilderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/calendar/CalendarEpisodeBuilderTest.kt
@@ -1,0 +1,30 @@
+package com.nuvio.tv.core.calendar
+
+import com.nuvio.tv.data.remote.api.TmdbEpisode
+import com.nuvio.tv.domain.model.LibraryEntry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+
+class CalendarEpisodeBuilderTest {
+    private val show = LibraryEntry(
+        id = "tmdb:123", type = "series", name = "Saved Show", poster = "poster",
+        background = "background", logo = null, description = null, releaseInfo = null,
+        imdbRating = null, genres = emptyList(), addonBaseUrl = "https://example.test"
+    )
+
+    @Test
+    fun `keeps only upcoming episodes inside horizon and groups by date`() {
+        val episodes = listOf(
+            TmdbEpisode(episodeNumber = 1, name = "Past", airDate = "2026-08-15"),
+            TmdbEpisode(episodeNumber = 2, name = "Tonight", airDate = "2026-08-16"),
+            TmdbEpisode(episodeNumber = 3, name = "Next", airDate = "2026-08-23"),
+            TmdbEpisode(episodeNumber = 4, name = "Too far", airDate = "2026-12-01"),
+            TmdbEpisode(episodeNumber = 5, name = "Unknown", airDate = null)
+        )
+        val result = CalendarEpisodeBuilder.build(show, 123, 4, episodes, LocalDate.of(2026, 8, 16), 30)
+        assertEquals(listOf(2, 3), result.map { it.episodeNumber })
+        assertEquals("tmdb:123:4:2", result.first().videoId)
+        assertEquals(2, CalendarEpisodeBuilder.groupByDay(result).size)
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Feature approval requested in #3060. This PR remains a draft and is not presented as approved or ready for review. The implementation can be revised, reduced, or closed based on maintainer direction.

## What changed

- adds an Android TV-first Calendar destination to the main sidebar
- shows announced episodes for series in the active local, Trakt, or Simkl library, grouped by air date for the next 90 days
- opens episode cards at the corresponding show, season, and episode
- adds deduplicated TMDb recommendations derived from several saved shows
- excludes already-saved titles from recommendations
- limits concurrent TMDb requests and tolerates individual metadata failures
- adds focused tests for episode filtering and date grouping

## Why

Nuvio already has the library and TMDb metadata needed to help users answer two common questions on TV: what is airing next from saved shows, and what similar series might be worth adding. Keeping this inside Nuvio also means it follows whichever library source is currently active without exposing credentials to an external companion.

## Approval status

- Feature request: #3060
- Maintainer approval: pending
- PR status: draft pending product-direction review

## Scope boundaries

This implementation is read-only. It does not change library membership, watched state, playback state, add-on behavior, or tracking-provider synchronization. It only uses announced TMDb schedule data and existing library entries.

## Validation

- `:app:compileFullDebugKotlin` — passes
- `git diff --check` — passes
- focused episode filtering and date-grouping tests are included
- APK assembly proceeds through compilation, Hilt, D8, and resources; final signing is unavailable because the upstream checkout expects its private `nuviotv.jks`
- the complete unit-test source set currently has unrelated pre-existing compile failures in `TmdbCollectionSourceResolverTest`, trailer tests, and `SearchViewModelConcurrencyTest`

## Screenshots / video

Pending maintainer approval and final Android TV UI review.

## Breaking changes

None.

## Notes

TMDb only exposes announced schedules. Shows without a `next_episode_to_air` value are omitted from the episode calendar but can still contribute to recommendations.
