### PR TITLE
Fix trailer preview falling back to low resolution

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractor.kt
@@ -26,6 +26,7 @@ import javax.inject.Singleton
 
 private const val TAG = "InAppYouTubeExtractor"
 private const val EXTRACTOR_TIMEOUT_MS = 30_000L
+private const val MAX_ADAPTIVE_VIDEO_PROBES = 4
 private const val DEFAULT_USER_AGENT =
     "Mozilla/5.0 (Linux; Android 12; Android TV) AppleWebKit/537.36 " +
         "(KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
@@ -438,10 +439,18 @@ class InAppYouTubeExtractor @Inject constructor() {
         val bestProgressive = sortCandidates(progressive).firstOrNull()
         val bestVideo = pickBestForClient(adaptiveVideo, PREFERRED_SEPARATE_CLIENT)
         val bestAudio = pickBestForClient(adaptiveAudio, PREFERRED_SEPARATE_CLIENT)
+        // Preserve the preferred-client first choice, then try globally ranked fallbacks.
+        val adaptiveVideoUrls = listOfNotNull(bestVideo?.url)
+            .plus(sortCandidates(adaptiveVideo).map { it.url })
+            .distinct()
 
         // Try adaptive video + audio first (best quality, separate streams)
         kotlinx.coroutines.yield()
-        val resolvedVideo = bestVideo?.url?.let { resolveReachableUrl(it) }
+        val resolvedVideo = firstResolvedUrl(
+            candidates = adaptiveVideoUrls,
+            maxAttempts = MAX_ADAPTIVE_VIDEO_PROBES,
+            resolve = ::resolveReachableUrl
+        )
         val resolvedAudio = if (resolvedVideo != null) bestAudio?.url?.let { resolveReachableUrl(it) } else null
 
         if (resolvedVideo != null) {
@@ -829,6 +838,17 @@ class InAppYouTubeExtractor @Inject constructor() {
         }
         return headers.build()
     }
+}
+
+internal suspend fun firstResolvedUrl(
+    candidates: Iterable<String>,
+    maxAttempts: Int,
+    resolve: suspend (String) -> String?
+): String? {
+    for (candidate in candidates.take(maxAttempts)) {
+        resolve(candidate)?.let { return it }
+    }
+    return null
 }
 
 private data class RequestResponse(

--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -498,8 +498,8 @@ internal fun rankTmdbVideoCandidates(results: List<TmdbVideoResult>): List<TmdbV
         }
         .sortedWith(
             compareBy<TmdbVideoResult> { videoTypePriority(it.type) }
-                .thenBy { if (it.official == true) 0 else 1 }
                 .thenByDescending { it.size ?: 0 }
+                .thenBy { if (it.official == true) 0 else 1 }
                 .thenByDescending { parsePublishedAtEpoch(it.publishedAt) }
         )
         .toList()

--- a/app/src/test/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractorCandidateFallbackTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/InAppYouTubeExtractorCandidateFallbackTest.kt
@@ -1,0 +1,58 @@
+package com.nuvio.tv.data.trailer
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class InAppYouTubeExtractorCandidateFallbackTest {
+
+    @Test
+    fun `tries the next adaptive candidate when the first cannot be resolved`() = runTest {
+        val attempted = mutableListOf<String>()
+
+        val result = firstResolvedUrl(
+            candidates = listOf("adaptive-2160p", "adaptive-1080p"),
+            maxAttempts = 4
+        ) { candidate ->
+            attempted += candidate
+            if (candidate == "adaptive-2160p") null else "resolved-$candidate"
+        }
+
+        assertEquals("resolved-adaptive-1080p", result)
+        assertEquals(listOf("adaptive-2160p", "adaptive-1080p"), attempted)
+    }
+
+    @Test
+    fun `stops probing after the first candidate resolves`() = runTest {
+        val attempted = mutableListOf<String>()
+
+        val result = firstResolvedUrl(
+            candidates = listOf("adaptive-2160p", "adaptive-1080p"),
+            maxAttempts = 4
+        ) { candidate ->
+            attempted += candidate
+            "resolved-$candidate"
+        }
+
+        assertEquals("resolved-adaptive-2160p", result)
+        assertEquals(listOf("adaptive-2160p"), attempted)
+    }
+
+    @Test
+    fun `stops after the adaptive probe limit when all candidates fail`() = runTest {
+        val candidates = (1..5).map { "adaptive-$it" }
+        val attempted = mutableListOf<String>()
+
+        val result = firstResolvedUrl(
+            candidates = candidates,
+            maxAttempts = 4
+        ) { candidate ->
+            attempted += candidate
+            null
+        }
+
+        assertNull(result)
+        assertEquals(candidates.take(4), attempted)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCandidateRankingTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCandidateRankingTest.kt
@@ -1,0 +1,149 @@
+package com.nuvio.tv.data.trailer
+
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TmdbVideoResult
+import com.nuvio.tv.data.remote.api.TmdbVideosResponse
+import com.nuvio.tv.data.remote.api.TrailerApi
+import com.nuvio.tv.domain.model.TmdbSettings
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class TrailerServiceCandidateRankingTest {
+
+    @Test
+    fun `higher resolution outranks official status within the same video type`() {
+        val officialLowResolution = youtubeVideo(
+            key = LOW_RESOLUTION_KEY,
+            size = 480,
+            official = true,
+            publishedAt = "2026-08-01T00:00:00Z"
+        )
+        val unofficialHighResolution = youtubeVideo(
+            key = HIGH_RESOLUTION_KEY,
+            size = 2160,
+            official = false,
+            publishedAt = "2025-08-01T00:00:00Z"
+        )
+
+        val ranked = rankTmdbVideoCandidates(
+            listOf(officialLowResolution, unofficialHighResolution)
+        )
+
+        assertEquals(
+            listOf(HIGH_RESOLUTION_KEY, LOW_RESOLUTION_KEY),
+            ranked.map { it.key }
+        )
+    }
+
+    @Test
+    fun `video type remains higher priority than resolution`() {
+        val lowResolutionTrailer = youtubeVideo(
+            key = LOW_RESOLUTION_KEY,
+            type = "Trailer",
+            size = 480,
+            official = false
+        )
+        val highResolutionTeaser = youtubeVideo(
+            key = HIGH_RESOLUTION_KEY,
+            type = "Teaser",
+            size = 2160,
+            official = true
+        )
+
+        val ranked = rankTmdbVideoCandidates(
+            listOf(highResolutionTeaser, lowResolutionTrailer)
+        )
+
+        assertEquals(
+            listOf(LOW_RESOLUTION_KEY, HIGH_RESOLUTION_KEY),
+            ranked.map { it.key }
+        )
+    }
+
+    @Test
+    fun `external trailer selection uses the highest resolution trailer candidate`() = runTest {
+        val trailerApi = mockk<TrailerApi>(relaxed = true)
+        val tmdbApi = mockk<TmdbApi>()
+        val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
+            every { settings } returns MutableStateFlow(TmdbSettings(language = "en", useTrailers = true))
+        }
+        val tmdbService = mockk<TmdbService> {
+            every { apiKey() } returns "tmdb-key"
+        }
+        coEvery {
+            tmdbApi.getMovieVideos(
+                movieId = 123,
+                apiKey = "tmdb-key",
+                language = "en-US"
+            )
+        } returns Response.success(
+            TmdbVideosResponse(
+                id = 123,
+                results = listOf(
+                    youtubeVideo(
+                        key = LOW_RESOLUTION_KEY,
+                        size = 480,
+                        official = true,
+                        publishedAt = "2026-08-01T00:00:00Z"
+                    ),
+                    youtubeVideo(
+                        key = HIGH_RESOLUTION_KEY,
+                        size = 2160,
+                        official = false,
+                        publishedAt = "2025-08-01T00:00:00Z"
+                    )
+                )
+            )
+        )
+        val service = TrailerService(
+            trailerApi = trailerApi,
+            tmdbApi = tmdbApi,
+            inAppYouTubeExtractor = extractor,
+            tmdbSettingsDataStore = tmdbSettingsDataStore,
+            tmdbService = tmdbService
+        )
+
+        val result = service.getExternalTrailerUrl(tmdbId = "123", type = "movie")
+
+        assertEquals("https://www.youtube.com/watch?v=$HIGH_RESOLUTION_KEY", result)
+        coVerify(exactly = 1) {
+            tmdbApi.getMovieVideos(
+                movieId = 123,
+                apiKey = "tmdb-key",
+                language = "en-US"
+            )
+        }
+    }
+
+    private fun youtubeVideo(
+        key: String,
+        type: String = "Trailer",
+        size: Int,
+        official: Boolean,
+        publishedAt: String = "2026-01-01T00:00:00Z"
+    ): TmdbVideoResult {
+        return TmdbVideoResult(
+            key = key,
+            site = "YouTube",
+            size = size,
+            type = type,
+            official = official,
+            publishedAt = publishedAt
+        )
+    }
+
+    private companion object {
+        const val LOW_RESOLUTION_KEY = "lowres00001"
+        const val HIGH_RESOLUTION_KEY = "highres0001"
+    }
+}


### PR DESCRIPTION
## Summary
Two related trailer-quality defects fixed as two small, focused commits:
- The YouTube extractor only probed the single top-ranked adaptive video
  stream before falling back to HLS/progressive (~360-480p).
- TMDB trailer-candidate ranking placed the `official` flag above upload
  resolution, so a low-res official upload could beat a high-res one.

## PR type
- [x] Critical bug fix

## Why
Trailer previews were playing at noticeably lower quality than the same
trailer on YouTube, even when high-resolution streams were available.

## Issue or approval
Fixes #3127

## Reproduction steps
See linked issue.

## UI / behavior impact
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes.
- [x] I listed the testing performed below.

## Scope boundaries
Does not touch trailer audio-track or language selection — those are a
separate, follow-up fix.

## Testing
- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.data.trailer.*"` — all passing, including new tests for both fixes.
- `./gradlew :app:assembleFullDebug` — builds successfully.
- Manually verified on-device: trailer preview now plays the ranked-highest reachable adaptive stream instead of falling back after a single failed probe.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #3127