### PR TITLE
Feat: Make Preferred Subtitle Language follow the system language

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -42,6 +42,10 @@ val SubtitleLanguage.displayName: String
 
 const val SUBTITLE_LANGUAGE_FORCED = "forced"
 
+object SubtitleLanguageOption {
+    const val DEVICE = "device"
+}
+
 val AVAILABLE_SUBTITLE_LANGUAGES = listOf(
     SubtitleLanguage("af", "Afrikaans"),
     SubtitleLanguage("sq", "Albanian"),
@@ -134,6 +138,7 @@ val AVAILABLE_TMDB_LANGUAGES = AVAILABLE_SUBTITLE_LANGUAGES + listOf(
  */
 data class SubtitleStyleSettings(
     val preferredLanguage: String = "en",
+    val isPreferredLanguageSystemDefault: Boolean = true,
     val secondaryPreferredLanguage: String? = null,
     val useForcedSubtitles: Boolean = false,
     val showOnlyPreferredLanguages: Boolean = false,
@@ -776,7 +781,7 @@ class PlayerSettingsDataStore @Inject constructor(
                     prefs[subtitleUseForcedSubtitlesKey] = true
                     val migratedPreferred = normalizedSecondarySubtitleLanguage
                         ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED || it == "none" }
-                        ?: "en"
+                        ?: SubtitleLanguageOption.DEVICE
                     prefs[subtitlePreferredLanguageKey] = migratedPreferred
                     prefs.remove(subtitleSecondaryLanguageKey)
                 }
@@ -941,28 +946,32 @@ class PlayerSettingsDataStore @Inject constructor(
                 enableHttp2 = prefs[enableHttp2Key] ?: PlayerSettings.DEFAULT_ENABLE_HTTP2,
                 nuvioPerformanceModeEnabled = (prefs[nuvioPerformanceModeEnabledKey] ?: PlayerSettings.DEFAULT_NUVIO_PERFORMANCE_MODE_ENABLED) &&
                         android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O,
-                subtitleStyle = SubtitleStyleSettings(
-                    preferredLanguage = normalizeSubtitlePreferredLanguageForRead(
+                subtitleStyle = run {
+                    val resolvedPreferredLanguage = resolveSubtitlePreferredLanguage(
                         prefs[subtitlePreferredLanguageKey],
                         prefs[subtitleSecondaryLanguageKey]
-                    ),
-                    secondaryPreferredLanguage = prefs[subtitleSecondaryLanguageKey]
-                        ?.let(::normalizeSelectableLanguageCode)
-                        ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED },
-                    useForcedSubtitles = (prefs[subtitleUseForcedSubtitlesKey] ?: false) ||
-                        prefs[subtitlePreferredLanguageKey]?.let(::normalizeSelectableLanguageCode) == SUBTITLE_LANGUAGE_FORCED ||
-                        prefs[subtitleSecondaryLanguageKey]?.let(::normalizeSelectableLanguageCode) == SUBTITLE_LANGUAGE_FORCED,
-                    showOnlyPreferredLanguages = prefs[subtitleShowOnlyPreferredLanguagesKey] ?: false,
-                    stripSdh = prefs[subtitleStripSdhKey] ?: false,
-                    size = prefs[subtitleSizeKey] ?: 100,
-                    verticalOffset = prefs[subtitleVerticalOffsetKey] ?: 5,
-                    bold = prefs[subtitleBoldKey] ?: false,
-                    textColor = prefs[subtitleTextColorKey] ?: Color.White.toArgb(),
-                    backgroundColor = prefs[subtitleBackgroundColorKey] ?: Color.Transparent.toArgb(),
-                    outlineEnabled = prefs[subtitleOutlineEnabledKey] ?: true,
-                    outlineColor = prefs[subtitleOutlineColorKey] ?: Color.Black.toArgb(),
-                    outlineWidth = prefs[subtitleOutlineWidthKey] ?: 2
-                ),
+                    )
+                    SubtitleStyleSettings(
+                        preferredLanguage = resolvedPreferredLanguage.languageCode,
+                        isPreferredLanguageSystemDefault = resolvedPreferredLanguage.isSystemDefault,
+                        secondaryPreferredLanguage = prefs[subtitleSecondaryLanguageKey]
+                            ?.let(::normalizeSelectableLanguageCode)
+                            ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED },
+                        useForcedSubtitles = (prefs[subtitleUseForcedSubtitlesKey] ?: false) ||
+                            prefs[subtitlePreferredLanguageKey]?.let(::normalizeSelectableLanguageCode) == SUBTITLE_LANGUAGE_FORCED ||
+                            prefs[subtitleSecondaryLanguageKey]?.let(::normalizeSelectableLanguageCode) == SUBTITLE_LANGUAGE_FORCED,
+                        showOnlyPreferredLanguages = prefs[subtitleShowOnlyPreferredLanguagesKey] ?: false,
+                        stripSdh = prefs[subtitleStripSdhKey] ?: false,
+                        size = prefs[subtitleSizeKey] ?: 100,
+                        verticalOffset = prefs[subtitleVerticalOffsetKey] ?: 5,
+                        bold = prefs[subtitleBoldKey] ?: false,
+                        textColor = prefs[subtitleTextColorKey] ?: Color.White.toArgb(),
+                        backgroundColor = prefs[subtitleBackgroundColorKey] ?: Color.Transparent.toArgb(),
+                        outlineEnabled = prefs[subtitleOutlineEnabledKey] ?: true,
+                        outlineColor = prefs[subtitleOutlineColorKey] ?: Color.Black.toArgb(),
+                        outlineWidth = prefs[subtitleOutlineWidthKey] ?: 2
+                    )
+                },
                 bufferSettings = BufferSettings(
                     minBufferMs = prefs[minBufferMsKey] ?: BufferSettings.DEFAULT_MIN_BUFFER_MS,
                     maxBufferMs = prefs[maxBufferMsKey] ?: BufferSettings.DEFAULT_MAX_BUFFER_MS,
@@ -1360,19 +1369,51 @@ class PlayerSettingsDataStore @Inject constructor(
         }
     }
 
-    private fun normalizeSubtitlePreferredLanguageForRead(
+    private data class ResolvedSubtitlePreferredLanguage(
+        val languageCode: String,
+        val isSystemDefault: Boolean
+    )
+
+    private fun resolveDeviceSubtitleLanguage(): String {
+        val locale = if (android.os.Build.VERSION.SDK_INT >= 24) {
+            android.content.res.Resources.getSystem().configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            android.content.res.Resources.getSystem().configuration.locale
+        }
+        // Locale.getLanguage() can return legacy ISO codes ("iw", "in") instead
+        // of the modern ones our language list uses ("he", "id").
+        val rawLanguage = locale?.language.orEmpty()
+        val legacyMapped = when (rawLanguage) {
+            "iw" -> "he"
+            "in" -> "id"
+            else -> rawLanguage
+        }
+        val candidate = normalizeSelectableLanguageCode(legacyMapped)
+        val isSupported = candidate.isNotBlank() && AVAILABLE_SUBTITLE_LANGUAGES.any { it.code == candidate }
+        return if (isSupported) candidate else "en"
+    }
+
+    private fun resolveSubtitlePreferredLanguage(
         preferredLanguage: String?,
         secondaryLanguage: String?
-    ): String {
-        val preferred = preferredLanguage
-            ?.let(::normalizeSelectableLanguageCode)
-            ?: return "en"
-        if (preferred != SUBTITLE_LANGUAGE_FORCED) return preferred
+    ): ResolvedSubtitlePreferredLanguage {
+        val preferred = preferredLanguage?.let(::normalizeSelectableLanguageCode)
+        if (preferred == null || preferred == SubtitleLanguageOption.DEVICE) {
+            return ResolvedSubtitlePreferredLanguage(resolveDeviceSubtitleLanguage(), isSystemDefault = true)
+        }
+        if (preferred != SUBTITLE_LANGUAGE_FORCED) {
+            return ResolvedSubtitlePreferredLanguage(preferred, isSystemDefault = false)
+        }
 
-        return secondaryLanguage
+        val migratedFromForced = secondaryLanguage
             ?.let(::normalizeSelectableLanguageCode)
             ?.takeUnless { it == SUBTITLE_LANGUAGE_FORCED || it == "none" }
-            ?: "en"
+        return if (migratedFromForced != null) {
+            ResolvedSubtitlePreferredLanguage(migratedFromForced, isSystemDefault = false)
+        } else {
+            ResolvedSubtitlePreferredLanguage(resolveDeviceSubtitleLanguage(), isSystemDefault = true)
+        }
     }
 
     suspend fun setMpvHardwareDecodeMode(mode: MpvHardwareDecodeMode) {
@@ -1407,7 +1448,7 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setStripHdr10PlusSei(enabled: Boolean) { store().edit { it[stripHdr10PlusSeiKey] = enabled } }
 
     // Subtitle styles
-    suspend fun setSubtitlePreferredLanguage(language: String) { store().edit { it[subtitlePreferredLanguageKey] = normalizeSelectableLanguageCode(language.ifBlank { "en" }) } }
+    suspend fun setSubtitlePreferredLanguage(language: String) { store().edit { it[subtitlePreferredLanguageKey] = normalizeSelectableLanguageCode(language.ifBlank { SubtitleLanguageOption.DEVICE }) } }
     suspend fun setSubtitleSecondaryLanguage(language: String?) {
         store().edit { prefs ->
             val normalizedLanguage = language?.takeIf { it.isNotBlank() }?.let(::normalizeSelectableLanguageCode)

--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -1356,7 +1356,17 @@ class PlayerSettingsDataStore @Inject constructor(
 
     private fun normalizeSelectableLanguageCode(language: String): String {
         val code = language.trim().lowercase()
-        return when (code) { "pt-br", "pt_br", "br", "pob" -> "pt-br"; "pt-pt", "pt_pt", "por" -> "pt"; "forced", "force", "forc" -> SUBTITLE_LANGUAGE_FORCED; else -> code }
+        return when (code) {
+            "pt-br", "pt_br", "br", "pob" -> "pt-br"
+            "pt-pt", "pt_pt", "por" -> "pt"
+            "forced", "force", "forc" -> SUBTITLE_LANGUAGE_FORCED
+            "zh-cn", "zh_cn" -> "zh-CN"
+            "zh-tw", "zh_tw" -> "zh-TW"
+            "en-au", "en_au" -> "en-AU"
+            "en-ca", "en_ca" -> "en-CA"
+            "en-gb", "en_gb" -> "en-GB"
+            else -> code
+        }
     }
 
     private fun normalizeSecondaryAudioLanguageCode(language: String): String? {
@@ -1381,14 +1391,23 @@ class PlayerSettingsDataStore @Inject constructor(
             @Suppress("DEPRECATION")
             android.content.res.Resources.getSystem().configuration.locale
         }
-        // Locale.getLanguage() can return legacy ISO codes ("iw", "in") instead
-        // of the modern ones our language list uses ("he", "id").
+        
         val rawLanguage = locale?.language.orEmpty()
         val legacyMapped = when (rawLanguage) {
             "iw" -> "he"
             "in" -> "id"
+            "ji" -> "yi"
             else -> rawLanguage
         }
+        val country = locale?.country.orEmpty()
+
+        if (country.isNotBlank()) {
+            val regionSpecific = normalizeSelectableLanguageCode("$legacyMapped-$country")
+            if (AVAILABLE_SUBTITLE_LANGUAGES.any { it.code == regionSpecific }) {
+                return regionSpecific
+            }
+        }
+
         val candidate = normalizeSelectableLanguageCode(legacyMapped)
         val isSupported = candidate.isNotBlank() && AVAILABLE_SUBTITLE_LANGUAGES.any { it.code == candidate }
         return if (isSupported) candidate else "en"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/EssentialPlaybackSettingsContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/EssentialPlaybackSettingsContent.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.tv.R
 import com.nuvio.tv.data.local.AudioLanguageOption
 import com.nuvio.tv.data.local.StreamAutoPlayMode
+import com.nuvio.tv.data.local.SubtitleLanguageOption
 import com.nuvio.tv.ui.components.P2pConsentDialog
 import kotlinx.coroutines.launch
 
@@ -120,10 +121,10 @@ fun EssentialPlaybackSettingsContent(
                     SettingsActionRow(
                         title = stringResource(R.string.essential_subtitle_language),
                         subtitle = stringResource(R.string.essential_subtitle_language_subtitle),
-                        value = if (settings?.subtitleStyle?.preferredLanguage == "none") {
-                            stringResource(R.string.action_none)
-                        } else {
-                            settings?.subtitleStyle?.preferredLanguage.orEmpty()
+                        value = when {
+                            settings?.subtitleStyle?.preferredLanguage == "none" -> stringResource(R.string.action_none)
+                            settings?.subtitleStyle?.isPreferredLanguageSystemDefault == true -> stringResource(R.string.appearance_language_system)
+                            else -> settings?.subtitleStyle?.preferredLanguage.orEmpty()
                         },
                         trailingIcon = Icons.Default.VideoSettings,
                         onClick = { showSubtitleLanguageDialog = true },
@@ -169,8 +170,13 @@ fun EssentialPlaybackSettingsContent(
     if (showSubtitleLanguageDialog && settings != null) {
         LanguageSelectionDialog(
             title = stringResource(R.string.essential_subtitle_language),
-            selectedLanguage = if (settings.subtitleStyle.preferredLanguage == "none") null else settings.subtitleStyle.preferredLanguage,
+            selectedLanguage = when {
+                settings.subtitleStyle.preferredLanguage == "none" -> null
+                settings.subtitleStyle.isPreferredLanguageSystemDefault -> SubtitleLanguageOption.DEVICE
+                else -> settings.subtitleStyle.preferredLanguage
+            },
             showNoneOption = true,
+            extraOptions = listOf(SubtitleLanguageOption.DEVICE to stringResource(R.string.appearance_language_system)),
             onLanguageSelected = { language ->
                 coroutineScope.launch { viewModel.setSubtitlePreferredLanguage(language ?: "none") }
                 showSubtitleLanguageDialog = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSubtitleSettings.kt
@@ -36,6 +36,7 @@ import com.nuvio.tv.data.local.AVAILABLE_SUBTITLE_LANGUAGES
 import com.nuvio.tv.data.local.displayName
 import com.nuvio.tv.data.local.LibassRenderType
 import com.nuvio.tv.data.local.PlayerSettings
+import com.nuvio.tv.data.local.SubtitleLanguageOption
 import com.nuvio.tv.ui.components.NuvioDialog
 
 private val subtitleColors = listOf(
@@ -88,12 +89,12 @@ internal fun LazyListScope.subtitleSettingsItems(
 
 
     item(key = "subtitle_preferred_language") {
-        val languageName = if (playerSettings.subtitleStyle.preferredLanguage == "none") {
-            stringResource(R.string.action_none)
-        } else {
-            AVAILABLE_SUBTITLE_LANGUAGES.find {
+        val languageName = when {
+            playerSettings.subtitleStyle.preferredLanguage == "none" -> stringResource(R.string.action_none)
+            playerSettings.subtitleStyle.isPreferredLanguageSystemDefault -> stringResource(R.string.appearance_language_system)
+            else -> AVAILABLE_SUBTITLE_LANGUAGES.find {
                 it.code == playerSettings.subtitleStyle.preferredLanguage
-            }?.displayName ?: stringResource(R.string.language_english)
+            }?.displayName ?: stringResource(R.string.appearance_language_system)
         }
 
         NavigationSettingsItem(
@@ -353,8 +354,13 @@ internal fun SubtitleSettingsDialogs(
     if (showLanguageDialog) {
         LanguageSelectionDialog(
             title = stringResource(R.string.sub_preferred_lang),
-            selectedLanguage = if (playerSettings.subtitleStyle.preferredLanguage == "none") null else playerSettings.subtitleStyle.preferredLanguage,
+            selectedLanguage = when {
+                playerSettings.subtitleStyle.preferredLanguage == "none" -> null
+                playerSettings.subtitleStyle.isPreferredLanguageSystemDefault -> SubtitleLanguageOption.DEVICE
+                else -> playerSettings.subtitleStyle.preferredLanguage
+            },
             showNoneOption = true,
+            extraOptions = listOf(SubtitleLanguageOption.DEVICE to stringResource(R.string.appearance_language_system)),
             onLanguageSelected = {
                 onSetPreferredLanguage(it)
                 onDismissLanguageDialog()


### PR DESCRIPTION
## Summary

Preferred Subtitle Language now follows the device’s system language by default, consistent with the existing App Language behavior.

When no subtitle language has been manually selected, subtitles use the device’s system language. If that language isn’t supported, the default remains English. Any language selected manually is still saved and used as before.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

App Language already gives users a seamless first experience by automatically matching their device language. However, when a new user starts watching a movie, subtitles immediately default to English, even if the app itself is using a different language.

This makes the experience feel inconsistent and means users have to manually configure subtitles before they can simply start watching.

This PR makes subtitles work the way users would naturally expect: open the app, press play, and everything is already in the right language. It provides a more welcoming, plug-and-play experience without requiring new users to touch the settings.

## Issue or approval

Fixes #3096 

## Reproduction steps

1. Set the device language to a language other than English.
2. Install the app or use an account that has never changed the Preferred Subtitle Language setting.
3. Open the subtitle language setting.
4. Observe that English is selected by default.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

This change is limited to the default value of the Preferred Subtitle Language setting. Explicitly selected subtitle languages continue to work as before.

No unrelated UI changes, refactoring, or additional subtitle behavior changes are included.

## Testing

* Verified that a fresh install uses the device's system language when no subtitle language has been selected.
* Verified that the Settings screen displays System Default in this state.
* Verified that selecting a specific subtitle language persists the selection.
* Verified that an explicitly selected language continues to be used instead of the system language.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

#3096 