### PR TITLE
fix(details): prevent genre metadata overflow

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -85,6 +85,8 @@ import com.nuvio.tv.ui.util.localizedGenreLabel
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import java.util.Locale
 
+private const val MAX_VISIBLE_HERO_GENRES = 6
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun HeroContentSection(
@@ -667,7 +669,11 @@ private fun MetaInfoRow(
     tmdbRating: Float? = null
 ) {
     val context = LocalContext.current
-    val genresText = remember(meta.genres) { meta.genres.map { localizedGenreLabel(context, it) }.joinToString(" • ") }
+    val genresText = remember(meta.genres) {
+        meta.genres
+            .take(MAX_VISIBLE_HERO_GENRES)
+            .joinToString(" • ") { localizedGenreLabel(context, it) }
+    }
     val runtimeText = remember(meta.runtime) { meta.runtime?.let { formatRuntime(it) } }
     val yearText = remember(meta.releaseInfo, meta.released, meta.type, showFullReleaseDate) {
         if (showFullReleaseDate && meta.type == ContentType.MOVIE) {
@@ -731,12 +737,14 @@ private fun MetaInfoRow(
             horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Show all genres
             if (meta.genres.isNotEmpty()) {
                 Text(
                     text = genresText,
+                    modifier = Modifier.weight(1f, fill = false),
                     style = MaterialTheme.typography.labelLarge,
-                    color = NuvioTheme.extendedColors.textSecondary
+                    color = NuvioTheme.extendedColors.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 if (yearText != null || shouldShowImdbRating || shouldShowTmdbRating) {
                     MetaInfoDivider()


### PR DESCRIPTION
## Summary

Prevents genre metadata from wrapping into and clipping the detail hero metadata below it. The detail page now shows up to six genres on one line, preserves room for the year and ratings, and ellipsizes unusually long labels when needed.

The complete genre list remains unchanged in the underlying metadata. The visible count is controlled by `MAX_VISIBLE_HERO_GENRES`, so increasing or reducing the limit later only requires changing that constant.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Kitsu anime entries can provide far more genres than the detail hero was designed to display. One Piece currently provides 21 category tags, which caused the text to wrap into the age rating and runtime row. Even a smaller list can consume the row when genres have long names or expand after localization.

## Issue or approval

Fixes #3176

## Reproduction steps

1. Use a metadata addon that supplies Kitsu anime entries.
2. Open the Kitsu entry for One Piece.
3. Scroll to the season and episode section.
4. Observe the genre text wrapping and clipping into the metadata below it.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes genre presentation in the existing detail hero. It does not modify metadata fetching, genre ordering, localization, addon data, episode content, or any other screen. The complete genre list remains available to the rest of the app.

## Testing

- Built the full debug variant successfully.
- Installed and tested the build on an NVIDIA Shield TV.
- Verified the Kitsu One Piece detail page with its 21 category tags.
- Confirmed only six genres are shown.
- Confirmed the genre text stays on one line and no longer overlaps the metadata below it.
- Confirmed long labels ellipsize before crowding the year and ratings.
- Ran `git diff --check` successfully.

## Screenshots / Video

### Before

<img width="3840" height="2160" alt="ShowsWithExtremeAmountofGenres" src="https://github.com/user-attachments/assets/88bf6641-7613-4338-a6ac-3707ae053c19" />

### After

<img width="3840" height="2160" alt="GenreOverflowFixed" src="https://github.com/user-attachments/assets/5da29479-eff5-471d-94f5-d1a0dd8ae2bb" />

## Breaking changes

None.

## Linked issues

Fixes #3176
