### PR TITLE
fix(meta): canonicalize tv to series and stop selecting unsupported addon types

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -212,12 +212,9 @@ class MetaRepositoryImpl @Inject constructor(
             }
         }
         metaResourceAddons.firstOrNull { it.supportsMetaId(id) }?.let { topMetaAddon ->
-            val fallbackType = when {
-                topMetaAddon.supportsMetaType(requestedType) -> requestedType
-                topMetaAddon.supportsMetaType(inferredType) -> inferredType
-                else -> inferredType.ifBlank { requestedType }
+            topMetaAddon.supportedCandidateType(requestedType, inferredType)?.let { fallbackType ->
+                prioritizedCandidates.add(topMetaAddon to fallbackType)
             }
-            prioritizedCandidates.add(topMetaAddon to fallbackType)
         }
         // Fallback: if no ID-matching addons found, include addons without idPrefixes
         if (prioritizedCandidates.isEmpty()) {
@@ -227,12 +224,9 @@ class MetaRepositoryImpl @Inject constructor(
                 }
             }
             metaResourceAddons.firstOrNull { it.idPrefixes.isEmpty() }?.let { topMetaAddon ->
-                val fallbackType = when {
-                    topMetaAddon.supportsMetaType(requestedType) -> requestedType
-                    topMetaAddon.supportsMetaType(inferredType) -> inferredType
-                    else -> inferredType.ifBlank { requestedType }
+                topMetaAddon.supportedCandidateType(requestedType, inferredType)?.let { fallbackType ->
+                    prioritizedCandidates.add(topMetaAddon to fallbackType)
                 }
-                prioritizedCandidates.add(topMetaAddon to fallbackType)
             }
         }
 
@@ -505,17 +499,33 @@ class MetaRepositoryImpl @Inject constructor(
 
     private fun inferCanonicalType(type: String, id: String): String {
         val normalizedType = type.trim()
-        val known = setOf("movie", "series", "tv", "channel", "anime")
+        // "tv" is Nuvio's internal synonym for episodic content. Stremio metadata
+        // addons advertise episodic content as "series", so fold it over here rather
+        // than requesting a type nothing declares. Live TV is a separate type
+        // ("channel") and is left alone.
+        if (normalizedType.equals("tv", ignoreCase = true)) return "series"
+        val known = setOf("movie", "series", "channel", "anime")
         if (normalizedType.lowercase() in known) return normalizedType
 
         val normalizedId = id.lowercase()
         return when {
             ":movie:" in normalizedId -> "movie"
             ":series:" in normalizedId -> "series"
-            ":tv:" in normalizedId -> "tv"
+            ":tv:" in normalizedId -> "series"
             ":anime:" in normalizedId -> "anime"
             else -> normalizedType
         }
+    }
+
+    /**
+     * Picks a meta type this addon actually advertises, preferring the requested one.
+     * Returns null when it supports neither, so a candidate is never built with a type
+     * the addon has already rejected.
+     */
+    private fun Addon.supportedCandidateType(requestedType: String, inferredType: String): String? = when {
+        supportsMetaType(requestedType) -> requestedType
+        supportsMetaType(inferredType) -> inferredType
+        else -> null
     }
 
     private fun selectPrimaryMetaCandidate(
@@ -538,11 +548,8 @@ class MetaRepositoryImpl @Inject constructor(
         val topMetaAddon = addons.firstOrNull { addon ->
             addon.resources.any { it.name == "meta" }
         } ?: return null
-        val fallbackType = when {
-            topMetaAddon.supportsMetaType(requestedType) -> requestedType
-            topMetaAddon.supportsMetaType(inferredType) -> inferredType
-            else -> inferredType.ifBlank { requestedType }
-        }
+        val fallbackType = topMetaAddon.supportedCandidateType(requestedType, inferredType)
+            ?: return null
         return topMetaAddon to fallbackType
     }
 

--- a/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryCandidateTypeTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryCandidateTypeTest.kt
@@ -1,0 +1,158 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.MetaDto
+import com.nuvio.tv.data.remote.dto.MetaResponseDto
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+/**
+ * A meta candidate must only ever be built with a type the addon advertises.
+ * Nuvio uses "tv" internally for episodic content while addons declare "series",
+ * so a "tv" request against a series-only addon must go out as "series" and never
+ * as "tv", which returns null meta and leaves the seasons list empty.
+ */
+class MetaRepositoryCandidateTypeTest {
+
+    private val contentId = "tt0944947"
+
+    @Test
+    fun `tv request against a series-only addon is sent as series`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("movie", "series")))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        assertEquals("https://addon.example/meta/series/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `tv request is sent as tv when the addon actually declares tv`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series", "tv")))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        assertEquals("https://addon.example/meta/tv/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `uppercase TV is canonicalized to series`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series")))
+
+        repository.getMetaFromAllAddons("TV", contentId).last()
+
+        assertEquals("https://addon.example/meta/series/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `addon supporting neither requested nor inferred type is never requested`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("movie")))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        coVerify(exactly = 0) { api.getMeta(any()) }
+    }
+
+    @Test
+    fun `addon declaring no meta types still receives the request`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = emptyList()))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        coVerify(exactly = 1) { api.getMeta(any()) }
+    }
+
+    @Test
+    fun `movie requests are unaffected`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("movie", "series")))
+
+        repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertEquals("https://addon.example/meta/movie/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `tv in the id is inferred as series when the type is not canonical`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(
+            api,
+            addon(metaTypes = listOf("series"), idPrefixes = listOf("tmdb:"))
+        )
+
+        repository.getMetaFromAllAddons("unknown", "tmdb:tv:1399").last()
+
+        assertEquals(
+            "https://addon.example/meta/series/tmdb%3Atv%3A1399.json",
+            capturedUrl(api)
+        )
+    }
+
+    @Test
+    fun `primary addon selection skips an addon that supports neither type`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("movie")))
+
+        repository.getMetaFromPrimaryAddon("tv", contentId).last()
+
+        coVerify(exactly = 0) { api.getMeta(any()) }
+    }
+
+    private fun addon(
+        metaTypes: List<String>,
+        idPrefixes: List<String> = listOf("tt")
+    ) = Addon(
+        id = "test.addon",
+        name = "Test Addon",
+        version = "1.0.0",
+        description = null,
+        logo = null,
+        baseUrl = "https://addon.example",
+        catalogs = emptyList(),
+        types = listOf(ContentType.MOVIE, ContentType.SERIES),
+        rawTypes = listOf("movie", "series"),
+        resources = listOf(AddonResource(name = "meta", types = metaTypes, idPrefixes = null)),
+        idPrefixes = idPrefixes
+    )
+
+    private fun apiReturningMeta(): AddonApi = mockk<AddonApi>().also { api ->
+        coEvery { api.getMeta(any()) } returns Response.success(
+            MetaResponseDto(meta = MetaDto(id = contentId, type = "series", name = "Test Meta"))
+        )
+    }
+
+    private suspend fun capturedUrl(api: AddonApi): String {
+        val url = slot<String>()
+        coVerify { api.getMeta(capture(url)) }
+        return url.captured
+    }
+
+    private fun newRepository(api: AddonApi, vararg addons: Addon): MetaRepositoryImpl {
+        val context = mockk<Context>(relaxed = true) {
+            every { getString(any()) } returns "Episode"
+            every { getString(any(), *anyVararg()) } returns "No supported addon"
+        }
+        val addonRepository = mockk<AddonRepository>(relaxed = true) {
+            every { getInstalledAddons() } returns flowOf(addons.toList())
+        }
+        return MetaRepositoryImpl(context = context, api = api, addonRepository = addonRepository)
+    }
+}


### PR DESCRIPTION
## Summary

Fix meta candidate selection for episodic content. Nuvio's internal `tv` type is now canonicalized to `series` for Stremio meta requests, and meta candidates are only created when the addon supports the selected type.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

**Old behavior:** `inferCanonicalType()` treated `tv` as canonical and returned it unchanged, so both `requestedType` and `inferredType` stayed `tv`. Candidate selection then had fallback paths that could add an addon even when `supportsMetaType()` had returned false for both types, passing along the unsupported type.

**Broken behavior:** Nuvio requested `/meta/tv/<id>.json` from addons that only declare `series`. Those return `{"meta":null}`, so no IDs were resolved, no episodes were fetched, and the series detail page showed no seasons or episodes. The section was simply blank.

**New behavior:** `tv` is canonicalized to `series`, and `:tv:` IDs are inferred as `series`. A candidate is only built with a type the addon supports. Addons with no declared meta types remain unrestricted. If an addon supports neither the requested nor the inferred type, it is skipped instead of being requested with a type it rejected.

Live TV is a separate type (`channel`) and is not affected.

## Issue or approval

Fixes #3135

## Reproduction steps

1. Install a metadata addon that declares `series` but not `tv`. AIOMetadata 2.13.0 was used here.
2. Put the addon first in the addon order.
3. Open any series from a catalog or search.
4. Scroll to the seasons and episodes section.
5. The section is empty.
6. Confirm the requests made to the addon:
   - `/meta/series/<id>.json` returns metadata containing videos.
   - `/meta/tv/<id>.json` returns `{"meta":null}`.
7. The addon logs `Invalid type: tv` when the detail page opens.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

One user-visible behavior change is worth calling out. `selectPrimaryMetaCandidate()` can now return null where it previously returned a candidate with an unsupported type. The caller already handles null and emits the existing `error_meta_no_supported_addon` message, so the user gets an explicit error instead of a blank page.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to meta type canonicalization and meta candidate validation, in one file plus one new test file.

Does not change the seasons/episodes UI, addon manifests, addon routing, or stream and subtitle behavior. The only user-visible change is the one noted above, where the primary addon path now surfaces the existing "no supported addon" message instead of issuing a request the addon rejects.

`inferCanonicalType()` still does not recognize `show` or `tvshow`, which other parts of the app treat as episodic. This is left unchanged deliberately to keep this PR focused. The candidate guard still ensures that any selected type is one the addon supports.

## Testing

### Automated

Added `MetaRepositoryCandidateTypeTest`, which drives the public `getMetaFromAllAddons()` and `getMetaFromPrimaryAddon()` and asserts on the URL that goes out:

- `tv` request against a series-only addon is sent as `series`
- an addon explicitly declaring `tv` still receives a `tv` request
- case-insensitive `TV` is canonicalized
- an addon supporting neither type is never requested
- an addon declaring no meta types still receives the request (empty `types` means unrestricted)
- existing `movie` requests remain unchanged
- `:tv:` in the ID is inferred as `series` when the type is not canonical
- primary-addon selection skips an addon supporting neither type

Command:

    ./gradlew :app:testFullDebugUnitTest --tests '*MetaRepositoryCandidateTypeTest*'

Result: Passed. 8 tests, 0 failures, 0 errors, 0 skipped.

Command:

    ./gradlew :app:testFullDebugUnitTest

Result: 891 tests, 12 failures, 1 skipped. `MetaRepositoryCandidateTypeTest` passes.

The 12 failures are pre-existing. Running the same task on the base commit in the same container produces an identical failure list, with the same assertions and the same line numbers: Dolby Vision base layer policy (2), ExoPlayer RAM tiering (3), Matroska/MKV probes (2), localhost data source, DefaultAllocator, Trakt auth, Simkl reconciliation, and Collections migration.

The base commit executes 883 tests and this branch executes 891. The difference is exactly the 8 tests added here. No existing tests were modified.

### Manual

Not tested on a device.

The `/meta/series/` vs `/meta/tv/` responses in the reproduction steps were captured with curl against AIOMetadata 2.13.0. That confirms the original bug, not the fix.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3135