### PR TITLE
fallback to English/Romaji cast and crew names when native script returned

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.core.tmdb
 
 import android.util.Log
 import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.data.remote.api.TmdbAggregateCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.TmdbCastMember
 import com.nuvio.tv.data.remote.api.TmdbCreditsResponse
@@ -102,30 +103,7 @@ class TmdbMetadataService(
                         when (tmdbType) {
                             "tv" -> {
                                 val aggregate = tmdbApi.getTvAggregateCredits(numericId, TMDB_API_KEY, normalizedLanguage).body()
-                                // Map aggregate credits to standard format for unified processing
-                                aggregate?.let { agg ->
-                                    TmdbCreditsResponse(
-                                        cast = agg.cast?.map { member ->
-                                            TmdbCastMember(
-                                                id = member.id,
-                                                name = member.name,
-                                                character = member.roles?.firstOrNull()?.character,
-                                                profilePath = member.profilePath
-                                            )
-                                        },
-                                        crew = agg.crew?.flatMap { member ->
-                                            member.jobs?.map { job ->
-                                                TmdbCrewMember(
-                                                    id = member.id,
-                                                    name = member.name,
-                                                    job = job.job,
-                                                    department = member.department,
-                                                    profilePath = member.profilePath
-                                                )
-                                            } ?: emptyList()
-                                        }
-                                    )
-                                }
+                                aggregate?.let { mapAggregateCreditsToStandard(it) }
                             }
                             else -> tmdbApi.getMovieCredits(numericId, TMDB_API_KEY, normalizedLanguage).body()
                         }
@@ -173,6 +151,63 @@ class TmdbMetadataService(
                         altTitlesDeferred.await(),
                         trailersDeferred.await()
                     )
+                }
+
+                val needsCastEnglishFallback = !normalizedLanguage.startsWith("en") &&
+                    !normalizedLanguage.startsWith("ja") &&
+                    !normalizedLanguage.startsWith("ko") &&
+                    !normalizedLanguage.startsWith("zh") &&
+                    (
+                        credits?.cast.orEmpty().any { member ->
+                            val name = member.name
+                            val original = member.originalName
+                            !name.isNullOrBlank() && containsCjkOrHangul(name) && (original.isNullOrBlank() || containsCjkOrHangul(original))
+                        } ||
+                        credits?.crew.orEmpty().any { member ->
+                            val name = member.name
+                            val original = member.originalName
+                            !name.isNullOrBlank() && containsCjkOrHangul(name) && (original.isNullOrBlank() || containsCjkOrHangul(original))
+                        } ||
+                        details?.createdBy.orEmpty().any { creatorItem ->
+                            val name = creatorItem.name
+                            val original = creatorItem.originalName
+                            !name.isNullOrBlank() && containsCjkOrHangul(name) && (original.isNullOrBlank() || containsCjkOrHangul(original))
+                        }
+                    )
+
+                val englishFallbackNames = if (needsCastEnglishFallback) {
+                    runCatching {
+                        val englishCredits = when (tmdbType) {
+                            "tv" -> tmdbApi.getTvAggregateCredits(numericId, TMDB_API_KEY, "en-US").body()?.let { mapAggregateCreditsToStandard(it) }
+                            else -> tmdbApi.getMovieCredits(numericId, TMDB_API_KEY, "en-US").body()
+                        }
+                        val englishTvDetails = if (tmdbType == "tv" && !details?.createdBy.isNullOrEmpty()) {
+                            tmdbApi.getTvDetails(numericId, TMDB_API_KEY, "en-US").body()
+                        } else null
+
+                        buildMap<Int, String> {
+                            englishCredits?.cast?.forEach { member ->
+                                val id = member.id
+                                val name = member.name?.trim()?.takeIf { it.isNotBlank() }
+                                if (id != null && name != null) put(id, name)
+                            }
+                            englishCredits?.crew?.forEach { member ->
+                                val id = member.id
+                                val name = member.name?.trim()?.takeIf { it.isNotBlank() }
+                                if (id != null && name != null) put(id, name)
+                            }
+                            englishTvDetails?.createdBy?.forEach { creatorItem ->
+                                val id = creatorItem.id
+                                val name = creatorItem.name?.trim()?.takeIf { it.isNotBlank() }
+                                if (id != null && name != null) put(id, name)
+                            }
+                        }
+                    }.getOrElse {
+                        Log.w(TAG, "Failed to fetch English credits fallback for $numericId: ${it.message}")
+                        emptyMap()
+                    }
+                } else {
+                    emptyMap()
                 }
 
                 val genres = details?.genres?.mapNotNull { genre ->
@@ -248,7 +283,12 @@ class TmdbMetadataService(
                 val castMembers = credits?.cast
                     .orEmpty()
                     .mapNotNull { member ->
-                        val name = member.name?.trim()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                        val name = resolvePersonName(
+                            localizedName = member.name,
+                            originalName = member.originalName,
+                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                            preferredLanguage = normalizedLanguage
+                        )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
                             name = name,
                             character = member.character?.takeIf { it.isNotBlank() },
@@ -260,17 +300,22 @@ class TmdbMetadataService(
                 val creatorMembers = if (tmdbType == "tv") {
                     details?.createdBy
                         .orEmpty()
-                        .mapNotNull { creator ->
-                            val tmdbPersonId = creator.id ?: return@mapNotNull null
-                            val name = creator.name?.trim()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                        .mapNotNull { creatorItem ->
+                            val tmdbPersonId = creatorItem.id ?: return@mapNotNull null
+                            val name = resolvePersonName(
+                                localizedName = creatorItem.name,
+                                originalName = creatorItem.originalName,
+                                fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                                preferredLanguage = normalizedLanguage
+                            )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                             MetaCastMember(
                                 name = name,
                                 character = "Creator",
-                                photo = buildImageUrl(creator.profilePath, size = "w500"),
+                                photo = buildImageUrl(creatorItem.profilePath, size = "w500"),
                                 tmdbId = tmdbPersonId
                             )
                         }
-                        .distinctBy { it.tmdbId ?: it.name.lowercase() }
+                        .distinctBy { it.tmdbId ?: it.name.lowercase(Locale.US) }
                 } else {
                     emptyList()
                 }
@@ -278,7 +323,14 @@ class TmdbMetadataService(
                 val creator = if (tmdbType == "tv") {
                     details?.createdBy
                         .orEmpty()
-                        .mapNotNull { it.name?.trim()?.takeIf { name -> name.isNotBlank() } }
+                        .mapNotNull { creatorItem ->
+                            resolvePersonName(
+                                localizedName = creatorItem.name,
+                                originalName = creatorItem.originalName,
+                                fallbackEnglishName = creatorItem.id?.let { englishFallbackNames[it] },
+                                preferredLanguage = normalizedLanguage
+                            )?.takeIf { it.isNotBlank() }
+                        }
                 } else {
                     emptyList()
                 }
@@ -290,7 +342,12 @@ class TmdbMetadataService(
                 val directorMembers = directorCrew
                     .mapNotNull { member ->
                         val tmdbPersonId = member.id ?: return@mapNotNull null
-                        val name = member.name?.trim()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                        val name = resolvePersonName(
+                            localizedName = member.name,
+                            originalName = member.originalName,
+                            fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                            preferredLanguage = normalizedLanguage
+                        )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
                             name = name,
                             character = "Director",
@@ -298,22 +355,34 @@ class TmdbMetadataService(
                             tmdbId = tmdbPersonId
                         )
                     }
-                    .distinctBy { it.tmdbId ?: it.name.lowercase() }
+                    .distinctBy { it.tmdbId ?: it.name.lowercase(Locale.US) }
 
                 val director = directorCrew
-                    .mapNotNull { it.name?.trim()?.takeIf { name -> name.isNotBlank() } }
+                    .mapNotNull { member ->
+                        resolvePersonName(
+                            localizedName = member.name,
+                            originalName = member.originalName,
+                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                            preferredLanguage = normalizedLanguage
+                        )?.takeIf { it.isNotBlank() }
+                    }
 
                 val writerCrew = credits?.crew
                     .orEmpty()
                     .filter { crew ->
-                        val job = crew.job?.lowercase() ?: ""
+                        val job = crew.job?.lowercase(Locale.US) ?: ""
                         job.contains("writer") || job.contains("screenplay")
                     }
 
                 val writerMembers = writerCrew
                     .mapNotNull { member ->
                         val tmdbPersonId = member.id ?: return@mapNotNull null
-                        val name = member.name?.trim()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                        val name = resolvePersonName(
+                            localizedName = member.name,
+                            originalName = member.originalName,
+                            fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                            preferredLanguage = normalizedLanguage
+                        )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
                             name = name,
                             character = "Writer",
@@ -321,10 +390,17 @@ class TmdbMetadataService(
                             tmdbId = tmdbPersonId
                         )
                     }
-                    .distinctBy { it.tmdbId ?: it.name.lowercase() }
+                    .distinctBy { it.tmdbId ?: it.name.lowercase(Locale.US) }
 
                 val writer = writerCrew
-                    .mapNotNull { it.name?.trim()?.takeIf { name -> name.isNotBlank() } }
+                    .mapNotNull { member ->
+                        resolvePersonName(
+                            localizedName = member.name,
+                            originalName = member.originalName,
+                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                            preferredLanguage = normalizedLanguage
+                        )?.takeIf { it.isNotBlank() }
+                    }
 
                 // Only expose either Director or Writer people (prefer Director).
                 val hasCreator = creatorMembers.isNotEmpty() || creator.isNotEmpty()
@@ -1101,6 +1177,32 @@ class TmdbMetadataService(
         private const val TOP_RATED_VOTE_COUNT_FLOOR = 200
     }
 
+    private fun mapAggregateCreditsToStandard(aggregate: TmdbAggregateCreditsResponse): TmdbCreditsResponse {
+        return TmdbCreditsResponse(
+            cast = aggregate.cast?.map { member ->
+                TmdbCastMember(
+                    id = member.id,
+                    name = member.name,
+                    originalName = member.originalName,
+                    character = member.roles?.firstOrNull()?.character,
+                    profilePath = member.profilePath
+                )
+            },
+            crew = aggregate.crew?.flatMap { member ->
+                member.jobs?.map { job ->
+                    TmdbCrewMember(
+                        id = member.id,
+                        name = member.name,
+                        originalName = member.originalName,
+                        job = job.job,
+                        department = member.department,
+                        profilePath = member.profilePath
+                    )
+                } ?: emptyList()
+            }
+        )
+    }
+
     suspend fun fetchPersonDetail(
         personId: Int,
         preferCrewCredits: Boolean? = null,
@@ -1124,14 +1226,32 @@ class TmdbMetadataService(
 
                 if (person == null) return@withContext null
 
+                val isCjkLanguage = normalizedLanguage.startsWith("ja") ||
+                    normalizedLanguage.startsWith("ko") ||
+                    normalizedLanguage.startsWith("zh")
+
+                val shouldFetchEnglishPerson = normalizedLanguage != "en" &&
+                    (person.biography.isNullOrBlank() || (!isCjkLanguage && person.name != null && containsCjkOrHangul(person.name) && (person.originalName == null || containsCjkOrHangul(person.originalName))))
+
+                val englishPerson = if (shouldFetchEnglishPerson) {
+                    runCatching {
+                        tmdbApi.getPersonDetails(personId, TMDB_API_KEY, "en").body()
+                    }.getOrNull()
+                } else null
+
                 // If biography is empty and language is not English, fetch English fallback
                 val biography = if (person.biography.isNullOrBlank() && normalizedLanguage != "en") {
-                    runCatching {
-                        tmdbApi.getPersonDetails(personId, TMDB_API_KEY, "en").body()?.biography
-                    }.getOrNull()
+                    englishPerson?.biography
                 } else {
                     person.biography
                 }?.takeIf { it.isNotBlank() }
+
+                val resolvedPersonName = resolvePersonName(
+                    localizedName = person.name,
+                    originalName = person.originalName,
+                    fallbackEnglishName = englishPerson?.name,
+                    preferredLanguage = normalizedLanguage
+                ) ?: "Unknown"
 
                 val preferCrewFilmography = preferCrewCredits ?: shouldPreferCrewCredits(person.knownForDepartment)
 
@@ -1153,7 +1273,7 @@ class TmdbMetadataService(
 
                 val detail = PersonDetail(
                     tmdbId = person.id,
-                    name = person.name ?: "Unknown",
+                    name = resolvedPersonName,
                     biography = biography,
                     birthday = person.birthday?.takeIf { it.isNotBlank() },
                     deathday = person.deathday?.takeIf { it.isNotBlank() },
@@ -1463,4 +1583,52 @@ private fun TmdbEpisode.toEnrichment(): TmdbEpisodeEnrichment {
         airDate = airDate,
         runtimeMinutes = runtime
     )
+}
+
+internal fun containsCjkOrHangul(text: String): Boolean {
+    return text.any { ch ->
+        ch in '\u3040'..'\u30FF' ||  // Hiragana + Katakana
+        ch in '\u4E00'..'\u9FFF' ||  // CJK Unified Ideographs
+        ch in '\u3400'..'\u4DBF' ||  // CJK Extension A
+        ch in '\uAC00'..'\uD7AF' ||  // Hangul Syllables
+        ch in '\u1100'..'\u11FF' ||  // Hangul Jamo
+        ch in '\u3130'..'\u318F'     // Hangul Compatibility Jamo
+    }
+}
+
+internal fun resolvePersonName(
+    localizedName: String?,
+    originalName: String?,
+    fallbackEnglishName: String? = null,
+    preferredLanguage: String
+): String? {
+    val name = localizedName?.trim()?.takeIf { it.isNotBlank() }
+    val original = originalName?.trim()?.takeIf { it.isNotBlank() }
+    val fallback = fallbackEnglishName?.trim()?.takeIf { it.isNotBlank() }
+
+    if (name == null) return original ?: fallback
+    val lang = preferredLanguage.lowercase(Locale.US)
+
+    // User explicitly prefers CJK / Hangul
+    if (lang.startsWith("ja") || lang.startsWith("ko") || lang.startsWith("zh")) {
+        return name
+    }
+
+    // If already Latin or non-CJK script, keep localized name
+    if (!containsCjkOrHangul(name)) {
+        return name
+    }
+
+    // Name is CJK/Hangul: if originalName is Latin (Romaji/stage name), use it
+    if (original != null && !containsCjkOrHangul(original)) {
+        return original
+    }
+
+    // If English fallback exists and is Latin / non-CJK, prefer it
+    if (fallback != null && !containsCjkOrHangul(fallback)) {
+        return fallback
+    }
+
+    // Otherwise fallback to whatever non-null exists
+    return fallback ?: original ?: name
 }

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -357,6 +357,7 @@ data class TmdbDetailsResponse(
 data class TmdbCreatedBy(
     @Json(name = "id") val id: Int? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "profile_path") val profilePath: String? = null
 )
 
@@ -396,6 +397,7 @@ data class TmdbAggregateCreditsResponse(
 data class TmdbAggregateCastMember(
     @Json(name = "id") val id: Int? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "roles") val roles: List<TmdbAggregateRole>? = null,
     @Json(name = "profile_path") val profilePath: String? = null,
     @Json(name = "total_episode_count") val totalEpisodeCount: Int? = null
@@ -411,6 +413,7 @@ data class TmdbAggregateRole(
 data class TmdbAggregateCrewMember(
     @Json(name = "id") val id: Int? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "jobs") val jobs: List<TmdbAggregateJob>? = null,
     @Json(name = "profile_path") val profilePath: String? = null,
     @Json(name = "department") val department: String? = null,
@@ -427,6 +430,7 @@ data class TmdbAggregateJob(
 data class TmdbCastMember(
     @Json(name = "id") val id: Int? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "character") val character: String? = null,
     @Json(name = "profile_path") val profilePath: String? = null
 )
@@ -435,6 +439,7 @@ data class TmdbCastMember(
 data class TmdbCrewMember(
     @Json(name = "id") val id: Int? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "job") val job: String? = null,
     @Json(name = "department") val department: String? = null,
     @Json(name = "profile_path") val profilePath: String? = null
@@ -634,6 +639,7 @@ data class TmdbRecommendationResult(
 data class TmdbPersonResponse(
     @Json(name = "id") val id: Int,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "biography") val biography: String? = null,
     @Json(name = "birthday") val birthday: String? = null,
     @Json(name = "deathday") val deathday: String? = null,
@@ -655,6 +661,8 @@ data class TmdbPersonCreditCast(
     @Json(name = "id") val id: Int,
     @Json(name = "title") val title: String? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_title") val originalTitle: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "media_type") val mediaType: String? = null,
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "backdrop_path") val backdropPath: String? = null,
@@ -672,6 +680,8 @@ data class TmdbPersonCreditCrew(
     @Json(name = "id") val id: Int,
     @Json(name = "title") val title: String? = null,
     @Json(name = "name") val name: String? = null,
+    @Json(name = "original_title") val originalTitle: String? = null,
+    @Json(name = "original_name") val originalName: String? = null,
     @Json(name = "media_type") val mediaType: String? = null,
     @Json(name = "poster_path") val posterPath: String? = null,
     @Json(name = "backdrop_path") val backdropPath: String? = null,

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -1,10 +1,15 @@
 package com.nuvio.tv.core.tmdb
 
+import com.nuvio.tv.data.remote.api.TmdbAggregateCastMember
 import com.nuvio.tv.data.remote.api.TmdbAggregateCreditsResponse
+import com.nuvio.tv.data.remote.api.TmdbAggregateRole
 import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TmdbCastMember
 import com.nuvio.tv.data.remote.api.TmdbCompany
 import com.nuvio.tv.data.remote.api.TmdbCompanyDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbCreatedBy
 import com.nuvio.tv.data.remote.api.TmdbCreditsResponse
+import com.nuvio.tv.data.remote.api.TmdbCrewMember
 import com.nuvio.tv.data.remote.api.TmdbDetailsResponse
 import com.nuvio.tv.data.remote.api.TmdbDiscoverResponse
 import com.nuvio.tv.data.remote.api.TmdbDiscoverResult
@@ -13,6 +18,7 @@ import com.nuvio.tv.data.remote.api.TmdbImagesResponse
 import com.nuvio.tv.data.remote.api.TmdbMovieReleaseDatesResponse
 import com.nuvio.tv.data.remote.api.TmdbNetwork
 import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbPersonResponse
 import com.nuvio.tv.data.remote.api.TmdbSeasonResponse
 import com.nuvio.tv.data.remote.api.TmdbTvContentRatingsResponse
 import com.nuvio.tv.data.remote.api.TmdbVideosResponse
@@ -28,6 +34,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -385,6 +392,285 @@ class TmdbMetadataServiceTest {
         assertTrue(tvCalls.all { it.withStatus == "0|3|4" })
         assertNull(tvCalls.firstOrNull { it.sortBy == "popularity.desc" }?.voteCountGte)
         assertEquals(200, tvCalls.first { it.sortBy == "vote_average.desc" }.voteCountGte)
+    }
+
+    @Test
+    fun `containsCjkOrHangul detects Asian scripts correctly`() {
+        assertTrue(containsCjkOrHangul("木村拓哉"))
+        assertTrue(containsCjkOrHangul("田中 敦子"))
+        assertTrue(containsCjkOrHangul("김수현"))
+        assertTrue(containsCjkOrHangul("成龙"))
+        assertFalse(containsCjkOrHangul("Scarlett Johansson"))
+        assertFalse(containsCjkOrHangul("Tom Hanks"))
+        assertFalse(containsCjkOrHangul("12345"))
+    }
+
+    @Test
+    fun `resolvePersonName falls back JP kanji to romaji or english for non-CJK locales`() {
+        assertEquals(
+            "Takuya Kimura",
+            resolvePersonName("木村拓哉", "Takuya Kimura", null, "tr-TR")
+        )
+        assertEquals(
+            "Takuya Kimura",
+            resolvePersonName("木村拓哉", "木村拓哉", "Takuya Kimura", "tr-TR")
+        )
+        assertEquals(
+            "Tsuyoshi Kusanagi",
+            resolvePersonName("草彅剛", "Tsuyoshi Kusanagi", null, "pl-PL")
+        )
+        assertEquals(
+            "Atsuko Tanaka",
+            resolvePersonName("田中敦子", "田中敦子", "Atsuko Tanaka", "de-DE")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps kanji when user language is Japanese`() {
+        assertEquals(
+            "木村拓哉",
+            resolvePersonName("木村拓哉", "Takuya Kimura", "Takuya Kimura", "ja-JP")
+        )
+        assertEquals(
+            "田中敦子",
+            resolvePersonName("田中敦子", "田中敦子", "Atsuko Tanaka", "ja")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName falls back Hangul to Latin for non-Korean locales`() {
+        assertEquals(
+            "Kim Soo-hyun",
+            resolvePersonName("김수현", "Kim Soo-hyun", null, "de-DE")
+        )
+        assertEquals(
+            "Kim Soo-hyun",
+            resolvePersonName("김수현", "김수현", "Kim Soo-hyun", "fr-FR")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps Hangul when user language is Korean`() {
+        assertEquals(
+            "김수현",
+            resolvePersonName("김수현", "Kim Soo-hyun", "Kim Soo-hyun", "ko-KR")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName falls back Chinese hanzi to stage name for non-Chinese locales`() {
+        assertEquals(
+            "Jackie Chan",
+            resolvePersonName("成龙", "Jackie Chan", null, "es-ES")
+        )
+        assertEquals(
+            "Jackie Chan",
+            resolvePersonName("成龙", "成龙", "Jackie Chan", "en-US")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps hanzi when user language is Chinese`() {
+        assertEquals(
+            "成龙",
+            resolvePersonName("成龙", "Jackie Chan", "Jackie Chan", "zh-CN")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName leaves already-Latin names unchanged`() {
+        assertEquals(
+            "Scarlett Johansson",
+            resolvePersonName("Scarlett Johansson", "Scarlett Johansson", null, "tr-TR")
+        )
+        assertEquals(
+            "Tom Hanks",
+            resolvePersonName("Tom Hanks", "Tom Hanks", null, "ja-JP")
+        )
+    }
+
+    @Test
+    fun `resolvePersonName handles null and blank inputs`() {
+        assertEquals("Takuya Kimura", resolvePersonName(null, "Takuya Kimura", null, "tr-TR"))
+        assertEquals("Scarlett Johansson", resolvePersonName("Scarlett Johansson", null, null, "tr-TR"))
+        assertNull(resolvePersonName(null, null, null, "tr-TR"))
+        assertEquals(
+            "Takuya Kimura",
+            resolvePersonName("  木村拓哉  ", "Takuya Kimura", null, "fr-FR")
+        )
+    }
+
+    @Test
+    fun `fetchEnrichment falls back Japanese movie cast names to English for Turkish locale`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getMovieDetails(100, any(), "tr-TR") } returns Response.success(
+            TmdbDetailsResponse(id = 100, title = "Ghost in the Shell")
+        )
+        coEvery { api.getMovieCredits(100, any(), "tr-TR") } returns Response.success(
+            TmdbCreditsResponse(
+                cast = listOf(
+                    TmdbCastMember(
+                        id = 1,
+                        name = "田中敦子",
+                        originalName = "田中敦子",
+                        character = "Motoko Kusanagi",
+                        profilePath = "/tanaka.jpg"
+                    ),
+                    TmdbCastMember(
+                        id = 2,
+                        name = "Scarlett Johansson",
+                        originalName = "Scarlett Johansson",
+                        character = "Major",
+                        profilePath = "/sj.jpg"
+                    )
+                ),
+                crew = listOf(
+                    TmdbCrewMember(
+                        id = 3,
+                        name = "押井守",
+                        originalName = "押井守",
+                        job = "Director",
+                        profilePath = "/oshii.jpg"
+                    )
+                )
+            )
+        )
+        coEvery { api.getMovieCredits(100, any(), "en-US") } returns Response.success(
+            TmdbCreditsResponse(
+                cast = listOf(
+                    TmdbCastMember(
+                        id = 1,
+                        name = "Atsuko Tanaka",
+                        originalName = "田中敦子",
+                        character = "Motoko Kusanagi",
+                        profilePath = "/tanaka.jpg"
+                    ),
+                    TmdbCastMember(
+                        id = 2,
+                        name = "Scarlett Johansson",
+                        originalName = "Scarlett Johansson",
+                        character = "Major",
+                        profilePath = "/sj.jpg"
+                    )
+                ),
+                crew = listOf(
+                    TmdbCrewMember(
+                        id = 3,
+                        name = "Mamoru Oshii",
+                        originalName = "押井守",
+                        job = "Director",
+                        profilePath = "/oshii.jpg"
+                    )
+                )
+            )
+        )
+        coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+        coEvery { api.getMovieReleaseDates(any(), any()) } returns Response.success(TmdbMovieReleaseDatesResponse())
+        coEvery { api.getMovieVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 100))
+
+        val service = TmdbMetadataService(api)
+        val enrichment = service.fetchEnrichment(
+            tmdbId = "100",
+            contentType = ContentType.MOVIE,
+            language = "tr-TR"
+        )
+
+        assertNotNull(enrichment)
+        val castNames = enrichment!!.castMembers.map { it.name }
+        assertEquals(listOf("Atsuko Tanaka", "Scarlett Johansson"), castNames)
+
+        val directorNames = enrichment.directorMembers.map { it.name }
+        assertEquals(listOf("Mamoru Oshii"), directorNames)
+    }
+
+    @Test
+    fun `fetchEnrichment falls back TV aggregate credits cast and creator names to English for Polish locale`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getTvDetails(255358, any(), "pl-PL") } returns Response.success(
+            TmdbDetailsResponse(
+                id = 255358,
+                name = "THE GHOST IN THE SHELL",
+                createdBy = listOf(
+                    TmdbCreatedBy(id = 10, name = "士郎正宗", originalName = "士郎正宗")
+                )
+            )
+        )
+        coEvery { api.getTvAggregateCredits(255358, any(), "pl-PL") } returns Response.success(
+            TmdbAggregateCreditsResponse(
+                cast = listOf(
+                    TmdbAggregateCastMember(
+                        id = 1,
+                        name = "田中敦子",
+                        originalName = "田中敦子",
+                        roles = listOf(TmdbAggregateRole(character = "Motoko Kusanagi", episodeCount = 12))
+                    )
+                )
+            )
+        )
+        coEvery { api.getTvAggregateCredits(255358, any(), "en-US") } returns Response.success(
+            TmdbAggregateCreditsResponse(
+                cast = listOf(
+                    TmdbAggregateCastMember(
+                        id = 1,
+                        name = "Atsuko Tanaka",
+                        originalName = "田中敦子",
+                        roles = listOf(TmdbAggregateRole(character = "Motoko Kusanagi", episodeCount = 12))
+                    )
+                )
+            )
+        )
+        coEvery { api.getTvDetails(255358, any(), "en-US") } returns Response.success(
+            TmdbDetailsResponse(
+                id = 255358,
+                name = "THE GHOST IN THE SHELL",
+                createdBy = listOf(
+                    TmdbCreatedBy(id = 10, name = "Masamune Shirow", originalName = "士郎正宗")
+                )
+            )
+        )
+        coEvery { api.getTvImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+        coEvery { api.getTvContentRatings(any(), any()) } returns Response.success(TmdbTvContentRatingsResponse())
+        coEvery { api.getTvVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 255358))
+
+        val service = TmdbMetadataService(api)
+        val enrichment = service.fetchEnrichment(
+            tmdbId = "255358",
+            contentType = ContentType.SERIES,
+            language = "pl-PL"
+        )
+
+        assertNotNull(enrichment)
+        assertEquals(listOf("Atsuko Tanaka"), enrichment!!.castMembers.map { it.name })
+        assertEquals(listOf("Masamune Shirow"), enrichment.directorMembers.map { it.name })
+    }
+
+    @Test
+    fun `fetchPersonDetail falls back Japanese person name to English for Turkish locale`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getPersonDetails(500, any(), "tr-TR") } returns Response.success(
+            TmdbPersonResponse(
+                id = 500,
+                name = "田中敦子",
+                originalName = "田中敦子",
+                biography = ""
+            )
+        )
+        coEvery { api.getPersonDetails(500, any(), "en") } returns Response.success(
+            TmdbPersonResponse(
+                id = 500,
+                name = "Atsuko Tanaka",
+                originalName = "田中敦子",
+                biography = "Atsuko Tanaka was a Japanese voice actress."
+            )
+        )
+        coEvery { api.getPersonCombinedCredits(500, any(), "tr-TR") } returns Response.success(null)
+
+        val service = TmdbMetadataService(api)
+        val detail = service.fetchPersonDetail(personId = 500, language = "tr-TR")
+
+        assertNotNull(detail)
+        assertEquals("Atsuko Tanaka", detail?.name)
+        assertEquals("Atsuko Tanaka was a Japanese voice actress.", detail?.biography)
     }
 
     private data class MovieDiscoverCall(


### PR DESCRIPTION
## Summary

When TMDB returns Asian cast, crew (directors, writers), creators, or person details in native scripts (Kanji, Kana, Hangul, Hanzi) for non-CJK user languages (e.g., Turkish, Polish, German, French, English), this PR falls back to Romaji (`original_name`) or English names fetched from `en-US` credits.

```mermaid
flowchart LR
    A["TMDB Name"] --> B{"ja/ko/zh?"}
    B -- Yes --> C["Keep Native Script"]
    B -- No --> D{"Is CJK/Hangul?"}
    D -- No --> E["Use Localized Name"]
    D -- Yes --> F{"Latin in original_name?"}
    F -- Yes --> G["Use Romaji"]
    F -- No --> H["Fetch en-US Fallback"]
```

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

TMDB person names for Japanese, Korean, and Chinese actors/directors are returned in native Asian characters even when the user has configured a non-CJK language (such as Turkish, Polish, German, or English). Non-CJK users cannot read native Kanji/Kana/Hangul characters. This PR ensures readable English/Romaji names are displayed while preserving native script for CJK users.

## Issue or approval

Maintainer approval / Discord request: Japanese and Asian cast/crew names returned in native letters instead of Romaji for non-CJK languages.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only TMDB person name resolution (`cast`, `crew`, `createdBy`, `PersonDetail`) was modified to introduce English/Romaji fallback for Asian scripts. No unrelated screens, UI components, or player logic were touched.

## Testing

- **Unit tests executed:**
  `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest` (BUILD SUCCESSFUL, 100% passed)
  - Tested `containsCjkOrHangul` character range detection.
  - Tested `resolvePersonName` across multiple locales (`tr-TR`, `pl-PL`, `de-DE`, `ja-JP`, `ko-KR`, `zh-CN`).
  - Tested Movie and TV Aggregate Credits enrichment with English fallback mock responses.
  - Tested `fetchPersonDetail` fallback.
- **Kotlin compilation:**
  `./gradlew :app:compileFullDebugKotlin` (BUILD SUCCESSFUL)

## Screenshots / Video

| Before | After |
|:------:|:-----:|
| <img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/a9bcf20b-afc9-4a63-878b-f95683620a36" />|<img width="1920" height="1080" alt="nuvio_tv_2026-08-24_21-44-06" src="https://github.com/user-attachments/assets/7a1ec020-3ef1-45a7-bcb4-ea17eef8a0ba" /> |

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.
