### PR TITLE
stub CS3 HomeViewModel so SyncProvider cannot crash playback (NUVIO-TV-2X)

### DIFF
--- a/app/src/full/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/full/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -1,0 +1,24 @@
+@file:Suppress("unused")
+
+package com.lagradost.cloudstream3.ui.home
+
+import androidx.lifecycle.ViewModel
+import com.lagradost.cloudstream3.utils.DataStoreHelper
+
+/**
+ * Compatibility stub for CloudStream's HomeViewModel.
+ *
+ * NuvioTV's real home screen lives at [com.nuvio.tv.ui.screens.home.HomeViewModel].
+ * original package at runtime. Without this class the plugin coroutine crashes the
+ * process with NoClassDefFoundError when it calls [getResumeWatching].
+ */
+class HomeViewModel : ViewModel() {
+    companion object {
+        /**
+         * CloudStream plugins call this to read continue-watching items for sync.
+         * NuvioTV does not persist CS3 resume state, so this returns empty.
+         */
+        @JvmStatic
+        suspend fun getResumeWatching(): List<DataStoreHelper.ResumeWatchingResult>? = emptyList()
+    }
+}

--- a/app/src/full/java/com/lagradost/cloudstream3/utils/DataStoreHelper.kt
+++ b/app/src/full/java/com/lagradost/cloudstream3/utils/DataStoreHelper.kt
@@ -1,0 +1,53 @@
+@file:Suppress("unused")
+
+package com.lagradost.cloudstream3.utils
+
+import com.lagradost.cloudstream3.Score
+import com.lagradost.cloudstream3.SearchQuality
+import com.lagradost.cloudstream3.SearchResponse
+import com.lagradost.cloudstream3.TvType
+
+/**
+ * Compatibility stub for CloudStream's DataStoreHelper.
+ *
+ * CloudStream plugins (notably SyncPlugin) read resume-watching state through
+ * [com.lagradost.cloudstream3.ui.home.HomeViewModel.getResumeWatching], whose
+ * return type is [ResumeWatchingResult]. NuvioTV stores progress in its own
+ * repositories, so these helpers are no-ops that keep the plugin classloader
+ * from crashing on missing CS3 UI types.
+ */
+object DataStoreHelper {
+    const val TAG = "data_store_helper"
+
+    val currentAccount: String = "0"
+
+    data class PosDur(
+        val position: Long,
+        val duration: Long,
+    )
+
+    data class ResumeWatchingResult(
+        override val name: String,
+        override val url: String,
+        override val apiName: String,
+        override var type: TvType? = null,
+        override var posterUrl: String?,
+        val watchPos: PosDur?,
+        override var id: Int?,
+        val parentId: Int?,
+        val episode: Int?,
+        val season: Int?,
+        val isFromDownload: Boolean,
+        override var quality: SearchQuality? = null,
+        override var posterHeaders: Map<String, String>? = null,
+        override var score: Score? = null,
+    ) : SearchResponse
+
+    fun getAllResumeStateIds(): List<Int>? = emptyList()
+
+    fun getViewPos(id: Int?): PosDur? = null
+
+    fun setViewPos(id: Int?, pos: Long, dur: Long) {}
+
+    fun removeLastWatched(parentId: Int?) {}
+}

--- a/app/src/testFull/java/com/nuvio/tv/core/plugin/cloudstream/HomeViewModelCompatStubTest.kt
+++ b/app/src/testFull/java/com/nuvio/tv/core/plugin/cloudstream/HomeViewModelCompatStubTest.kt
@@ -1,0 +1,24 @@
+package com.nuvio.tv.core.plugin.cloudstream
+
+import com.lagradost.cloudstream3.ui.home.HomeViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeViewModelCompatStubTest {
+
+    @Test
+    fun `CloudStream HomeViewModel class is resolvable for plugins`() {
+        val clazz = Class.forName("com.lagradost.cloudstream3.ui.home.HomeViewModel")
+        assertEquals("com.lagradost.cloudstream3.ui.home.HomeViewModel", clazz.name)
+        assertNotNull(clazz.getDeclaredClasses().firstOrNull { it.simpleName == "Companion" })
+    }
+
+    @Test
+    fun `getResumeWatching returns empty instead of throwing`() = runBlocking {
+        val result = HomeViewModel.getResumeWatching()
+        assertTrue(result.isNullOrEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Adds CloudStream compatibility stubs so the Vietnamese **SyncProvider** plugin (`SyncProvider.cs3`) no longer crashes NuvioTV during playback.

The plugin resolves `com.lagradost.cloudstream3.ui.home.HomeViewModel` at runtime. NuvioTV never shipped that class. This PR adds a no-op `HomeViewModel.getResumeWatching()` plus the `DataStoreHelper.ResumeWatchingResult` return type, and a unit test that the class loads.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Production crash NUVIO-TV-2X: uncaught `NoClassDefFoundError` / `ClassNotFoundException` for `Lcom/lagradost/cloudstream3/ui/home/HomeViewModel;` on `full` release `0.8.6-beta` (1047). SyncProvider's coroutine (`SyncPlugin.kt:33`) fires on playback and kills the process because the CS3 UI class is missing from the host app.

## Issue or approval

Fixes NUVIO-TV-2X

## Reproduction steps

1. Install NuvioTV full flavor and add the CloudStream Vietnamese repo
2. Enable only **SyncProvider**.
3. Start playback of any media item so the plugin's sync runnable runs.
4. Without this fix: fatal `NoClassDefFoundError` for `com.lagradost.cloudstream3.ui.home.HomeViewModel`.
5. With this fix: playback continues; `getResumeWatching()` returns empty (CS3 resume sync is not implemented in NuvioTV).

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Does not implement CS3 continue-watching sync, Trakt/Simkl bridging, or extra CS3 UI stubs beyond `HomeViewModel` and `DataStoreHelper` types required by `getResumeWatching()`. Does not change NuvioTV's own `com.nuvio.tv.ui.screens.home.HomeViewModel`. Playstore flavor is unchanged.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.plugin.cloudstream.HomeViewModelCompatStubTest` — passed (class resolves; `getResumeWatching()` returns empty).
- Verified on a real device with SyncProvider loaded: playback no longer crashes (`NoClassDefFoundError` for `HomeViewModel` is gone).

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes NUVIO-TV-2X
