### PR TITLE
fix(meta): canonicalize the type on the single-addon meta path

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.CacheControl
 import java.net.URLEncoder
 import java.util.concurrent.ConcurrentHashMap
@@ -43,6 +45,20 @@ class MetaRepositoryImpl @Inject constructor(
         private const val MIN_META_TTL_MS = 5L * 60 * 1000
         private const val MAX_META_CACHE_ENTRIES = 32
         private const val MAX_PRIMARY_META_CACHE_ENTRIES = 16
+        /**
+         * How long a meta lookup waits for the installed addon list to populate.
+         *
+         * [AddonRepository.getInstalledAddons] is a StateFlow seeded with an empty
+         * list, so a cold start reads the seed rather than the addons. Cached
+         * manifests make that a few milliseconds. A first-ever launch has nothing
+         * cached and waits on live fetches, usually longer than this, so that one
+         * start falls back to the requested type and pays the wait as well.
+         *
+         * Without the wait a lookup resolves against an empty list and reports
+         * "no addon supports this" for content that is fetchable a second later.
+         * [getMeta] checks its cache first, so a hit never waits.
+         */
+        private const val INSTALLED_ADDONS_WAIT_MS = 750L
     }
 
     /**
@@ -60,7 +76,13 @@ class MetaRepositoryImpl @Inject constructor(
      *  "fetched meta", "nothing found", and "source addon already provides this data". */
     private sealed class MetaLookupResult {
         data class Found(val meta: Meta) : MetaLookupResult()
-        data object NotFound : MetaLookupResult()
+        /** Carries what was tried, so every caller can report it. The loop runs in a
+         *  shared Deferred, so attempts held in one caller's flow would leave the
+         *  others reporting nothing. */
+        data class NotFound(
+            val attemptedAddonNames: List<String> = emptyList(),
+            val failures: List<MetaAttemptFailure> = emptyList()
+        ) : MetaLookupResult()
         /** The first viable candidate is the same addon that served the catalog,
          *  so the item already has its meta — no request needed. */
         data object SourceSufficient : MetaLookupResult()
@@ -104,18 +126,58 @@ class MetaRepositoryImpl @Inject constructor(
         type: String,
         id: String
     ): Flow<NetworkResult<Meta>> = flow {
-        val cacheKey = addonMetaCacheKey(addonBaseUrl, type, id)
-        metaCache[cacheKey]?.let { cached ->
-            if (!cached.isExpired()) {
-                emit(NetworkResult.Success(cached.meta))
-                return@flow
+        val requestedType = type.trim()
+        val inferredType = inferCanonicalType(requestedType, id)
+
+        // supportedCandidateType only ever returns one of these two, so every
+        // metaCache entry written for this addon and title sits under one of two
+        // keys. Check both, in the order it would pick them, before resolving
+        // the addon, so a cache hit skips the cold-start wait below. Only metaCache
+        // needs this: addonMetaCache is already canonical via metaLookupCacheKey.
+        val probeTypes = listOf(requestedType, inferredType)
+            .filter { it.isNotBlank() }
+            .distinct()
+        probeTypes.forEach { probeType ->
+            val probeKey = addonMetaCacheKey(addonBaseUrl, probeType, id)
+            metaCache[probeKey]?.let { cached ->
+                if (!cached.isExpired()) {
+                    emit(NetworkResult.Success(cached.meta))
+                    return@flow
+                }
+                metaCache.remove(probeKey)
             }
-            metaCache.remove(cacheKey)
         }
+
+        // The caller names the addon but not necessarily a type it serves. Nuvio's
+        // internal "tv" against a series-only addon is the usual case. Resolve it
+        // like the multi-addon path does, so the request and the cached entry line
+        // up with the other paths.
+        val addon = findAddonByBaseUrl(addonBaseUrl)
+        val advertisedType = addon?.supportedCandidateType(requestedType, inferredType)
+        if (advertisedType == null) {
+            // Both fall back to the requested type, for different reasons. Log which,
+            // so a request expected to fail is not confused with an unknown addon.
+            if (addon == null) {
+                Log.w(
+                    TAG,
+                    "Addon unresolved (not installed, disabled, or URL not matched), " +
+                        "requesting as-is url=$addonBaseUrl type=$requestedType id=$id"
+                )
+            } else {
+                Log.w(
+                    TAG,
+                    "Addon advertises neither type, requesting as-is " +
+                        "addonId=${addon.id} requested=$requestedType inferred=$inferredType id=$id"
+                )
+            }
+        }
+        val effectiveType = advertisedType ?: requestedType
+
+        val cacheKey = addonMetaCacheKey(addonBaseUrl, effectiveType, id)
 
         emit(NetworkResult.Loading)
 
-        val url = buildMetaUrl(addonBaseUrl, type, id)
+        val url = buildMetaUrl(addonBaseUrl, effectiveType, id)
         val deferred = inFlightMeta.getOrPut(cacheKey) {
             repositoryScope.async {
                 try {
@@ -126,7 +188,7 @@ class MetaRepositoryImpl @Inject constructor(
                         val ttlMs = parseMaxAgeMs(response.headers()["Cache-Control"])
                         val cached = CachedMeta(meta, System.currentTimeMillis() + ttlMs)
                         metaCache[cacheKey] = cached
-                        addonMetaCache["$type:$id"] = cached
+                        addonMetaCache[metaLookupCacheKey(requestedType, id)] = cached
                         meta
                     } else {
                         null
@@ -155,7 +217,7 @@ class MetaRepositoryImpl @Inject constructor(
         id: String,
         sourceAddonBaseUrl: String?
     ): Flow<NetworkResult<Meta>> = flow {
-        val cacheKey = "$type:$id"
+        val cacheKey = metaLookupCacheKey(type, id)
         addonMetaCache[cacheKey]?.let { cached ->
             if (!cached.isExpired()) {
                 emit(NetworkResult.Success(cached.meta))
@@ -182,7 +244,7 @@ class MetaRepositoryImpl @Inject constructor(
 
         emit(NetworkResult.Loading)
 
-        val addons = addonRepository.getInstalledAddons().first().enabledAddons()
+        val addons = installedAddonsOrEmpty()
 
         val requestedType = type.trim()
         val inferredType = inferCanonicalType(requestedType, id)
@@ -291,10 +353,15 @@ class MetaRepositoryImpl @Inject constructor(
         val deferred = inFlightAddonMeta.getOrPut(cacheKey) {
             repositoryScope.async {
                 try {
+                    // Kept here rather than in the enclosing flow's lists: this
+                    // Deferred is shared, so only its creator would see those, and
+                    // everyone else would report "no addon found" for addons tried.
+                    val loopAddonNames = linkedSetOf<String>()
+                    val loopFailures = mutableListOf<MetaAttemptFailure>()
+
                     // Normalize source addon URL for comparison so we can detect
                     // when the candidate is the same addon that served the catalog.
-                    val normalizedSourceUrl = sourceAddonBaseUrl
-                        ?.let { splitAddonBaseUrl(it).let { (p, q) -> "$p$q" } }
+                    val normalizedSourceUrl = sourceAddonBaseUrl?.let(::normalizedAddonKey)
 
                     for ((addon, candidateType) in prioritizedCandidates) {
                         // If this candidate is the same addon that provided the catalog
@@ -302,9 +369,7 @@ class MetaRepositoryImpl @Inject constructor(
                         // return immediately without making a request and without
                         // trying further addons.
                         if (normalizedSourceUrl != null) {
-                            val normalizedCandidateUrl = splitAddonBaseUrl(addon.baseUrl)
-                                .let { (p, q) -> "$p$q" }
-                            if (normalizedCandidateUrl == normalizedSourceUrl) {
+                            if (normalizedAddonKey(addon.baseUrl) == normalizedSourceUrl) {
                                 Log.d(TAG, "Source addon matched, catalog meta is sufficient addon=${addon.name} type=$candidateType id=$id")
                                 return@async MetaLookupResult.SourceSufficient
                             }
@@ -312,6 +377,7 @@ class MetaRepositoryImpl @Inject constructor(
 
                         val url = buildMetaUrl(addon.baseUrl, candidateType, id)
                         Log.d(TAG, "Trying meta addonId=${addon.id} addonName=${addon.name} type=$candidateType id=$id url=$url")
+                        loopAddonNames += addon.displayName
                         try {
                             val response = api.getMeta(url)
                             if (response.isSuccessful) {
@@ -326,15 +392,27 @@ class MetaRepositoryImpl @Inject constructor(
                                     return@async MetaLookupResult.Found(meta)
                                 }
                                 Log.d(TAG, "Meta response was null addonId=${addon.id} type=$candidateType id=$id")
+                                loopFailures += buildMissingMetaFailure(addon)
+                            } else {
+                                loopFailures += MetaAttemptFailure(
+                                    addonName = addon.displayName,
+                                    kind = if (response.code() == 404) MetaFailureKind.MISSING else MetaFailureKind.REQUEST_FAILED,
+                                    detail = response.message() ?: "HTTP ${response.code()}"
+                                )
                             }
                         } catch (e: kotlinx.coroutines.CancellationException) {
                             throw e
                         } catch (e: Exception) {
                             Log.d(TAG, "Meta fetch failed addonId=${addon.id} type=$candidateType id=$id: ${e.message}")
+                            loopFailures += MetaAttemptFailure(
+                                addonName = addon.displayName,
+                                kind = MetaFailureKind.REQUEST_FAILED,
+                                detail = e.message ?: context.getString(R.string.network_error_unknown)
+                            )
                             /* try next */
                         }
                     }
-                    MetaLookupResult.NotFound
+                    MetaLookupResult.NotFound(loopAddonNames.toList(), loopFailures)
                 } finally {
                     inFlightAddonMeta.remove(cacheKey)
                 }
@@ -349,13 +427,15 @@ class MetaRepositoryImpl @Inject constructor(
                 emit(NetworkResult.Error("Source addon sufficient", NetworkResult.SOURCE_SUFFICIENT_CODE))
             }
             is MetaLookupResult.NotFound -> {
+                // The loop reports its own attempts. The enclosing lists are only used
+                // by the legacy raw-type path, which returns before reaching here.
                 emit(
                     NetworkResult.Error(
                         buildAggregateFailureMessage(
                             type = requestedType,
                             id = id,
-                            attemptedAddonNames = attemptedAddonNames.toList(),
-                            failures = attemptedFailures
+                            attemptedAddonNames = lookupResult.attemptedAddonNames,
+                            failures = lookupResult.failures
                         )
                     )
                 )
@@ -367,7 +447,7 @@ class MetaRepositoryImpl @Inject constructor(
         type: String,
         id: String
     ): Flow<NetworkResult<Meta>> = flow {
-        val cacheKey = "$type:$id"
+        val cacheKey = metaLookupCacheKey(type, id)
         primaryAddonMetaCache[cacheKey]?.let { cached ->
             if (!cached.isExpired()) {
                 emit(NetworkResult.Success(cached.meta))
@@ -378,7 +458,7 @@ class MetaRepositoryImpl @Inject constructor(
 
         emit(NetworkResult.Loading)
 
-        val addons = addonRepository.getInstalledAddons().first().enabledAddons()
+        val addons = installedAddonsOrEmpty()
         val requestedType = type.trim()
         val inferredType = inferCanonicalType(requestedType, id)
         val candidate = selectPrimaryMetaCandidate(
@@ -454,6 +534,34 @@ class MetaRepositoryImpl @Inject constructor(
     private fun addonMetaCacheKey(addonBaseUrl: String, type: String, id: String): String {
         val (basePath, baseQuery) = splitAddonBaseUrl(addonBaseUrl)
         return "$basePath$baseQuery|$type:$id"
+    }
+
+    /** Normalized addon base URL, so two spellings of the same one compare equal. */
+    private fun normalizedAddonKey(baseUrl: String): String =
+        splitAddonBaseUrl(baseUrl).let { (basePath, baseQuery) -> "$basePath$baseQuery" }
+
+    /**
+     * Key for the caches that are not per addon. Canonicalized so one title asked
+     * for as "tv" and as "series" shares an entry instead of taking two.
+     */
+    private fun metaLookupCacheKey(type: String, id: String): String =
+        "${inferCanonicalType(type.trim(), id).lowercase()}:$id"
+
+    /**
+     * Installed, enabled addons. Waits up to [INSTALLED_ADDONS_WAIT_MS] for a real
+     * list instead of taking the StateFlow's empty seed. Returns empty if nothing
+     * arrives in time, leaving callers to use the type as given or raise their
+     * own no-addon error.
+     */
+    private suspend fun installedAddonsOrEmpty(): List<Addon> =
+        withTimeoutOrNull(INSTALLED_ADDONS_WAIT_MS) {
+            addonRepository.getInstalledAddons().filter { it.isNotEmpty() }.firstOrNull()
+        }.orEmpty().enabledAddons()
+
+    /** The installed, enabled addon at [baseUrl], if it is still installed. */
+    private suspend fun findAddonByBaseUrl(baseUrl: String): Addon? {
+        val target = normalizedAddonKey(baseUrl)
+        return installedAddonsOrEmpty().firstOrNull { normalizedAddonKey(it.baseUrl) == target }
     }
 
     private fun buildMetaUrl(baseUrl: String, type: String, id: String): String {
@@ -620,7 +728,7 @@ class MetaRepositoryImpl @Inject constructor(
     }
 
     override fun getCachedMeta(type: String, id: String): Meta? {
-        val cacheKey = "$type:$id"
+        val cacheKey = metaLookupCacheKey(type, id)
         return addonMetaCache[cacheKey]?.takeIf { !it.isExpired() }?.meta
     }
 }

--- a/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryPreferredAddonTypeTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryPreferredAddonTypeTest.kt
@@ -1,0 +1,184 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.MetaDto
+import com.nuvio.tv.data.remote.dto.MetaResponseDto
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.system.measureTimeMillis
+
+/**
+ * The details screen tries [MetaRepositoryImpl.getMeta] first, so it has to handle "tv"
+ * the way the multi-addon path does, both in the URL it asks for and in the cache entry
+ * it reads and writes. Otherwise opening a series burns a round trip on /meta/tv/ and
+ * then walks past a warm entry filed under "series".
+ */
+class MetaRepositoryPreferredAddonTypeTest {
+
+    private val contentId = "tt0944947"
+    private val baseUrl = "https://addon.example"
+
+    @Test
+    fun `tv request to a series-only addon goes out as series`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("movie", "series")))
+
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        assertEquals("$baseUrl/meta/series/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `tv request goes out as tv when the addon declares tv`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series", "tv")))
+
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        assertEquals("$baseUrl/meta/tv/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `type is used as given when the addon is not installed`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series"), baseUrl = "https://other.example"))
+
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        assertEquals("$baseUrl/meta/tv/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `meta fetched by the multi-addon path is reused by a tv request for the same addon`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series")))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        coVerify(exactly = 1) { api.getMeta(any()) }
+    }
+
+    @Test
+    fun `cached meta stored for a tv request is found under the series spelling`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, addon(metaTypes = listOf("series")))
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        assertNotNull(repository.getCachedMeta("series", contentId))
+        assertNotNull(repository.getCachedMeta("tv", contentId))
+    }
+
+    @Test
+    fun `the empty startup seed is not mistaken for an addon list`() = runTest {
+        val api = apiReturningMeta()
+        // What getInstalledAddons() looks like during a cold start: a StateFlow
+        // seeded with emptyList(), filled in once manifests are loaded.
+        val repository = newRepository(api, flowOf(emptyList(), listOf(addon(metaTypes = listOf("series")))))
+
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        assertEquals("$baseUrl/meta/series/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `an installed list that stays empty degrades to the type as given`() = runTest {
+        val api = apiReturningMeta()
+        val repository = newRepository(api, flowOf(emptyList()))
+
+        repository.getMeta(baseUrl, "tv", contentId).last()
+
+        assertEquals("$baseUrl/meta/tv/$contentId.json", capturedUrl(api))
+    }
+
+    @Test
+    fun `a warm cache hit does not wait on the installed addon list`() = runTest {
+        val api = apiReturningMeta()
+        val collections = AtomicInteger(0)
+        // Emits once, enough to prime the cache, then hangs, standing in for a list
+        // that never filled in. A getMeta that resolved the addon before checking its
+        // cache would sit here for INSTALLED_ADDONS_WAIT_MS.
+        val addonsFlow = flow<List<Addon>> {
+            if (collections.getAndIncrement() == 0) {
+                emit(listOf(addon(metaTypes = listOf("series"))))
+            }
+            awaitCancellation()
+        }
+        val repository = newRepository(api, addonsFlow)
+
+        repository.getMetaFromAllAddons("tv", contentId).last()
+
+        val elapsedMs = measureTimeMillis {
+            repository.getMeta(baseUrl, "tv", contentId).last()
+        }
+
+        // Cached as "series", asked for as "tv". Both spellings get checked.
+        coVerify(exactly = 1) { api.getMeta(any()) }
+        assertTrue("warm hit took ${elapsedMs}ms, so it waited on the addon list", elapsedMs < 300L)
+    }
+
+    private fun addon(
+        metaTypes: List<String>,
+        baseUrl: String = this.baseUrl,
+        idPrefixes: List<String> = listOf("tt")
+    ) = Addon(
+        id = "test.addon",
+        name = "Test Addon",
+        version = "1.0.0",
+        description = null,
+        logo = null,
+        baseUrl = baseUrl,
+        catalogs = emptyList(),
+        types = listOf(ContentType.MOVIE, ContentType.SERIES),
+        rawTypes = listOf("movie", "series"),
+        resources = listOf(AddonResource(name = "meta", types = metaTypes, idPrefixes = null)),
+        idPrefixes = idPrefixes
+    )
+
+    private fun apiReturningMeta(): AddonApi = mockk<AddonApi>().also { api ->
+        coEvery { api.getMeta(any()) } returns Response.success(
+            MetaResponseDto(meta = MetaDto(id = contentId, type = "series", name = "Test Meta"))
+        )
+    }
+
+    private suspend fun capturedUrl(api: AddonApi): String {
+        val url = slot<String>()
+        coVerify(exactly = 1) { api.getMeta(capture(url)) }
+        return url.captured
+    }
+
+    private fun newRepository(api: AddonApi, vararg addons: Addon): MetaRepositoryImpl =
+        newRepository(api, flowOf(addons.toList()))
+
+    private fun newRepository(api: AddonApi, addonsFlow: Flow<List<Addon>>): MetaRepositoryImpl {
+        val context = mockk<Context>(relaxed = true) {
+            every { getString(any()) } returns "Episode"
+            every { getString(any(), *anyVararg()) } returns "No supported addon"
+        }
+        val addonRepository = mockk<AddonRepository>(relaxed = true) {
+            every { getInstalledAddons() } returns addonsFlow
+        }
+        return MetaRepositoryImpl(context = context, api = api, addonRepository = addonRepository)
+    }
+}


### PR DESCRIPTION
## Summary

Applies PR #3136's `tv` -> `series` canonicalization to `MetaRepositoryImpl.getMeta()`, the single-addon path the details screen tries first, and fixes two latent bugs that surfaced alongside it: cache keys disagreeing between paths, and failure attempts recorded in the wrong scope.

- `getMeta()` resolves the request type through `supportedCandidateType()`, the same helper #3136 added, so the URL it requests and the entry it caches match the other paths.
- `getMeta()` checks both reachable spellings of its per-addon cache before resolving the addon, which is what stops the doomed request recurring, and keeps cache hits off the addon-list lookup entirely.
- Separately, for coherence rather than to fix a miss, the addon-agnostic caches key through a new `metaLookupCacheKey()` so `tv:<id>` and `series:<id>` share one entry instead of duplicating. `getCachedMeta()` follows the same keying.
- `installedAddonsOrEmpty()` waits a bounded 750ms for the installed-addon `StateFlow` to populate instead of accepting its empty startup seed, and now serves all three sites that read it.
- `MetaLookupResult.NotFound` carries the addons the candidate loop actually tried, so concurrent callers no longer report "no addon found" for addons that were tried.
- `Log.w` on both fallback paths, distinguishing an addon that advertises neither type from one that could not be resolved.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Every series details open, for any user with an addon whose catalog items carry `"type": "tv"` while its `meta` resource declares only `series`, spends a doomed `GET /meta/tv/<id>.json` before the working path runs. It repeats on every subsequent open because it can never be cached: the multi-addon path writes the per-addon cache under the resolved spelling (`...|series:<id>`) while `getMeta` probes the raw `...|tv:<id>`.

Separately, when every candidate addon fails the error reads `No installed addon could provide metadata for id=<id> (type=<type>).` even though addons were tried, which sends users and triage down the wrong path.

## Issue or approval

Fixes #3170. Follows up #3136, which fixed the same root cause on the multi-addon paths only.

## Reproduction steps

Needs the default layout preference (prefer catalog addon, i.e. "prefer external meta addon" off) and an entry point that passes an `addonBaseUrl` nav arg, such as a home row, catalog or search.

1. Install an addon whose catalog items carry `"type": "tv"` and whose `meta` resource declares only `series`.
2. Open any series from that addon's catalog.
3. With a network inspector, or the addon's own logs, observe `GET /meta/tv/<id>.json` returning `200` with `{"meta": null}`, followed by a successful `GET /meta/series/<id>.json`. Nuvio itself logs nothing for the failed attempt: a 200 with null meta returns silently and only exceptions reach `Log.w`.
4. Reopen the same series. `/meta/tv/<id>.json` fires again; `/meta/series/<id>.json` does not, since the addon-agnostic cache serves it.

After this change, step 3 sends only `/meta/series/<id>.json`, and step 4 makes no network request at all.

Not affected: users with "prefer external meta addon" enabled never reach `getMeta` unless all addons genuinely fail, and entry points that navigate without an `addonBaseUrl` nav arg skip it entirely.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Two files only: `MetaRepositoryImpl.kt` and a new test file. Deliberately not included, each better as its own issue:

- The third candidate pass (`metaResourceAddons.firstOrNull { it.supportsMetaId(id) }`) is redundant since #3136: anything it can add, passes 1 and 2 already added, and otherwise it degrades to dropping the addon when `supportedCandidateType()` returns null. Dead logic worth removing or rethinking, behavior-neutral today.
- `supportedCandidateType()` preserves the caller's spelling: an addon declaring `tv` asked for as `"TV"` gets `/meta/TV/<id>`, which some backends reject. Normalizing to the manifest's own casing belongs with the candidate-pass cleanup above.
- `VideoDto.rating` is `String?`; an object-valued rating fails the whole meta parse for that addon.
- `hydrateLibraryLogos` in `LibraryRepositoryImpl` has no callers.
- The legacy manifest-cache key is deleted without being read (`AddonRepositoryImpl.kt:128-130`).

No UI polish, no formatting changes, no refactors beyond extracting `normalizedAddonKey()` from two existing copies of the same expression.

## Testing

`./gradlew :app:testFullDebugUnitTest`, run against upstream dev with this patch applied:

- With patch: 924 tests, 12 failures, 1 skipped.
- Clean dev baseline: 916 tests, 12 failures, 1 skipped.

The delta is exactly the 8 tests added here, and the failure count is unchanged, so the 8 new tests pass and nothing that passed before fails. The 12 failures are pre-existing and outside the touched packages.

Narrow run `--tests 'com.nuvio.tv.data.repository.MetaRepository*'` is fully green across all 20 tests, covering the 8 new ones plus the pre-existing `MetaRepositoryAddonCacheTest` and `MetaRepositoryCandidateTypeTest`.

New tests cover: `tv` against a series-only addon requesting `series`; `tv` preserved when the addon declares it; type used as given for an unknown addon; the empty startup seed not being mistaken for an addon list; degrading when the list stays empty; a warm cache hit not waiting on the addon list; and cache entries being shared across both spellings.

No manual device testing performed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Cache changes are in-memory only, with no persisted keys to migrate.

Two known costs, both documented in the commit message:

- An install with zero addons pays the full 750ms wait per lookup, since a `StateFlow` parked on its empty seed never completes. Mostly background work, though `fetchSeriesEpisodes` in `PosterOptionsController` and `HomeViewModelLibraryActions` collect without a timeout, so it lands on a user action there.
- A first-ever launch has no manifest cache on disk, so the addon list waits on live fetches, usually longer than the budget. That start falls back to the requested type and pays the wait as well.

Both are latency-only. In each scenario the pre-existing behavior was an immediate identical failure, so the outcome is never worse, only slower.

## Linked issues

Fixes #3170. Follows up #3136.
