### PR TITLE
Align and scroll titles according to their text direction

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
@@ -73,18 +73,18 @@ fun FocusMarqueeText(
         )
     }
 
-    if (focused) {
-        // basicMarquee scrolls according to LocalLayoutDirection, which reflects the app/UI
-        // locale (e.g. Hebrew -> Rtl) rather than this particular string's script. Override it
-        // per-text so an English title inside a Hebrew/Arabic UI still scrolls left (its own
-        // reading direction) instead of right, and vice versa for an RTL title in an LTR UI.
-        val marqueeDirection = remember(text) {
-            if (text.isRtl()) LayoutDirection.Rtl else LayoutDirection.Ltr
-        }
-        CompositionLocalProvider(LocalLayoutDirection provides marqueeDirection) {
-            marqueeText()
-        }
-    } else {
+    // Text alignment, ellipsis side, and basicMarquee's scroll direction all follow
+    // LocalLayoutDirection, which reflects the app/UI locale (e.g. Hebrew -> Rtl) rather than
+    // this particular string's script. Override it per-text so an English title inside a
+    // Hebrew/Arabic UI always rests and scrolls from the left (its own reading direction)
+    // instead of the right, and vice versa for an RTL title in an LTR UI. This is applied
+    // unconditionally (not just while focused) so the resting/ellipsized state already matches
+    // where the marquee will anchor once focused, and focusing never causes the title to jump
+    // from one side of the card to the other.
+    val textDirection = remember(text) {
+        if (text.isRtl()) LayoutDirection.Rtl else LayoutDirection.Ltr
+    }
+    CompositionLocalProvider(LocalLayoutDirection provides textDirection) {
         marqueeText()
     }
 }


### PR DESCRIPTION
## Summary

This PR makes title alignment and marquee scrolling follow the direction of the title’s text rather than the app’s UI locale.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

When an English title is displayed in a Hebrew or Arabic UI, it currently inherits the RTL layout direction and can align and scroll from the wrong side. The same issue occurs with RTL titles inside an LTR UI.

Using the title’s own text direction keeps the title anchored consistently and prevents it from jumping from one side of the card when it receives focus.

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

Two images showing the problem in Nuvio 0.8.7:

<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/8cb26eb1-12f7-4f2a-965f-6d14c83f297f" />

<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/1f5b1316-a65f-41b4-9fd3-a8566b1bdab4" />

The title jumps from right to left.

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

#2879 Follow-up.
