### PR TITLE
feat(torrent): support custom TorrServer endpoint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ android {
         targetSdk = 36
         versionCode = 1048
         versionName = "0.8.7-beta"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "PARENTAL_GUIDE_API_URL", "\"${localProperties.getProperty("PARENTAL_GUIDE_API_URL", "")}\"")
         buildConfigField("String", "INTRODB_API_URL", "\"${localProperties.getProperty("INTRODB_API_URL", "")}\"")

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TorrServerEndpointDialogTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TorrServerEndpointDialogTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyInput
@@ -13,6 +14,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.pressKey
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuvio.tv.ui.theme.NuvioTheme
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -31,7 +33,7 @@ class TorrServerEndpointDialogTest {
             NuvioTheme {
                 TorrServerEndpointDialog(
                     currentValue = "http://10.0.0.5:8090",
-                    onSave = {},
+                    onSave = { true },
                     onDismiss = {}
                 )
             }
@@ -48,12 +50,16 @@ class TorrServerEndpointDialogTest {
     @Test
     fun validUrlWithoutSchemeIsNormalizedAndSaved() {
         val saved = mutableListOf<String>()
+        var dismissed = false
         composeRule.setContent {
             NuvioTheme {
                 TorrServerEndpointDialog(
                     currentValue = "",
-                    onSave = { saved.add(it) },
-                    onDismiss = {}
+                    onSave = {
+                        saved.add(it)
+                        true
+                    },
+                    onDismiss = { dismissed = true }
                 )
             }
         }
@@ -66,17 +72,22 @@ class TorrServerEndpointDialogTest {
         activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
 
         assertEquals(listOf("http://10.0.0.5:8090"), saved)
+        assertTrue(dismissed)
     }
 
     @Test
-    fun invalidUrlIsNotSaved() {
+    fun invalidUrlShowsErrorAndIsNotSaved() {
         val saved = mutableListOf<String>()
+        var dismissed = false
         composeRule.setContent {
             NuvioTheme {
                 TorrServerEndpointDialog(
                     currentValue = "",
-                    onSave = { saved.add(it) },
-                    onDismiss = {}
+                    onSave = {
+                        saved.add(it)
+                        true
+                    },
+                    onDismiss = { dismissed = true }
                 )
             }
         }
@@ -89,6 +100,62 @@ class TorrServerEndpointDialogTest {
         activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
 
         assertTrue(saved.isEmpty())
+        assertTrue(!dismissed)
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_STATUS).assertIsDisplayed()
+    }
+
+    @Test
+    fun unreachableServerShowsRedErrorAndIsNotSaved() {
+        var dismissed = false
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "",
+                    onSave = { false },
+                    onDismiss = { dismissed = true }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextClearance()
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextInput("http://10.0.0.5:8090")
+        composeRule.waitForIdle()
+        activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
+
+        assertTrue(!dismissed)
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_STATUS).assertIsDisplayed()
+    }
+
+    @Test
+    fun saveShowsLoadingIndicatorWhileChecking() {
+        var dismissed = false
+        val gate = CompletableDeferred<Boolean>()
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "",
+                    onSave = { gate.await() },
+                    onDismiss = { dismissed = true }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextClearance()
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextInput("http://10.0.0.5:8090")
+        composeRule.waitForIdle()
+        activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_SAVE_PROGRESS)
+            .assertIsDisplayed()
+
+        gate.complete(true)
+        composeRule.waitForIdle()
+
+        assertTrue(dismissed)
     }
 
     @Test
@@ -98,13 +165,17 @@ class TorrServerEndpointDialogTest {
             NuvioTheme {
                 TorrServerEndpointDialog(
                     currentValue = "http://10.0.0.5:8090",
-                    onSave = { saved.add(it) },
+                    onSave = {
+                        saved.add(it)
+                        true
+                    },
                     onDismiss = {}
                 )
             }
         }
 
         activate(TorrServerSettingsTestTags.ENDPOINT_CLEAR)
+        composeRule.waitForIdle()
 
         assertEquals(listOf(""), saved)
     }
@@ -115,7 +186,7 @@ class TorrServerEndpointDialogTest {
             NuvioTheme {
                 TorrServerEndpointDialog(
                     currentValue = "",
-                    onSave = {},
+                    onSave = { true },
                     onDismiss = {}
                 )
             }

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TorrServerEndpointDialogTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TorrServerEndpointDialogTest.kt
@@ -1,0 +1,135 @@
+﻿package com.nuvio.tv.ui.screens.settings
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuvio.tv.ui.theme.NuvioTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TorrServerEndpointDialogTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun currentValueIsPrefilledInTheInput() {
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "http://10.0.0.5:8090",
+                    onSave = {},
+                    onDismiss = {}
+                )
+            }
+        }
+
+        val text = composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.EditableText]
+            .text
+
+        assertTrue(text.contains("http://10.0.0.5:8090"))
+    }
+
+    @Test
+    fun validUrlWithoutSchemeIsNormalizedAndSaved() {
+        val saved = mutableListOf<String>()
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "",
+                    onSave = { saved.add(it) },
+                    onDismiss = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextClearance()
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextInput("10.0.0.5:8090")
+        composeRule.waitForIdle()
+        activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
+
+        assertEquals(listOf("http://10.0.0.5:8090"), saved)
+    }
+
+    @Test
+    fun invalidUrlIsNotSaved() {
+        val saved = mutableListOf<String>()
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "",
+                    onSave = { saved.add(it) },
+                    onDismiss = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextClearance()
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+            .performTextInput("not a url")
+        composeRule.waitForIdle()
+        activate(TorrServerSettingsTestTags.ENDPOINT_SAVE)
+
+        assertTrue(saved.isEmpty())
+    }
+
+    @Test
+    fun clearSavesAnEmptyEndpoint() {
+        val saved = mutableListOf<String>()
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "http://10.0.0.5:8090",
+                    onSave = { saved.add(it) },
+                    onDismiss = {}
+                )
+            }
+        }
+
+        activate(TorrServerSettingsTestTags.ENDPOINT_CLEAR)
+
+        assertEquals(listOf(""), saved)
+    }
+
+    @Test
+    fun saveButtonExposesClickSemantics() {
+        composeRule.setContent {
+            NuvioTheme {
+                TorrServerEndpointDialog(
+                    currentValue = "",
+                    onSave = {},
+                    onDismiss = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TorrServerSettingsTestTags.ENDPOINT_SAVE)
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsActions.OnClick))
+    }
+
+    private fun activate(tag: String) {
+        val node = composeRule.onNodeWithTag(tag)
+        node.performSemanticsAction(SemanticsActions.RequestFocus)
+        composeRule.waitForIdle()
+        node.performKeyInput { pressKey(androidx.compose.ui.input.key.Key.DirectionCenter) }
+        composeRule.waitForIdle()
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsOverviewTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsOverviewTest.kt
@@ -164,7 +164,8 @@ class TrackingSettingsOverviewTest {
                     onWatchProgressClick = {},
                     onContinueWatchingWindowClick = {},
                     onCommentsChanged = {},
-                    onMoreLikeThisClick = {}
+                    onMoreLikeThisClick = {},
+                    onAnimeIdClick = {}
                 )
             }
         }
@@ -184,7 +185,6 @@ class TrackingSettingsOverviewTest {
                     state = TraktUiState(),
                     onStartConnection = {},
                     onRetryPolling = {},
-                    onSync = {},
                     onDisconnect = {},
                     onDismiss = {}
                 )
@@ -207,7 +207,6 @@ class TrackingSettingsOverviewTest {
                     ),
                     onStartConnection = {},
                     onRetryPolling = {},
-                    onSync = {},
                     onDisconnect = {},
                     onDismiss = {}
                 )
@@ -241,7 +240,8 @@ class TrackingSettingsOverviewTest {
                     onWatchProgressClick = {},
                     onContinueWatchingWindowClick = {},
                     onCommentsChanged = {},
-                    onMoreLikeThisClick = {}
+                    onMoreLikeThisClick = {},
+                    onAnimeIdClick = {}
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/core/di/TorrentModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/TorrentModule.kt
@@ -1,10 +1,13 @@
 package com.nuvio.tv.core.di
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.nuvio.tv.core.torrent.TorrServerApi
 import com.nuvio.tv.core.torrent.TorrServerBinary
 import com.nuvio.tv.core.torrent.TorrentService
 import com.nuvio.tv.core.torrent.TorrentSettings
+import com.nuvio.tv.core.torrent.torrentSettingsDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,15 +21,22 @@ object TorrentModule {
 
     @Provides
     @Singleton
-    fun provideTorrentSettings(
+    fun provideTorrentSettingsDataStore(
         @ApplicationContext context: Context
-    ): TorrentSettings = TorrentSettings(context)
+    ): DataStore<Preferences> = torrentSettingsDataStore(context)
+
+    @Provides
+    @Singleton
+    fun provideTorrentSettings(
+        dataStore: DataStore<Preferences>
+    ): TorrentSettings = TorrentSettings(dataStore)
 
     @Provides
     @Singleton
     fun provideTorrServerBinary(
-        @ApplicationContext context: Context
-    ): TorrServerBinary = TorrServerBinary(context)
+        @ApplicationContext context: Context,
+        torrentSettings: TorrentSettings
+    ): TorrServerBinary = TorrServerBinary(context, torrentSettings)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerApi.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerApi.kt
@@ -146,4 +146,18 @@ class TorrServerApi @Inject constructor(
         val encodedLink = URLEncoder.encode(magnetLink, "UTF-8")
         return "$baseUrl/stream?link=$encodedLink&index=$fileIdx&play"
     }
+
+    /**
+     * Checks whether a TorrServer instance is reachable at [endpoint] by
+     * hitting its /echo health endpoint.
+     */
+    suspend fun isEndpointReachable(endpoint: String): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val request = Request.Builder().url("$endpoint/echo").build()
+            client.newCall(request).execute().use { it.isSuccessful }
+        } catch (e: Exception) {
+            Log.w(TAG, "TorrServer endpoint not reachable: $endpoint", e)
+            false
+        }
+    }
 }

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerBinary.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerBinary.kt
@@ -18,10 +18,15 @@ import javax.inject.Singleton
  * Manages the TorrServer binary lifecycle.
  * The binary is bundled in jniLibs/ as libtorrserver.so and installed
  * to nativeLibraryDir by the Android package manager.
+ *
+ * When the user configures a custom TorrServer endpoint the local binary is
+ * not started/stopped and every request (health, torrents, stream URLs) is
+ * routed to the remote endpoint instead.
  */
 @Singleton
 class TorrServerBinary @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val torrentSettings: TorrentSettings
 ) {
     companion object {
         private const val TAG = "TorrServerBinary"
@@ -31,13 +36,19 @@ class TorrServerBinary @Inject constructor(
     }
 
     private var process: Process? = null
+
     private val healthClient = OkHttpClient.Builder()
         .dns(IPv4FirstDns())
         .connectTimeout(2, TimeUnit.SECONDS)
         .readTimeout(5, TimeUnit.SECONDS)
         .build()
 
-    val baseUrl: String get() = "http://127.0.0.1:$PORT"
+    private val customEndpoint: String
+        get() = torrentSettings.currentCustomTorrServerUrl
+
+    val baseUrl: String get() = customEndpoint.ifBlank { "http://127.0.0.1:$PORT" }
+
+    val isUsingCustomEndpoint: Boolean get() = customEndpoint.isNotBlank()
 
     private val binaryFile: File
         get() = File(context.applicationInfo.nativeLibraryDir, "libtorrserver.so")
@@ -58,6 +69,11 @@ class TorrServerBinary @Inject constructor(
     }
 
     suspend fun start() = withContext(Dispatchers.IO) {
+        if (isUsingCustomEndpoint) {
+            Log.d(TAG, "Using custom TorrServer endpoint: $baseUrl; skipping local binary")
+            return@withContext
+        }
+
         if (isRunning()) {
             Log.d(TAG, "TorrServer already running")
             return@withContext
@@ -132,6 +148,12 @@ class TorrServerBinary @Inject constructor(
     }
 
     fun stop() {
+        if (isUsingCustomEndpoint) {
+            Log.d(TAG, "Custom TorrServer endpoint in use; skipping local shutdown")
+            process = null
+            return
+        }
+
         // Try graceful shutdown
         try {
             val request = Request.Builder().url("$baseUrl/shutdown").build()

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerEndpoint.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrServerEndpoint.kt
@@ -1,0 +1,30 @@
+package com.nuvio.tv.core.torrent
+
+/**
+ * Normalizes a user-entered TorrServer endpoint.
+ *
+ * - Blank input -> "" (use the built-in server)
+ * - Missing scheme -> "http://" is prepended
+ * - Valid http(s) URL with a host -> trailing "/" trimmed and returned
+ * - Anything else -> null (invalid)
+ */
+fun normalizeTorrServerEndpoint(raw: String): String? {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return ""
+
+    val withScheme = if (trimmed.contains("://")) trimmed else "http://$trimmed"
+    val normalized = withScheme.trimEnd('/')
+
+    return try {
+        val uri = java.net.URI(normalized)
+        val scheme = uri.scheme?.lowercase()
+        val host = uri.host
+        if ((scheme == "http" || scheme == "https") && !host.isNullOrBlank()) {
+            normalized
+        } else {
+            null
+        }
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/torrent/TorrentSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/core/torrent/TorrentSettings.kt
@@ -1,10 +1,13 @@
 package com.nuvio.tv.core.torrent
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -16,18 +19,21 @@ import javax.inject.Singleton
 
 private val Context.torrentDataStore by preferencesDataStore(
     name = "torrent_settings",
-    corruptionHandler = androidx.datastore.core.handlers.ReplaceFileCorruptionHandler { androidx.datastore.preferences.core.emptyPreferences() }
+    corruptionHandler = androidx.datastore.core.handlers.ReplaceFileCorruptionHandler { emptyPreferences() }
 )
+
+internal fun torrentSettingsDataStore(context: Context): DataStore<Preferences> = context.torrentDataStore
 
 data class TorrentSettingsData(
     val p2pEnabled: Boolean = false,
     val enableUpload: Boolean = true,
-    val hideTorrentStats: Boolean = true
+    val hideTorrentStats: Boolean = true,
+    val customTorrServerUrl: String = ""
 )
 
 @Singleton
 class TorrentSettings @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val dataStore: DataStore<Preferences>
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -35,31 +41,59 @@ class TorrentSettings @Inject constructor(
         val P2P_ENABLED = booleanPreferencesKey("p2p_enabled")
         val ENABLE_UPLOAD = booleanPreferencesKey("enable_upload")
         val HIDE_TORRENT_STATS = booleanPreferencesKey("hide_torrent_stats")
+        val CUSTOM_TORR_SERVER_URL = stringPreferencesKey("custom_torr_server_url")
     }
 
-    val settings: Flow<TorrentSettingsData> = context.torrentDataStore.data.map { prefs ->
+    @Volatile
+    private var cachedCustomTorrServerUrl: String = ""
+
+    init {
+        scope.launch {
+            dataStore.data.collect { prefs ->
+                cachedCustomTorrServerUrl = prefs[Keys.CUSTOM_TORR_SERVER_URL] ?: ""
+            }
+        }
+    }
+
+    val settings: Flow<TorrentSettingsData> = dataStore.data.map { prefs ->
         TorrentSettingsData(
             p2pEnabled = prefs[Keys.P2P_ENABLED] ?: false,
             enableUpload = prefs[Keys.ENABLE_UPLOAD] ?: true,
-            hideTorrentStats = prefs[Keys.HIDE_TORRENT_STATS] ?: true
-        )
+            hideTorrentStats = prefs[Keys.HIDE_TORRENT_STATS] ?: true,
+            customTorrServerUrl = prefs[Keys.CUSTOM_TORR_SERVER_URL] ?: ""
+        ).also { cachedCustomTorrServerUrl = it.customTorrServerUrl }
     }
+
+    val currentCustomTorrServerUrl: String
+        get() = cachedCustomTorrServerUrl
 
     fun setP2pEnabled(enabled: Boolean) {
         scope.launch {
-            context.torrentDataStore.edit { it[Keys.P2P_ENABLED] = enabled }
+            dataStore.edit { it[Keys.P2P_ENABLED] = enabled }
         }
     }
 
     fun setEnableUpload(enabled: Boolean) {
         scope.launch {
-            context.torrentDataStore.edit { it[Keys.ENABLE_UPLOAD] = enabled }
+            dataStore.edit { it[Keys.ENABLE_UPLOAD] = enabled }
         }
     }
 
     fun setHideTorrentStats(enabled: Boolean) {
         scope.launch {
-            context.torrentDataStore.edit { it[Keys.HIDE_TORRENT_STATS] = enabled }
+            dataStore.edit { it[Keys.HIDE_TORRENT_STATS] = enabled }
+        }
+    }
+
+    fun setCustomTorrServerUrl(url: String) {
+        val normalized = url.trim()
+        cachedCustomTorrServerUrl = normalized
+        scope.launch {
+            if (normalized.isBlank()) {
+                dataStore.edit { it.remove(Keys.CUSTOM_TORR_SERVER_URL) }
+            } else {
+                dataStore.edit { it[Keys.CUSTOM_TORR_SERVER_URL] = normalized }
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -64,7 +65,6 @@ import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.screens.player.NuvioExoPlayerPerformanceHelper
 import com.nuvio.tv.R
 import android.view.KeyEvent
-import android.widget.Toast
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
@@ -607,7 +607,7 @@ fun PlaybackSettingsContent(
     if (showTorrServerEndpointDialog) {
         TorrServerEndpointDialog(
             currentValue = torrentSettings.customTorrServerUrl,
-            onSave = { url -> viewModel.setCustomTorrServerUrl(url) },
+            onSave = { url -> viewModel.saveCustomTorrServerUrl(url) },
             onDismiss = { showTorrServerEndpointDialog = false }
         )
     }
@@ -1662,20 +1662,32 @@ private fun ColorOption(
 internal object TorrServerSettingsTestTags {
     const val ENDPOINT_INPUT = "torrserver_endpoint_input"
     const val ENDPOINT_SAVE = "torrserver_endpoint_save"
+    const val ENDPOINT_SAVE_PROGRESS = "torrserver_endpoint_save_progress"
     const val ENDPOINT_CLEAR = "torrserver_endpoint_clear"
+    const val ENDPOINT_STATUS = "torrserver_endpoint_status"
+}
+
+private enum class TorrServerEndpointSaveStatus {
+    IDLE,
+    CHECKING,
+    INVALID,
+    UNREACHABLE
 }
 
 @Composable
 internal fun TorrServerEndpointDialog(
     currentValue: String,
-    onSave: (String) -> Unit,
+    onSave: suspend (String) -> Boolean,
     onDismiss: () -> Unit
 ) {
     var value by remember(currentValue) { mutableStateOf(currentValue) }
+    var status by remember { mutableStateOf(TorrServerEndpointSaveStatus.IDLE) }
     val inputFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
-    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val invalidUrlMsg = stringResource(R.string.settings_torrserver_invalid_url)
+    val checkingMsg = stringResource(R.string.settings_p2p_custom_endpoint_checking)
+    val unreachableMsg = stringResource(R.string.settings_p2p_custom_endpoint_unreachable)
 
     LaunchedEffect(Unit) {
         inputFocusRequester.requestFocus()
@@ -1710,7 +1722,10 @@ internal fun TorrServerEndpointDialog(
             Box(modifier = Modifier.padding(horizontal = 14.dp, vertical = NuvioTheme.spacing.md)) {
                 BasicTextField(
                     value = value,
-                    onValueChange = { value = it },
+                    onValueChange = {
+                        value = it
+                        status = TorrServerEndpointSaveStatus.IDLE
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
@@ -1734,6 +1749,34 @@ internal fun TorrServerEndpointDialog(
             }
         }
 
+        when (status) {
+            TorrServerEndpointSaveStatus.CHECKING -> Text(
+                text = checkingMsg,
+                style = MaterialTheme.typography.bodySmall,
+                color = NuvioTheme.colors.TextSecondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(TorrServerSettingsTestTags.ENDPOINT_STATUS)
+            )
+            TorrServerEndpointSaveStatus.INVALID -> Text(
+                text = invalidUrlMsg,
+                style = MaterialTheme.typography.bodySmall,
+                color = NuvioTheme.colors.Error,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(TorrServerSettingsTestTags.ENDPOINT_STATUS)
+            )
+            TorrServerEndpointSaveStatus.UNREACHABLE -> Text(
+                text = unreachableMsg,
+                style = MaterialTheme.typography.bodySmall,
+                color = NuvioTheme.colors.Error,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(TorrServerSettingsTestTags.ENDPOINT_STATUS)
+            )
+            TorrServerEndpointSaveStatus.IDLE -> Unit
+        }
+
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
             Button(
                 onClick = onDismiss,
@@ -1745,8 +1788,10 @@ internal fun TorrServerEndpointDialog(
             Spacer(modifier = Modifier.width(NuvioTheme.spacing.sm))
             Button(
                 onClick = {
-                    onSave("")
-                    onDismiss()
+                    scope.launch {
+                        onSave("")
+                        onDismiss()
+                    }
                 },
                 modifier = Modifier.testTag(TorrServerSettingsTestTags.ENDPOINT_CLEAR),
                 colors = ButtonDefaults.colors(
@@ -1759,18 +1804,39 @@ internal fun TorrServerEndpointDialog(
                 onClick = {
                     val normalized = normalizeTorrServerEndpoint(value)
                     if (normalized == null) {
-                        Toast.makeText(context, invalidUrlMsg, Toast.LENGTH_SHORT).show()
+                        status = TorrServerEndpointSaveStatus.INVALID
                     } else {
-                        onSave(normalized)
-                        onDismiss()
+                        scope.launch {
+                            status = TorrServerEndpointSaveStatus.CHECKING
+                            val ok = onSave(normalized)
+                            status = if (ok) {
+                                TorrServerEndpointSaveStatus.IDLE
+                            } else {
+                                TorrServerEndpointSaveStatus.UNREACHABLE
+                            }
+                            if (ok) onDismiss()
+                        }
                     }
                 },
+                enabled = status != TorrServerEndpointSaveStatus.CHECKING,
                 modifier = Modifier.testTag(TorrServerSettingsTestTags.ENDPOINT_SAVE),
                 colors = ButtonDefaults.colors(
                     containerColor = NuvioTheme.colors.BackgroundCard,
                     contentColor = NuvioTheme.colors.TextPrimary
                 )
-            ) { Text(stringResource(R.string.action_save)) }
+            ) {
+                if (status == TorrServerEndpointSaveStatus.CHECKING) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(18.dp)
+                            .testTag(TorrServerSettingsTestTags.ENDPOINT_SAVE_PROGRESS),
+                        strokeWidth = 2.dp,
+                        color = NuvioTheme.colors.TextPrimary
+                    )
+                } else {
+                    Text(stringResource(R.string.action_save))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -21,8 +21,12 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
@@ -47,8 +51,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.stringResource
@@ -56,6 +64,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.screens.player.NuvioExoPlayerPerformanceHelper
 import com.nuvio.tv.R
 import android.view.KeyEvent
+import android.widget.Toast
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
@@ -66,6 +75,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.tv.material3.Border
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -84,6 +95,7 @@ import com.nuvio.tv.data.local.PlayerSettings
 import com.nuvio.tv.data.local.displayName
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.components.P2pConsentDialog
+import com.nuvio.tv.core.torrent.normalizeTorrServerEndpoint
 import com.nuvio.tv.ui.screens.detail.requestFocusAfterFrames
 import kotlinx.coroutines.launch
 import androidx.compose.material.icons.filled.PlayCircle
@@ -146,6 +158,7 @@ fun PlaybackSettingsContent(
     var showPlayerPreferenceDialog by remember { mutableStateOf(false) }
     var showInternalPlayerEngineDialog by remember { mutableStateOf(false) }
     var showP2pConsentDialog by remember { mutableStateOf(false) }
+    var showTorrServerEndpointDialog by remember { mutableStateOf(false) }
 
     fun dismissAllDialogs() {
         showLanguageDialog = false
@@ -169,6 +182,7 @@ fun PlaybackSettingsContent(
         showPlayerPreferenceDialog = false
         showInternalPlayerEngineDialog = false
         showP2pConsentDialog = false
+        showTorrServerEndpointDialog = false
     }
 
     fun openDialog(setter: () -> Unit) {
@@ -340,6 +354,8 @@ fun PlaybackSettingsContent(
                 },
                 hideTorrentStats = torrentSettings.hideTorrentStats,
                 onSetHideTorrentStats = { enabled -> viewModel.setHideTorrentStats(enabled) },
+                customTorrServerUrl = torrentSettings.customTorrServerUrl,
+                onShowCustomTorrServerDialog = { openDialog { showTorrServerEndpointDialog = true } },
                 onSetUseParallelConnections = { enabled ->
                     coroutineScope.launch { viewModel.setUseParallelConnections(enabled) }
                     memoryUsageTrigger++
@@ -587,6 +603,14 @@ fun PlaybackSettingsContent(
             onDismiss = { showP2pConsentDialog = false }
         )
     }
+
+    if (showTorrServerEndpointDialog) {
+        TorrServerEndpointDialog(
+            currentValue = torrentSettings.customTorrServerUrl,
+            onSave = { url -> viewModel.setCustomTorrServerUrl(url) },
+            onDismiss = { showTorrServerEndpointDialog = false }
+        )
+    }
 }
 
 @Composable
@@ -684,6 +708,99 @@ internal fun ToggleSettingsItem(
                     uncheckedThumbColor = NuvioTheme.colors.TextSecondary.copy(alpha = contentAlpha),
                     uncheckedTrackColor = NuvioTheme.colors.Border
                 )
+            )
+        }
+    }
+}
+
+@Composable
+internal fun ActionSettingsItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    value: String,
+    onClick: () -> Unit,
+    onFocused: () -> Unit = {},
+    enabled: Boolean = true
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val contentAlpha = if (enabled) 1f else 0.4f
+
+    Card(
+        onClick = { if (enabled) onClick() },
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged { state ->
+                val nowFocused = state.isFocused
+                if (isFocused != nowFocused) {
+                    isFocused = nowFocused
+                    if (nowFocused) onFocused()
+                }
+            },
+        colors = CardDefaults.colors(
+            containerColor = NuvioTheme.colors.Background,
+            focusedContainerColor = NuvioTheme.colors.Background
+        ),
+        border = CardDefaults.border(
+            focusedBorder = Border(
+                border = NuvioTheme.focusRing.border(NuvioTheme.spacing.xxs, alpha = if (enabled) 1f else 0.3f),
+                shape = RoundedCornerShape(SettingsPillRadius)
+            )
+        ),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(SettingsPillRadius)),
+        scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = NuvioTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = (if (isFocused && enabled) NuvioTheme.colors.Primary else NuvioTheme.colors.TextSecondary).copy(alpha = contentAlpha),
+                modifier = Modifier.size(22.dp)
+            )
+
+            Spacer(modifier = Modifier.width(NuvioTheme.spacing.lg))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = NuvioTheme.colors.TextPrimary.copy(alpha = contentAlpha),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(NuvioTheme.spacing.xxs))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioTheme.colors.TextSecondary.copy(alpha = contentAlpha),
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Spacer(modifier = Modifier.width(NuvioTheme.spacing.lg))
+
+            Text(
+                text = value,
+                style = MaterialTheme.typography.labelLarge,
+                color = NuvioTheme.colors.TextSecondary.copy(alpha = contentAlpha),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.widthIn(max = 180.dp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = NuvioTheme.colors.TextTertiary.copy(alpha = contentAlpha),
+                modifier = Modifier.size(18.dp)
             )
         }
     }
@@ -1538,6 +1655,122 @@ private fun ColorOption(
                     modifier = Modifier.size(20.dp)
                 )
             }
+        }
+    }
+}
+
+internal object TorrServerSettingsTestTags {
+    const val ENDPOINT_INPUT = "torrserver_endpoint_input"
+    const val ENDPOINT_SAVE = "torrserver_endpoint_save"
+    const val ENDPOINT_CLEAR = "torrserver_endpoint_clear"
+}
+
+@Composable
+internal fun TorrServerEndpointDialog(
+    currentValue: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var value by remember(currentValue) { mutableStateOf(currentValue) }
+    val inputFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val context = LocalContext.current
+    val invalidUrlMsg = stringResource(R.string.settings_torrserver_invalid_url)
+
+    LaunchedEffect(Unit) {
+        inputFocusRequester.requestFocus()
+    }
+
+    NuvioDialog(
+        onDismiss = onDismiss,
+        title = stringResource(R.string.settings_p2p_custom_endpoint_dialog_title),
+        subtitle = stringResource(R.string.settings_p2p_custom_endpoint_dialog_subtitle),
+        width = 700.dp
+    ) {
+        Card(
+            onClick = { inputFocusRequester.requestFocus() },
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.colors(
+                containerColor = NuvioTheme.colors.BackgroundElevated,
+                focusedContainerColor = NuvioTheme.colors.BackgroundElevated
+            ),
+            border = CardDefaults.border(
+                border = Border(
+                    border = BorderStroke(NuvioTheme.spacing.hairline, NuvioTheme.colors.Border),
+                    shape = RoundedCornerShape(10.dp)
+                ),
+                focusedBorder = Border(
+                    border = NuvioTheme.focusRing.border(NuvioTheme.spacing.xxs),
+                    shape = RoundedCornerShape(10.dp)
+                )
+            ),
+            shape = CardDefaults.shape(RoundedCornerShape(10.dp)),
+            scale = CardDefaults.scale(focusedScale = 1f)
+        ) {
+            Box(modifier = Modifier.padding(horizontal = 14.dp, vertical = NuvioTheme.spacing.md)) {
+                BasicTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(TorrServerSettingsTestTags.ENDPOINT_INPUT)
+                        .focusRequester(inputFocusRequester),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = NuvioTheme.colors.TextPrimary),
+                    cursorBrush = SolidColor(NuvioTheme.colors.Primary),
+                    decorationBox = { innerTextField ->
+                        if (value.isBlank()) {
+                            Text(
+                                text = stringResource(R.string.settings_p2p_custom_endpoint_placeholder),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = NuvioTheme.colors.TextTertiary
+                            )
+                        }
+                        innerTextField()
+                    }
+                )
+            }
+        }
+
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            Button(
+                onClick = onDismiss,
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioTheme.colors.BackgroundElevated,
+                    contentColor = NuvioTheme.colors.TextPrimary
+                )
+            ) { Text(stringResource(R.string.action_cancel)) }
+            Spacer(modifier = Modifier.width(NuvioTheme.spacing.sm))
+            Button(
+                onClick = {
+                    onSave("")
+                    onDismiss()
+                },
+                modifier = Modifier.testTag(TorrServerSettingsTestTags.ENDPOINT_CLEAR),
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioTheme.colors.BackgroundElevated,
+                    contentColor = NuvioTheme.colors.TextPrimary
+                )
+            ) { Text(stringResource(R.string.action_clear)) }
+            Spacer(modifier = Modifier.width(NuvioTheme.spacing.sm))
+            Button(
+                onClick = {
+                    val normalized = normalizeTorrServerEndpoint(value)
+                    if (normalized == null) {
+                        Toast.makeText(context, invalidUrlMsg, Toast.LENGTH_SHORT).show()
+                    } else {
+                        onSave(normalized)
+                        onDismiss()
+                    }
+                },
+                modifier = Modifier.testTag(TorrServerSettingsTestTags.ENDPOINT_SAVE),
+                colors = ButtonDefaults.colors(
+                    containerColor = NuvioTheme.colors.BackgroundCard,
+                    contentColor = NuvioTheme.colors.TextPrimary
+                )
+            ) { Text(stringResource(R.string.action_save)) }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Image
@@ -176,6 +177,8 @@ internal fun PlaybackSettingsSections(
     onSetP2pEnabled: (Boolean) -> Unit = {},
     hideTorrentStats: Boolean = false,
     onSetHideTorrentStats: (Boolean) -> Unit = {},
+    customTorrServerUrl: String = "",
+    onShowCustomTorrServerDialog: () -> Unit = {},
     onSetNuvioPerformanceModeEnabled: (Boolean) -> Unit,
     onSetBufferEngineEnabled: (Boolean) -> Unit,
     onSetParallelNetworkEnabled: (Boolean) -> Unit,
@@ -263,6 +266,9 @@ internal fun PlaybackSettingsSections(
     val strSectionP2pDesc = stringResource(R.string.settings_p2p_subtitle)
     val strHideTorrentStats = stringResource(R.string.settings_p2p_hide_stats_title)
     val strHideTorrentStatsDesc = stringResource(R.string.settings_p2p_hide_stats_subtitle)
+    val strCustomTorrServerEndpoint = stringResource(R.string.settings_p2p_custom_endpoint_title)
+    val strCustomTorrServerEndpointDesc = stringResource(R.string.settings_p2p_custom_endpoint_subtitle)
+    val strCustomTorrServerBuiltin = stringResource(R.string.settings_p2p_custom_endpoint_builtin)
     val generalUi = PlaybackGeneralUi(
         isExternalPlayer = playerSettings.playerPreference == PlayerPreference.EXTERNAL,
         frameRateMatchingLabel = frameRateMatchingModeLabel(
@@ -686,6 +692,16 @@ internal fun PlaybackSettingsSections(
                     subtitle = strHideTorrentStatsDesc,
                     isChecked = hideTorrentStats,
                     onCheckedChange = onSetHideTorrentStats,
+                    onFocused = { focusedSection = PlaybackSection.P2P }
+                )
+            }
+            item(key = "p2p_custom_endpoint") {
+                ActionSettingsItem(
+                    icon = Icons.Default.Dns,
+                    title = strCustomTorrServerEndpoint,
+                    subtitle = strCustomTorrServerEndpointDesc,
+                    value = customTorrServerUrl.ifBlank { strCustomTorrServerBuiltin },
+                    onClick = onShowCustomTorrServerDialog,
                     onFocused = { focusedSection = PlaybackSection.P2P }
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -22,6 +22,8 @@ import com.nuvio.tv.data.local.TrailerSettings
 import com.nuvio.tv.data.local.TrailerSettingsDataStore
 import com.nuvio.tv.core.torrent.TorrentSettings
 import com.nuvio.tv.core.torrent.TorrentSettingsData
+import com.nuvio.tv.core.torrent.TorrServerApi
+import com.nuvio.tv.core.torrent.normalizeTorrServerEndpoint
 import com.nuvio.tv.data.local.VodCacheSizeMode
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.repository.AddonRepository
@@ -38,7 +40,8 @@ class PlaybackSettingsViewModel @Inject constructor(
     private val trailerSettingsDataStore: TrailerSettingsDataStore,
     private val addonRepository: AddonRepository,
     private val pluginManager: PluginManager,
-    private val torrentSettings: TorrentSettings
+    private val torrentSettings: TorrentSettings,
+    private val torrentServerApi: TorrServerApi
 ) : ViewModel() {
 
     val playerSettings: Flow<PlayerSettings> = playerSettingsDataStore.playerSettings
@@ -48,6 +51,25 @@ class PlaybackSettingsViewModel @Inject constructor(
     fun setP2pEnabled(enabled: Boolean) = torrentSettings.setP2pEnabled(enabled)
     fun setHideTorrentStats(enabled: Boolean) = torrentSettings.setHideTorrentStats(enabled)
     fun setCustomTorrServerUrl(url: String) = torrentSettings.setCustomTorrServerUrl(url)
+
+    /**
+     * Validates and persists a custom TorrServer endpoint.
+     * Returns true when the endpoint was saved (an empty value clears the
+     * setting back to the built-in server without any reachability check).
+     * Returns false when the value is invalid or the server is unreachable.
+     */
+    suspend fun saveCustomTorrServerUrl(url: String): Boolean {
+        val normalized = normalizeTorrServerEndpoint(url) ?: return false
+        if (normalized.isEmpty()) {
+            torrentSettings.setCustomTorrServerUrl("")
+            return true
+        }
+        val reachable = torrentServerApi.isEndpointReachable(normalized)
+        if (reachable) {
+            torrentSettings.setCustomTorrServerUrl(normalized)
+        }
+        return reachable
+    }
 
     val lastPlaybackDiagnostics: Flow<LastPlaybackDiagnostics> = playerSettingsDataStore.lastPlaybackDiagnostics
     val installedAddonNames: Flow<List<String>> = addonRepository.getInstalledAddons().map { addons ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -47,6 +47,7 @@ class PlaybackSettingsViewModel @Inject constructor(
 
     fun setP2pEnabled(enabled: Boolean) = torrentSettings.setP2pEnabled(enabled)
     fun setHideTorrentStats(enabled: Boolean) = torrentSettings.setHideTorrentStats(enabled)
+    fun setCustomTorrServerUrl(url: String) = torrentSettings.setCustomTorrServerUrl(url)
 
     val lastPlaybackDiagnostics: Flow<LastPlaybackDiagnostics> = playerSettingsDataStore.lastPlaybackDiagnostics
     val installedAddonNames: Flow<List<String>> = addonRepository.getInstalledAddons().map { addons ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1566,6 +1566,13 @@
     <string name="settings_p2p_subtitle">Allow peer-to-peer (torrent) streams</string>
     <string name="settings_p2p_hide_stats_title">Hide torrent stats</string>
     <string name="settings_p2p_hide_stats_subtitle">Hide buffer, seeds, peers and download speed during loading and playback</string>
+    <string name="settings_p2p_custom_endpoint_title">Custom TorrServer endpoint</string>
+    <string name="settings_p2p_custom_endpoint_subtitle">Stream through a remote TorrServer instead of the built-in one. Leave empty to use the built-in server.</string>
+    <string name="settings_p2p_custom_endpoint_builtin">Built-in</string>
+    <string name="settings_p2p_custom_endpoint_dialog_title">TorrServer endpoint</string>
+    <string name="settings_p2p_custom_endpoint_dialog_subtitle">Enter the base URL of a remote TorrServer, e.g. http://192.168.1.100:8090. Leave empty to use the built-in server.</string>
+    <string name="settings_p2p_custom_endpoint_placeholder">http://192.168.1.100:8090</string>
+    <string name="settings_torrserver_invalid_url">Invalid TorrServer URL</string>
     <string name="p2p_download_title">Downloading P2P Engine</string>
     <string name="p2p_download_subtitle">This is a one-time download required for P2P streaming.</string>
     <string name="stream_type_external">External</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1573,6 +1573,8 @@
     <string name="settings_p2p_custom_endpoint_dialog_subtitle">Enter the base URL of a remote TorrServer, e.g. http://192.168.1.100:8090. Leave empty to use the built-in server.</string>
     <string name="settings_p2p_custom_endpoint_placeholder">http://192.168.1.100:8090</string>
     <string name="settings_torrserver_invalid_url">Invalid TorrServer URL</string>
+    <string name="settings_p2p_custom_endpoint_checking">Checking connection…</string>
+    <string name="settings_p2p_custom_endpoint_unreachable">Server not accessible</string>
     <string name="p2p_download_title">Downloading P2P Engine</string>
     <string name="p2p_download_subtitle">This is a one-time download required for P2P streaming.</string>
     <string name="stream_type_external">External</string>

--- a/app/src/test/java/com/nuvio/tv/core/torrent/InMemoryPreferencesDataStore.kt
+++ b/app/src/test/java/com/nuvio/tv/core/torrent/InMemoryPreferencesDataStore.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.core.torrent
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory [DataStore] used by unit tests to avoid file I/O and Windows
+ * file-lock flakiness. Mutations are serialized with a [Mutex] to mirror the
+ * behavior of the real file-backed DataStore.
+ */
+class InMemoryPreferencesDataStore(
+    initial: Preferences = emptyPreferences()
+) : DataStore<Preferences> {
+
+    private val mutex = Mutex()
+    private val state = MutableStateFlow(initial)
+
+    override val data: Flow<Preferences> = state
+
+    fun set(key: Preferences.Key<String>, value: String) {
+        state.value = state.value.toMutablePreferences().apply {
+            this[key] = value
+        }.toPreferences()
+    }
+
+    fun remove(key: Preferences.Key<String>) {
+        state.value = state.value.toMutablePreferences().apply {
+            remove(key)
+        }.toPreferences()
+    }
+
+    override suspend fun updateData(
+        transform: suspend (t: Preferences) -> Preferences
+    ): Preferences {
+        return mutex.withLock {
+            state.value = transform(state.value)
+            state.value
+        }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerApiTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerApiTest.kt
@@ -1,0 +1,50 @@
+package com.nuvio.tv.core.torrent
+
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+
+class TorrServerApiTest {
+
+    @Test
+    fun reachableEndpointReturnsTrue() = runTest {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        thread(isDaemon = true) {
+            server.accept().use { socket ->
+                val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    if (line.isEmpty()) break
+                }
+                socket.getOutputStream().use { out ->
+                    out.write(
+                        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray()
+                    )
+                    out.flush()
+                }
+            }
+            server.close()
+        }
+
+        val api = TorrServerApi(mockk<TorrServerBinary>(relaxed = true))
+        val result = api.isEndpointReachable("http://127.0.0.1:$port")
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun unreachableEndpointReturnsFalse() = runTest {
+        val api = TorrServerApi(mockk<TorrServerBinary>(relaxed = true))
+
+        val result = api.isEndpointReachable("http://127.0.0.1:1")
+
+        assertFalse(result)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerBinaryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerBinaryTest.kt
@@ -1,0 +1,78 @@
+package com.nuvio.tv.core.torrent
+
+import android.content.Context
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TorrServerBinaryTest {
+
+    @Test
+    fun `default base url is the local binary`() = runTest {
+        val harness = harness()
+
+        assertEquals("http://127.0.0.1:8091", harness.binary.baseUrl)
+        assertFalse(harness.binary.isUsingCustomEndpoint)
+    }
+
+    @Test
+    fun `custom endpoint overrides base url`() = runTest {
+        val harness = harness()
+
+        harness.settings.setCustomTorrServerUrl("http://10.0.0.5:8090")
+
+        assertTrue(harness.binary.isUsingCustomEndpoint)
+        assertEquals("http://10.0.0.5:8090", harness.binary.baseUrl)
+    }
+
+    @Test
+    fun `start is a no-op when a custom endpoint is configured`() = runTest {
+        val harness = harness()
+        harness.settings.setCustomTorrServerUrl("https://ts.example.com")
+
+        // Must not attempt to launch the bundled binary or hit the network.
+        harness.binary.start()
+
+        assertTrue(harness.binary.isUsingCustomEndpoint)
+        assertEquals("https://ts.example.com", harness.binary.baseUrl)
+    }
+
+    @Test
+    fun `stop is a no-op when a custom endpoint is configured`() = runTest {
+        val harness = harness()
+        harness.settings.setCustomTorrServerUrl("http://10.0.0.5:8090")
+
+        harness.binary.stop()
+
+        assertTrue(harness.binary.isUsingCustomEndpoint)
+        assertEquals("http://10.0.0.5:8090", harness.binary.baseUrl)
+    }
+
+    @Test
+    fun `clearing the custom endpoint falls back to the local binary`() = runTest {
+        val harness = harness()
+        harness.settings.setCustomTorrServerUrl("http://10.0.0.5:8090")
+        assertTrue(harness.binary.isUsingCustomEndpoint)
+
+        harness.settings.setCustomTorrServerUrl("")
+
+        assertFalse(harness.binary.isUsingCustomEndpoint)
+        assertEquals("http://127.0.0.1:8091", harness.binary.baseUrl)
+    }
+
+    private fun harness(): Harness {
+        val settings = TorrentSettings(InMemoryPreferencesDataStore())
+        return Harness(
+            settings = settings,
+            binary = TorrServerBinary(mockk<Context>(relaxed = true), settings)
+        )
+    }
+
+    private data class Harness(
+        val settings: TorrentSettings,
+        val binary: TorrServerBinary
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerEndpointTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/torrent/TorrServerEndpointTest.kt
@@ -1,0 +1,57 @@
+package com.nuvio.tv.core.torrent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TorrServerEndpointTest {
+
+    @Test
+    fun `blank input clears the endpoint`() {
+        assertEquals("", normalizeTorrServerEndpoint("   "))
+        assertEquals("", normalizeTorrServerEndpoint(""))
+    }
+
+    @Test
+    fun `missing scheme is prefixed with http`() {
+        assertEquals("http://10.0.0.5:8090", normalizeTorrServerEndpoint("10.0.0.5:8090"))
+        assertEquals("http://torrserver.lan", normalizeTorrServerEndpoint("torrserver.lan"))
+    }
+
+    @Test
+    fun `valid http url is kept`() {
+        assertEquals("http://192.168.1.100:8090", normalizeTorrServerEndpoint("http://192.168.1.100:8090"))
+    }
+
+    @Test
+    fun `valid https url is kept`() {
+        assertEquals("https://ts.example.com", normalizeTorrServerEndpoint("https://ts.example.com"))
+    }
+
+    @Test
+    fun `trailing slash is trimmed`() {
+        assertEquals("http://10.0.0.5:8090", normalizeTorrServerEndpoint("http://10.0.0.5:8090/"))
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed`() {
+        assertEquals("http://10.0.0.5:8090", normalizeTorrServerEndpoint("  http://10.0.0.5:8090  "))
+    }
+
+    @Test
+    fun `non http scheme is rejected`() {
+        assertNull(normalizeTorrServerEndpoint("ftp://10.0.0.5:8090"))
+    }
+
+    @Test
+    fun `missing host is rejected`() {
+        assertNull(normalizeTorrServerEndpoint("http://"))
+        assertNull(normalizeTorrServerEndpoint("https:///path"))
+    }
+
+    @Test
+    fun `unparseable input is rejected`() {
+        assertNull(normalizeTorrServerEndpoint("not a url at all"))
+        assertNull(normalizeTorrServerEndpoint("http://exa mple.com"))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/torrent/TorrentSettingsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/torrent/TorrentSettingsTest.kt
@@ -1,0 +1,68 @@
+package com.nuvio.tv.core.torrent
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class TorrentSettingsTest {
+
+    private val customKey = stringPreferencesKey("custom_torr_server_url")
+
+    @Test
+    fun `defaults are used when nothing is stored`() = runBlocking {
+        val settings = TorrentSettings(InMemoryPreferencesDataStore())
+
+        val value = settings.settings.first()
+
+        assertEquals(TorrentSettingsData(), value)
+        assertEquals("", value.customTorrServerUrl)
+        assertEquals("", settings.currentCustomTorrServerUrl)
+    }
+
+    @Test
+    fun `setCustomTorrServerUrl persists a trimmed value`() = runBlocking {
+        val settings = TorrentSettings(InMemoryPreferencesDataStore())
+        settings.setCustomTorrServerUrl("  http://10.0.0.5:8090/  ")
+
+        val value = withTimeout(5_000) {
+            settings.settings.map { it.customTorrServerUrl }.first { it == "http://10.0.0.5:8090/" }
+        }
+
+        assertEquals("http://10.0.0.5:8090/", value)
+        assertEquals("http://10.0.0.5:8090/", settings.currentCustomTorrServerUrl)
+    }
+
+    @Test
+    fun `clearing the custom endpoint restores the built-in default`() = runBlocking {
+        val settings = TorrentSettings(InMemoryPreferencesDataStore())
+        settings.setCustomTorrServerUrl("http://10.0.0.5:8090")
+
+        settings.setCustomTorrServerUrl("")
+
+        val value = withTimeout(5_000) {
+            settings.settings.map { it.customTorrServerUrl }.first { it.isEmpty() }
+        }
+        assertEquals("", value)
+        assertEquals("", settings.currentCustomTorrServerUrl)
+    }
+
+    @Test
+    fun `stored endpoint is exposed through the settings flow`() = runBlocking {
+        val store = InMemoryPreferencesDataStore()
+        val settings = TorrentSettings(store)
+        store.set(customKey, "https://ts.example.com")
+
+        val value = withTimeout(5_000) {
+            settings.settings.map { it.customTorrServerUrl }.first { it == "https://ts.example.com" }
+        }
+
+        assertEquals("https://ts.example.com", value)
+        assertEquals("https://ts.example.com", settings.currentCustomTorrServerUrl)
+        assertFalse(settings.settings.first().p2pEnabled)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModelTest.kt
@@ -1,0 +1,92 @@
+﻿package com.nuvio.tv.ui.screens.settings
+
+import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.core.torrent.TorrentSettings
+import com.nuvio.tv.core.torrent.TorrServerApi
+import com.nuvio.tv.data.local.PlayerSettingsDataStore
+import com.nuvio.tv.data.local.TrailerSettingsDataStore
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackSettingsViewModelTest {
+
+    @Test
+    fun `empty endpoint clears the setting without a reachability check`() = runTest {
+        val torrentSettings = mockk<TorrentSettings>(relaxed = true)
+        val api = mockk<TorrServerApi>(relaxed = true)
+        val viewModel = viewModel(torrentSettings, api)
+
+        val result = viewModel.saveCustomTorrServerUrl("   ")
+
+        assertTrue(result)
+        verify { torrentSettings.setCustomTorrServerUrl("") }
+        coVerify(exactly = 0) { api.isEndpointReachable(any()) }
+    }
+
+    @Test
+    fun `invalid endpoint is rejected and not saved`() = runTest {
+        val torrentSettings = mockk<TorrentSettings>(relaxed = true)
+        val api = mockk<TorrServerApi>(relaxed = true)
+        val viewModel = viewModel(torrentSettings, api)
+
+        val result = viewModel.saveCustomTorrServerUrl("not a url")
+
+        assertFalse(result)
+        verify(exactly = 0) { torrentSettings.setCustomTorrServerUrl(any()) }
+        coVerify(exactly = 0) { api.isEndpointReachable(any()) }
+    }
+
+    @Test
+    fun `reachable endpoint is saved`() = runTest {
+        val torrentSettings = mockk<TorrentSettings>(relaxed = true)
+        val api = mockk<TorrServerApi>(relaxed = true)
+        coEvery { api.isEndpointReachable("http://10.0.0.5:8090") } returns true
+        val viewModel = viewModel(torrentSettings, api)
+
+        val result = viewModel.saveCustomTorrServerUrl("http://10.0.0.5:8090")
+
+        assertTrue(result)
+        verify { torrentSettings.setCustomTorrServerUrl("http://10.0.0.5:8090") }
+    }
+
+    @Test
+    fun `unreachable endpoint is not saved`() = runTest {
+        val torrentSettings = mockk<TorrentSettings>(relaxed = true)
+        val api = mockk<TorrServerApi>(relaxed = true)
+        coEvery { api.isEndpointReachable(any()) } returns false
+        val viewModel = viewModel(torrentSettings, api)
+
+        val result = viewModel.saveCustomTorrServerUrl("http://10.0.0.5:8090")
+
+        assertFalse(result)
+        verify(exactly = 0) { torrentSettings.setCustomTorrServerUrl(any()) }
+    }
+
+    private fun viewModel(
+        torrentSettings: TorrentSettings,
+        torrentServerApi: TorrServerApi
+    ): PlaybackSettingsViewModel {
+        val addonRepository = mockk<AddonRepository>(relaxed = true)
+        every { addonRepository.getInstalledAddons() } returns flowOf(emptyList())
+        val pluginManager = mockk<PluginManager>(relaxed = true)
+        every { pluginManager.pluginsEnabled } returns flowOf(false)
+        every { pluginManager.scrapers } returns flowOf(emptyList())
+        return PlaybackSettingsViewModel(
+            playerSettingsDataStore = mockk<PlayerSettingsDataStore>(relaxed = true),
+            trailerSettingsDataStore = mockk<TrailerSettingsDataStore>(relaxed = true),
+            addonRepository = addonRepository,
+            pluginManager = pluginManager,
+            torrentSettings = torrentSettings,
+            torrentServerApi = torrentServerApi
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds a configurable TorrServer endpoint under **Settings → Playback → P2P Streaming → Custom TorrServer endpoint**.

When a custom endpoint is set, Nuvio routes all TorrServer traffic (health checks, torrent add/drop, stats, stream URLs) to the remote server instead of starting the bundled binary. Leaving it empty uses the built-in server as before.

## What's included
- **`TorrentSettings`** — new `customTorrServerUrl` preference (DataStore-backed) with a synchronous cache used to resolve the effective base URL.
- **`TorrServerBinary`** — `baseUrl` returns the custom endpoint when configured; `start()`/`stop()` become no-ops so the local binary isn't launched.
- **`TorrServerEndpoint`** — URL normalization/validation helper (blank → built-in, missing scheme → `http://`, invalid rejected).
- **Settings UI** — an action row in the P2P section opens a dialog to enter the endpoint. On save the app pings the server's `/echo` endpoint; the Save button shows a loading spinner while checking, and if the server is unreachable the save is blocked with a red "Server not accessible" message. An empty value clears the setting back to built-in.
- **DI** — `TorrentModule` provides the new DataStore binding.

## Testing
- **Unit tests** — settings persistence, endpoint normalization, binary routing (no-op start/stop), `TorrServerApi.isEndpointReachable` against a real loopback HTTP server, and `PlaybackSettingsViewModel.saveCustomTorrServerUrl` (reachable / unreachable / invalid / empty).
- **Compose instrumentation tests** — dialog prefill, normalized save, invalid URL rejection, unreachable server error, loading indicator, clear.
- **Manual** — verified on an Android TV emulator and a real Android TV: an unreachable endpoint shows the red error and blocks save; a reachable endpoint saves and the row reflects the new URL.