### PR TITLE
fix(player): align loading overlay backdrop to TopEnd like StreamScreen

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/LoadingOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/LoadingOverlay.kt
@@ -124,7 +124,8 @@ fun LoadingOverlay(
                     model = backdropRequest,
                     contentDescription = stringResource(R.string.cd_loading_backdrop),
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.TopEnd
                 )
             }
 


### PR DESCRIPTION
## Summary

- Align `LoadingOverlay` backdrop crop to `Alignment.TopEnd`, matching Modern Home fullscreen hero and StreamScreen backdrop.
- Stops the left/right jump when Continue Watching binge-group auto-play skips the stream list and goes straight to the loading overlay.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

- StreamScreen backdrop was already cropped `TopEnd` so it matches the home hero. Loading overlay still used the default `Center` crop.
- With Modern Home **fullscreen hero backdrop** enabled, the home image already fills the screen. Skipping the stream source list then showing the overlay immediately swaps that full-screen `TopEnd` crop for a `Center` crop, so the background slides left and right.

## Issue or approval

Modern Home fullscreen hero backdrop is on. Continue Watching binge-group auto-play skips the stream source list and opens the loading overlay directly. The backdrop jumps left and right because overlay crop was centered instead of TopEnd.

## Reproduction steps

1. Use Modern Home.
2. Enable fullscreen hero backdrop in layout settings.
3. Play a Continue Watching series item that has a persisted binge group (auto-play, not Play manually).
4. Stream source list is skipped and loading overlay appears.
5. Backdrop jumps left/right during the overlay transition.
6. After this change, the overlay keeps the same TopEnd crop as the fullscreen hero / StreamScreen backdrop.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Overlay logo, fill, message, and progress UI are unchanged.
- StreamScreen backdrop, home hero layout, auto-play selection, and navigation transitions are unchanged.
- No extra animation or overlay restyle.

## Testing

- Compared crop alignment with StreamScreen `StreamBackdrop` (`ContentScale.Crop` + `Alignment.TopEnd`) and Modern Home hero (`ContentScale.Crop` + `Alignment.TopEnd`).
- Manual path: Modern Home + fullscreen hero backdrop + Continue Watching binge-group auto-play that skips the stream list and opens loading overlay. Backdrop should stay put instead of shifting horizontally.
- Overlay still covers player and external auto-next loading; only crop origin changed.

## Screenshots / Video

Before: Modern Home fullscreen hero (`TopEnd`) → loading overlay (`Center`) makes the same backdrop jump left/right.

After: loading overlay uses `TopEnd`, so the fullscreen hero and overlay share the same crop.

## Breaking changes

None.

## Linked issues

On Modern Home with fullscreen hero backdrop enabled, Continue Watching binge-group auto-play skips the stream source list and goes straight to the loading overlay. The overlay cropped the backdrop at Center while the fullscreen hero and StreamScreen use TopEnd, so the background jumps left and right.
