### PR TITLE
Respect poster corner radius everywhere

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailScreen.kt
@@ -119,6 +119,7 @@ fun CastDetailScreen(
                         person = state.personDetail,
                         onNavigateToDetail = onNavigateToDetail,
                         posterOptions = viewModel.posterOptions,
+                        posterCardCornerRadiusDp = viewModel.posterCardCornerRadiusDp.collectAsState().value,
                         isItemWatched = { item ->
                             if (item.apiType == "movie") item.id in watchedMovieIds
                             else item.id in watchedSeriesIds
@@ -145,6 +146,7 @@ private fun CastDetailContent(
     person: PersonDetail,
     onNavigateToDetail: (itemId: String, itemType: String, addonBaseUrl: String?) -> Unit,
     posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController,
+    posterCardCornerRadiusDp: Int = 12,
     isItemWatched: (MetaPreview) -> Boolean = { false }
 ) {
     val backgroundColor = NuvioTheme.colors.Background
@@ -156,11 +158,11 @@ private fun CastDetailContent(
             .sortedByDescending { releaseYearSortKey(it.releaseInfo) }
     }
 
-    val filmographyPosterStyle = remember {
+    val filmographyPosterStyle = remember(posterCardCornerRadiusDp) {
         PosterCardStyle(
             width = 112.dp,
             height = 168.dp,
-            cornerRadius = PosterCardDefaults.Style.cornerRadius,
+            cornerRadius = posterCardCornerRadiusDp.dp,
             focusedBorderWidth = PosterCardDefaults.Style.focusedBorderWidth,
             focusedScale = PosterCardDefaults.Style.focusedScale
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/cast/CastDetailViewModel.kt
@@ -23,6 +23,7 @@ class CastDetailViewModel @Inject constructor(
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
     private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
     private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
+    private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     val posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -40,10 +41,17 @@ class CastDetailViewModel @Inject constructor(
     val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
     val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
 
+    private val _posterCardCornerRadiusDp = MutableStateFlow(12)
+    val posterCardCornerRadiusDp: StateFlow<Int> = _posterCardCornerRadiusDp.asStateFlow()
+
     init {
         posterOptions.bind(viewModelScope)
         loadPersonDetail()
         observeWatchedStatus()
+        viewModelScope.launch {
+            layoutPreferenceDataStore.posterCardCornerRadiusDp
+                .collect { _posterCardCornerRadiusDp.value = it }
+        }
     }
 
     private fun observeWatchedStatus() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -366,7 +366,9 @@ private fun TabbedGridContent(
         }
         currentTab.catalogRow != null -> {
             val items = currentTab.catalogRow.items
-            val posterCardStyle = PosterCardDefaults.Style
+            val posterCardStyle = PosterCardDefaults.Style.copy(
+                cornerRadius = uiState.posterCardCornerRadiusDp.dp
+            )
             val itemFocusRequesters = remember(uiState.selectedTabIndex) { mutableMapOf<String, FocusRequester>() }
             var lastFocusedItemKey by remember(
                 uiState.selectedTabIndex,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/CollectionSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/CollectionSection.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -31,6 +32,7 @@ import com.nuvio.tv.ui.components.PosterCardStyle
 fun CollectionSection(
     items: List<MetaPreview>,
     title: String? = null,
+    posterCardCornerRadius: Dp = NuvioTheme.spacing.md,
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
     sectionFocusRequester: FocusRequester? = null,
@@ -59,11 +61,11 @@ fun CollectionSection(
         restoreFocusRequester.requestFocusAfterFrames()
     }
 
-    val landscapeStyle = remember {
+    val landscapeStyle = remember(posterCardCornerRadius) {
         PosterCardStyle(
             width = 260.dp,
             height = 146.dp,
-            cornerRadius = NuvioTheme.spacing.md,
+            cornerRadius = posterCardCornerRadius,
             focusedBorderWidth = NuvioTheme.spacing.xxs,
             focusedScale = 1.02f
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -260,6 +260,7 @@ fun EpisodesRow(
     watchedEpisodes: Set<Pair<Int, Int>> = emptySet(),
     episodeWatchedPendingKeys: Set<String> = emptySet(),
     blurUnwatchedEpisodes: Boolean = false,
+    posterCardCornerRadiusDp: Int = 12,
     onEpisodeClick: (Video) -> Unit,
     onEpisodeManualPlayClick: (Video) -> Unit = onEpisodeClick,
     onEpisodeStartFromBeginningClick: (Video) -> Unit = onEpisodeClick,
@@ -286,7 +287,7 @@ fun EpisodesRow(
     val restoreTargetRequester = restoreEpisodeId?.let { episodeFocusRequesters[it] }
     var optionsEpisode by remember { mutableStateOf<Video?>(null) }
     val isOverlayOpen = optionsEpisode != null
-    val cardMetrics = rememberEpisodeCardMetrics()
+    val cardMetrics = rememberEpisodeCardMetrics(posterCardCornerRadiusDp)
     val density = LocalDensity.current
     val rowPrefetchStrategy = remember { LazyListPrefetchStrategy(nestedPrefetchItemCount = 2) }
     val initialEpisodeIndex = remember(dedupedEpisodes, restoreEpisodeId, scrollToEpisodeId) {
@@ -1053,9 +1054,10 @@ private data class EpisodeCardMetrics(
 )
 
 @Composable
-private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
+private fun rememberEpisodeCardMetrics(posterCardCornerRadiusDp: Int = 12): EpisodeCardMetrics {
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
-    return remember(screenWidthDp) {
+    val userCornerRadius = posterCardCornerRadiusDp.dp
+    return remember(screenWidthDp, userCornerRadius) {
         when {
             screenWidthDp >= 1300 -> EpisodeCardMetrics(
                 rowHorizontalPadding = NuvioTheme.spacing.huge,
@@ -1063,7 +1065,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 itemSpacing = 20.dp,
                 cardWidth = 400.dp,
                 cardHeight = 263.dp,
-                cornerRadius = 20.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 20.dp,
                 contentBottomPadding = NuvioTheme.spacing.xl,
                 episodeBadgeHorizontalPadding = 10.dp,
@@ -1088,7 +1090,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 itemSpacing = 18.dp,
                 cardWidth = 360.dp,
                 cardHeight = 235.dp,
-                cornerRadius = 18.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 18.dp,
                 contentBottomPadding = 22.dp,
                 episodeBadgeHorizontalPadding = 9.dp,
@@ -1113,7 +1115,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 itemSpacing = NuvioTheme.spacing.lg,
                 cardWidth = 320.dp,
                 cardHeight = 207.dp,
-                cornerRadius = NuvioTheme.spacing.lg,
+                cornerRadius = userCornerRadius,
                 contentPadding = NuvioTheme.spacing.lg,
                 contentBottomPadding = 20.dp,
                 episodeBadgeHorizontalPadding = NuvioTheme.spacing.sm,
@@ -1138,7 +1140,7 @@ private fun rememberEpisodeCardMetrics(): EpisodeCardMetrics {
                 itemSpacing = 14.dp,
                 cardWidth = 280.dp,
                 cardHeight = 179.dp,
-                cornerRadius = NuvioTheme.spacing.lg,
+                cornerRadius = userCornerRadius,
                 contentPadding = 14.dp,
                 contentBottomPadding = NuvioTheme.spacing.lg,
                 episodeBadgeHorizontalPadding = 7.dp,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -277,6 +277,7 @@ fun MetaDetailsScreen(
     ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val posterCardCornerRadiusDp by viewModel.posterCardCornerRadiusDp.collectAsStateWithLifecycle()
     val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsStateWithLifecycle(
         initialValue = false
     )
@@ -493,6 +494,7 @@ fun MetaDetailsScreen(
                     isMovieWatchedPending = uiState.isMovieWatchedPending,
                     moreLikeThis = uiState.moreLikeThis,
                     moreLikeThisSource = uiState.moreLikeThisSource,
+                    posterCardCornerRadiusDp = posterCardCornerRadiusDp,
                     collection = uiState.collection,
                     collectionName = uiState.collectionName,
                     relatedWatchedStatus = uiState.relatedWatchedStatus,
@@ -869,6 +871,7 @@ private fun MetaDetailsContent(
     isMovieWatchedPending: Boolean,
     moreLikeThis: List<MetaPreview>,
     moreLikeThisSource: MoreLikeThisSource?,
+    posterCardCornerRadiusDp: Int = 12,
     collection: List<MetaPreview>,
     collectionName: String?,
     relatedWatchedStatus: Map<String, Boolean> = emptyMap(),
@@ -1750,6 +1753,7 @@ private fun MetaDetailsContent(
                             watchedEpisodes = watchedEpisodes,
                             episodeWatchedPendingKeys = episodeWatchedPendingKeys,
                             blurUnwatchedEpisodes = blurUnwatchedEpisodes,
+                            posterCardCornerRadiusDp = posterCardCornerRadiusDp,
                             onEpisodeClick = episodeClick,
                             onEpisodeManualPlayClick = episodeManualClick,
                             onEpisodeStartFromBeginningClick = { video ->
@@ -1866,6 +1870,7 @@ private fun MetaDetailsContent(
                                 MoreLikeThisSection(
                                     items = moreLikeThis,
                                     sourceLabel = moreLikeThisSourceLabel,
+                                    posterCardCornerRadius = posterCardCornerRadiusDp.dp,
                                     upFocusRequester = if (hasVisiblePeopleTabs) moreLikeTabFocusRequester else seasonDownFocusRequester ?: heroPlayFocusRequester,
                                     downFocusRequester = if (shouldShowCommentsSection && canToggleEpisodeComments) commentsSelectedModeFocusRequester else null,
                                     sectionFocusRequester = moreLikeSectionFocusRequester,
@@ -1888,6 +1893,7 @@ private fun MetaDetailsContent(
                             PeopleSectionTab.TRAILER -> {
                                 TrailerSection(
                                     trailers = meta.trailers,
+                                    posterCardCornerRadius = posterCardCornerRadiusDp.dp,
                                     upFocusRequester = if (hasVisiblePeopleTabs) trailerTabFocusRequester else seasonDownFocusRequester ?: heroPlayFocusRequester,
                                     sectionFocusRequester = trailerSectionFocusRequester,
                                     restoreTrailerId = if (restoreSharedTrailerFocusToken > 0) selectedSharedTrailer?.ytId else null,
@@ -1902,6 +1908,7 @@ private fun MetaDetailsContent(
                             PeopleSectionTab.COLLECTION -> {
                                 CollectionSection(
                                     items = collection,
+                                    posterCardCornerRadius = posterCardCornerRadiusDp.dp,
                                     upFocusRequester = if (hasVisiblePeopleTabs) collectionTabFocusRequester else seasonDownFocusRequester ?: heroPlayFocusRequester,
                                     downFocusRequester = if (shouldShowCommentsSection && canToggleEpisodeComments) commentsSelectedModeFocusRequester else null,
                                     sectionFocusRequester = collectionSectionFocusRequester,
@@ -1950,6 +1957,7 @@ private fun MetaDetailsContent(
                     CollectionSection(
                         items = collection,
                         title = collectionName ?: strTabCollection,
+                        posterCardCornerRadius = posterCardCornerRadiusDp.dp,
                         upFocusRequester = if (hasVisiblePeopleSection) {
                             when (activePeopleTab) {
                                 PeopleSectionTab.CAST -> castSectionFocusRequester

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -108,6 +108,9 @@ class MetaDetailsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MetaDetailsUiState())
     val uiState: StateFlow<MetaDetailsUiState> = _uiState.asStateFlow()
 
+    private val _posterCardCornerRadiusDp = MutableStateFlow(12)
+    val posterCardCornerRadiusDp: StateFlow<Int> = _posterCardCornerRadiusDp.asStateFlow()
+
     private val localizedContext: Context
         get() {
             val tag = LocaleCache.localeTag.takeIf { it != LocaleCache.UNSET && it.isNotEmpty() }
@@ -165,6 +168,10 @@ class MetaDetailsViewModel @Inject constructor(
         observeBlurUnwatchedEpisodes()
         observeOverallRatingsVisibility()
         observeDetailImdbRatingsVisibility()
+        viewModelScope.launch {
+            layoutPreferenceDataStore.posterCardCornerRadiusDp
+                .collect { _posterCardCornerRadiusDp.value = it }
+        }
         observeShowFullReleaseDate()
         observeHideUnreleasedContent()
         loadMeta()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MoreLikeThisSection.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -35,6 +36,7 @@ import com.nuvio.tv.ui.components.PosterCardStyle
 fun MoreLikeThisSection(
     items: List<MetaPreview>,
     sourceLabel: String? = null,
+    posterCardCornerRadius: Dp = NuvioTheme.spacing.md,
     upFocusRequester: FocusRequester? = null,
     downFocusRequester: FocusRequester? = null,
     sectionFocusRequester: FocusRequester? = null,
@@ -72,11 +74,11 @@ fun MoreLikeThisSection(
         restoreFocusRequester.requestFocusAfterFrames()
     }
 
-    val landscapeStyle = remember {
+    val landscapeStyle = remember(posterCardCornerRadius) {
         PosterCardStyle(
             width = 260.dp,
             height = 146.dp,
-            cornerRadius = NuvioTheme.spacing.md,
+            cornerRadius = posterCardCornerRadius,
             focusedBorderWidth = NuvioTheme.spacing.xxs,
             focusedScale = 1.02f
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/TrailerSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/TrailerSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -41,6 +42,7 @@ private data class TrailerListItem(
 @Composable
 fun TrailerSection(
     trailers: List<MetaTrailer>,
+    posterCardCornerRadius: Dp = NuvioTheme.spacing.md,
     upFocusRequester: FocusRequester? = null,
     sectionFocusRequester: FocusRequester? = null,
     restoreTrailerId: String? = null,
@@ -102,11 +104,11 @@ fun TrailerSection(
         restoreFocusRequester.requestFocusAfterFrames()
     }
 
-    val landscapeStyle = remember {
+    val landscapeStyle = remember(posterCardCornerRadius) {
         PosterCardStyle(
             width = 260.dp,
             height = 146.dp,
-            cornerRadius = NuvioTheme.spacing.md,
+            cornerRadius = posterCardCornerRadius,
             focusedBorderWidth = NuvioTheme.spacing.xxs,
             focusedScale = 1.02f
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -167,7 +167,9 @@ fun LibraryScreen(
         visibleItemKeys.associateWith { FocusRequester() }
     }
     val firstVisiblePosterKey = visibleItemKeys.firstOrNull()
-    val posterCardStyle = PosterCardDefaults.Style
+    val posterCardStyle = PosterCardDefaults.Style.copy(
+        cornerRadius = uiState.posterCardCornerRadiusDp.dp
+    )
 
     val routeCloudPlayback: (CloudLibraryPlaybackInfo) -> Unit = { info ->
         scope.launch {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -687,6 +687,7 @@ fun SearchScreen(
 
                             CatalogRowSection(
                                 catalogRow = catalogRow,
+                                posterCardStyle = posterCardStyle,
                                 showSeeAll = hasEnoughForSeeAll,
                                 showPosterLabels = uiState.posterLabelsEnabled,
                                 showAddonName = uiState.catalogAddonNameEnabled,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseScreen.kt
@@ -137,6 +137,7 @@ fun TmdbEntityBrowseScreen(
                         sourceType = viewModel.sourceType,
                         watchedMovieIds = watchedMovieIds,
                         watchedSeriesIds = watchedSeriesIds,
+                        posterCardCornerRadiusDp = viewModel.posterCardCornerRadiusDp.collectAsStateWithLifecycle().value,
                         onNavigateToDetail = onNavigateToDetail,
                         onItemLongPress = { item ->
                             viewModel.posterOptions.show(item, null)
@@ -167,6 +168,7 @@ private fun TmdbEntityBrowseContent(
     sourceType: String,
     watchedMovieIds: Set<String>,
     watchedSeriesIds: Set<String>,
+    posterCardCornerRadiusDp: Int = 12,
     onNavigateToDetail: (itemId: String, itemType: String, addonBaseUrl: String?) -> Unit,
     onItemLongPress: (MetaPreview) -> Unit = {},
     onLoadMoreRail: (TmdbEntityMediaType, TmdbEntityRailType) -> Unit
@@ -188,7 +190,9 @@ private fun TmdbEntityBrowseContent(
         }
     }
 
-    val posterCardStyle = PosterCardDefaults.Style
+    val posterCardStyle = PosterCardDefaults.Style.copy(
+        cornerRadius = posterCardCornerRadiusDp.dp
+    )
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
     val localDensity = LocalDensity.current
     val focusedItemIndexByRail = remember { mutableMapOf<String, Int>() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/tmdb/TmdbEntityBrowseViewModel.kt
@@ -28,6 +28,7 @@ class TmdbEntityBrowseViewModel @Inject constructor(
     private val tmdbSettingsDataStore: TmdbSettingsDataStore,
     private val watchProgressRepository: com.nuvio.tv.domain.repository.WatchProgressRepository,
     private val watchedSeriesStateHolder: com.nuvio.tv.data.local.WatchedSeriesStateHolder,
+    private val layoutPreferenceDataStore: com.nuvio.tv.data.local.LayoutPreferenceDataStore,
     val posterOptions: com.nuvio.tv.ui.components.posteroptions.PosterOptionsController,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -50,12 +51,19 @@ class TmdbEntityBrowseViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<TmdbEntityBrowseUiState>(TmdbEntityBrowseUiState.Loading)
     val uiState: StateFlow<TmdbEntityBrowseUiState> = _uiState.asStateFlow()
 
+    private val _posterCardCornerRadiusDp = MutableStateFlow(12)
+    val posterCardCornerRadiusDp: StateFlow<Int> = _posterCardCornerRadiusDp.asStateFlow()
+
     init {
         posterOptions.bind(viewModelScope)
         load()
         viewModelScope.launch {
             watchProgressRepository.observeWatchedMovieIds()
                 .collect { ids -> _watchedMovieIds.value = ids }
+        }
+        viewModelScope.launch {
+            layoutPreferenceDataStore.posterCardCornerRadiusDp
+                .collect { _posterCardCornerRadiusDp.value = it }
         }
     }
 


### PR DESCRIPTION
## Summary

Poster card corner radius from user settings was not respected in multiple screens. Only Home screen applied the user-configured value - all other screens used hardcoded defaults (12dp, 18dp, 20dp etc.).

Fixed screens:
- Search results (missing posterCardStyle parameter in CatalogRowSection call)
- TMDB Entity Browse (used PosterCardDefaults.Style ignoring user setting)
- Cast/Actor detail filmography (hardcoded PosterCardDefaults.Style.cornerRadius)
- Detail view -> More Like This section (hardcoded NuvioTheme.spacing.md)
- Detail view -> Trailer section (hardcoded NuvioTheme.spacing.md)
- Detail view -> Collection section (hardcoded NuvioTheme.spacing.md)
- Detail view -> Episodes section (hardcoded 20dp/18dp/NuvioTheme.spacing.lg)
- Library screen (used PosterCardDefaults.Style)
- Folder detail TabbedGridContent (used PosterCardDefaults.Style)

## PR type

- [x] Critical bug fix

## Why

User-configurable poster card corner radius setting exists in Layout Settings but was only applied on the Home screen. All other screens ignored it and used compile-time defaults, making the setting appear broken.

## Issue or approval

User setting "Poster Card Corner Radius" has no visible effect outside Home screen.

## Reproduction steps

1. Open Settings -> Layout -> Poster Card Style
2. Set corner radius to 0dp (sharp corners)
3. Go to Home screen - posters have sharp corners (correct)
4. Go to Search, type something - result posters still have rounded corners (bug)
5. Open any title detail -> More Like This / Trailers / Collection - still rounded (bug)
6. Open TMDB entity browse, Actor detail, Library - still rounded (bug)

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Episode badge corner radius (small pill badges) left unchanged - those are UI-specific, not poster card radius
- Season tab chips left unchanged
- Only the main card/thumbnail corner radius is affected

## Testing

- Set corner radius to 0dp, verified sharp corners in:
  - Home screen catalogs (was already working)
  - Search text results (fixed - was using default)
  - TMDB entity browse rails (fixed)
  - Actor filmography row (fixed)
  - Detail -> More Like This (fixed)
  - Detail -> Trailers (fixed)
  - Detail -> Collection (fixed)
  - Detail -> Episodes (fixed)
  - Library grid (fixed)
  - Folder detail tabbed grid (fixed)
- Set corner radius to 24dp, verified all above screens show large rounding
- Verified no regression on Home screen
- Tested on Nvidia Shield TV (1080p)

## Screenshots / Video


## Breaking changes

None.

## Linked issues

Poster card corner radius setting not respected across app screens.
Similar fix made in https://github.com/NuvioMedia/NuvioMobile/pull/1784