### PR TITLE
fix(player): prevent subtitle timing crash on duplicate cue keys (NUVIO-TV-QR)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleTimingDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleTimingDialog.kt
@@ -308,7 +308,7 @@ private fun CueSelectionPanel(
         ) {
             itemsIndexed(
                 items = cues,
-                key = { _, cue -> "${cue.startTimeMs}:${cue.text.hashCode()}" }
+                key = { index, cue -> subtitleCueListItemKey(index, cue) }
             ) { index, cue ->
                 CueRow(
                     cue = cue,
@@ -403,7 +403,11 @@ private fun sanitizeCuePreviewText(text: String): String {
     return if (cleaned.isNotBlank()) cleaned else text.trim()
 }
 
-private fun selectAutoSyncVisibleCues(
+internal fun subtitleCueListItemKey(index: Int, cue: SubtitleSyncCue): String {
+    return "$index:${cue.startTimeMs}:${cue.endTimeMs}:${cue.text.hashCode()}"
+}
+
+internal fun selectAutoSyncVisibleCues(
     cues: List<SubtitleSyncCue>,
     anchorTimeMs: Long,
     marginMs: Long = 180_000L,


### PR DESCRIPTION
## Summary

Prevent a fatal player crash in the subtitle timing dialog when an add-on subtitle file contains two or more cues that produce the same LazyColumn key.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Opening Subtitle Timing with some add-on `.srt` / `.vtt` files crashed the entire app process. Cue list keys were `${startTimeMs}:${text.hashCode()}`, which is not unique when two cues share the same start timestamp and text, or when different texts share a `hashCode`. Compose then throws `IllegalArgumentException` during LazyColumn measure.

## Issue or approval

Fixes NUVIO-TV-QR

## Reproduction steps

1. Open the player and select an add-on subtitle (`.srt` or `.vtt`) that contains two cues at the same start timestamp with the same (or hash-colliding) text.
2. Open Subtitle Timing and capture a sync point near those cues so the cue list is shown.
3. App process crashes with `IllegalArgumentException: Key "..." was already used.`

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Cue list item keys now include index and end time so duplicates cannot collide. Subtitle parsing is unchanged and still keeps duplicate cues. No UI restyle, no parser dedup, no test files in this PR.

## Testing

- Reproduced the crash condition with duplicate SRT/VTT cues at `00:02:09.310` and with a known `String.hashCode` collision (`FB` / `Ea`).
- After the key change, the same cases produce unique LazyColumn keys.
- Ran `./gradlew :app:testPlaystoreDebugUnitTest --tests com.nuvio.tv.ui.screens.player.SubtitleTimingCueListKeyTest` locally (6/6). Test file is not included in this PR.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes NUVIO-TV-QR
