### PR TITLE
Fix focus navigation after dismissing the keyboard

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -66,10 +66,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.focus.LocalFocusManager
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.util.recompositionHighlighter
@@ -918,6 +920,7 @@ private fun SearchInputField(
     var isDiscoverButtonFocused by remember { mutableStateOf(false) }
     var isVoiceButtonFocused by remember { mutableStateOf(false) }
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val focusManager = LocalFocusManager.current
 
     Row(
         modifier = Modifier
@@ -1063,6 +1066,14 @@ private fun SearchInputField(
                         KeyEvent.KEYCODE_NUMPAD_ENTER -> {
                             if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
                                 onSubmit()
+                            }
+                            return@onPreviewKeyEvent true
+                        }
+
+                        KeyEvent.KEYCODE_BACK -> {
+                            if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                                keyboardController?.hide()
+                                focusManager.clearFocus(force = true)
                             }
                             return@onPreviewKeyEvent true
                         }


### PR DESCRIPTION
Fix focus navigation after dismissing the on-screen keyboard from the Addons input field.

## Summary

After closing the keyboard, pressing a directional button could move the focus back to the input field instead of continuing to the next available element.

This could happen when pressing Down, Left, or Right, making navigation feel inconsistent and trapping focus on the input field.

The fix ensures directional navigation correctly moves focus to the next available element after the keyboard is dismissed.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

<!-- Why this change is needed. Explain the critical bug or localization update. -->

## Issue or approval

Fixes #3050 

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

None.

## Linked issues

#3050 
