### PR TITLE
Fix Pause Overlay disappearing after Content Warning

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1120,7 +1120,9 @@ fun PlayerRuntimeController.hideControls() {
 }
 
 fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
-    onUserInteraction()
+    if (event != PlayerEvent.OnParentalGuideHide) {
+        onUserInteraction()
+    }
     when (event) {
         PlayerEvent.OnPlayPause -> {
             if (isUsingMpvEngine()) {


### PR DESCRIPTION
Fix Pause Overlay

## Summary

Fix the interaction between Pause Overlay and Content Warnings so that the Pause Overlay remains visible after the Content Warning finishes displaying.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

When both features are enabled, the Content Warning currently causes the Pause Overlay to disappear once the warning is dismissed. This results in the paused state no longer being visually represented correctly and creates inconsistent behavior between the two features.

This PR ensures that dismissing or completing the Content Warning restores/retains the Pause Overlay as expected, so both features can work together without interfering with each other.

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->
Fixes #3022 

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

#3022 