### PR TITLE
Reuse CJK name fallback for TMDB filmography titles.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.data.remote.api.TmdbEpisode
 import com.nuvio.tv.data.remote.api.TmdbImage
 import com.nuvio.tv.data.remote.api.TmdbPersonCreditCast
 import com.nuvio.tv.data.remote.api.TmdbPersonCreditCrew
+import com.nuvio.tv.data.remote.api.TmdbPersonCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbRecommendationResult
 import com.nuvio.tv.data.remote.api.TmdbVideoResult
 import com.nuvio.tv.domain.model.ContentType
@@ -1232,12 +1233,37 @@ class TmdbMetadataService(
 
                 val shouldFetchEnglishPerson = normalizedLanguage != "en" &&
                     (person.biography.isNullOrBlank() || (!isCjkLanguage && person.name != null && containsCjkOrHangul(person.name) && (person.originalName == null || containsCjkOrHangul(person.originalName))))
+                val shouldFetchEnglishCredits = normalizedLanguage != "en" &&
+                    !isCjkLanguage &&
+                    personCreditsContainCjkTitles(credits)
 
-                val englishPerson = if (shouldFetchEnglishPerson) {
-                    runCatching {
-                        tmdbApi.getPersonDetails(personId, TMDB_API_KEY, "en").body()
-                    }.getOrNull()
-                } else null
+                val (englishPerson, englishCredits) = if (shouldFetchEnglishPerson || shouldFetchEnglishCredits) {
+                    coroutineScope {
+                        val englishPersonDeferred = async {
+                            if (shouldFetchEnglishPerson) {
+                                runCatching {
+                                    tmdbApi.getPersonDetails(personId, TMDB_API_KEY, "en").body()
+                                }.getOrNull()
+                            } else {
+                                null
+                            }
+                        }
+                        val englishCreditsDeferred = async {
+                            if (shouldFetchEnglishCredits) {
+                                runCatching {
+                                    tmdbApi.getPersonCombinedCredits(personId, TMDB_API_KEY, "en").body()
+                                }.getOrNull()
+                            } else {
+                                null
+                            }
+                        }
+                        Pair(englishPersonDeferred.await(), englishCreditsDeferred.await())
+                    }
+                } else {
+                    Pair(null, null)
+                }
+
+                val englishTitlesById = englishCreditTitlesById(englishCredits)
 
                 // If biography is empty and language is not English, fetch English fallback
                 val biography = if (person.biography.isNullOrBlank() && normalizedLanguage != "en") {
@@ -1255,16 +1281,32 @@ class TmdbMetadataService(
 
                 val preferCrewFilmography = preferCrewCredits ?: shouldPreferCrewCredits(person.knownForDepartment)
 
-                val castMovieCredits = mapMovieCreditsFromCast(credits?.cast.orEmpty())
-                val crewMovieCredits = mapMovieCreditsFromCrew(credits?.crew.orEmpty())
+                val castMovieCredits = mapMovieCreditsFromCast(
+                    credits?.cast.orEmpty(),
+                    normalizedLanguage,
+                    englishTitlesById
+                )
+                val crewMovieCredits = mapMovieCreditsFromCrew(
+                    credits?.crew.orEmpty(),
+                    normalizedLanguage,
+                    englishTitlesById
+                )
                 val movieCredits = when {
                     preferCrewFilmography && crewMovieCredits.isNotEmpty() -> crewMovieCredits
                     castMovieCredits.isNotEmpty() -> castMovieCredits
                     else -> crewMovieCredits
                 }
 
-                val castTvCredits = mapTvCreditsFromCast(credits?.cast.orEmpty())
-                val crewTvCredits = mapTvCreditsFromCrew(credits?.crew.orEmpty())
+                val castTvCredits = mapTvCreditsFromCast(
+                    credits?.cast.orEmpty(),
+                    normalizedLanguage,
+                    englishTitlesById
+                )
+                val crewTvCredits = mapTvCreditsFromCrew(
+                    credits?.crew.orEmpty(),
+                    normalizedLanguage,
+                    englishTitlesById
+                )
                 val tvCredits = when {
                     preferCrewFilmography && crewTvCredits.isNotEmpty() -> crewTvCredits
                     castTvCredits.isNotEmpty() -> castTvCredits
@@ -1297,14 +1339,23 @@ class TmdbMetadataService(
         return department != "acting" && department != "actors"
     }
 
-    private fun mapMovieCreditsFromCast(cast: List<TmdbPersonCreditCast>): List<MetaPreview> {
+    private fun mapMovieCreditsFromCast(
+        cast: List<TmdbPersonCreditCast>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>
+    ): List<MetaPreview> {
         val seenMovieIds = mutableSetOf<Int>()
         return cast
             .filter { it.mediaType == "movie" && it.posterPath != null }
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenMovieIds.add(credit.id)) return@mapNotNull null
-                val title = credit.title ?: credit.name ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.title ?: credit.name,
+                    originalName = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage
+                ) ?: return@mapNotNull null
                 val year = credit.releaseDate?.take(4)
                 MetaPreview(
                     id = "tmdb:${credit.id}",
@@ -1322,14 +1373,23 @@ class TmdbMetadataService(
             }
     }
 
-    private fun mapMovieCreditsFromCrew(crew: List<TmdbPersonCreditCrew>): List<MetaPreview> {
+    private fun mapMovieCreditsFromCrew(
+        crew: List<TmdbPersonCreditCrew>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>
+    ): List<MetaPreview> {
         val seenMovieIds = mutableSetOf<Int>()
         return crew
             .filter { it.mediaType == "movie" && it.posterPath != null }
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenMovieIds.add(credit.id)) return@mapNotNull null
-                val title = credit.title ?: credit.name ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.title ?: credit.name,
+                    originalName = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage
+                ) ?: return@mapNotNull null
                 val year = credit.releaseDate?.take(4)
                 MetaPreview(
                     id = "tmdb:${credit.id}",
@@ -1347,14 +1407,23 @@ class TmdbMetadataService(
             }
     }
 
-    private fun mapTvCreditsFromCast(cast: List<TmdbPersonCreditCast>): List<MetaPreview> {
+    private fun mapTvCreditsFromCast(
+        cast: List<TmdbPersonCreditCast>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>
+    ): List<MetaPreview> {
         val seenTvIds = mutableSetOf<Int>()
         return cast
             .filter { it.mediaType == "tv" && it.posterPath != null }
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenTvIds.add(credit.id)) return@mapNotNull null
-                val title = credit.name ?: credit.title ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.name ?: credit.title,
+                    originalName = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage
+                ) ?: return@mapNotNull null
                 val year = credit.firstAirDate?.take(4)
                 MetaPreview(
                     id = "tmdb:${credit.id}",
@@ -1372,14 +1441,23 @@ class TmdbMetadataService(
             }
     }
 
-    private fun mapTvCreditsFromCrew(crew: List<TmdbPersonCreditCrew>): List<MetaPreview> {
+    private fun mapTvCreditsFromCrew(
+        crew: List<TmdbPersonCreditCrew>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>
+    ): List<MetaPreview> {
         val seenTvIds = mutableSetOf<Int>()
         return crew
             .filter { it.mediaType == "tv" && it.posterPath != null }
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenTvIds.add(credit.id)) return@mapNotNull null
-                val title = credit.name ?: credit.title ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.name ?: credit.title,
+                    originalName = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage
+                ) ?: return@mapNotNull null
                 val year = credit.firstAirDate?.take(4)
                 MetaPreview(
                     id = "tmdb:${credit.id}",
@@ -1583,6 +1661,28 @@ private fun TmdbEpisode.toEnrichment(): TmdbEpisodeEnrichment {
         airDate = airDate,
         runtimeMinutes = runtime
     )
+}
+
+private fun personCreditsContainCjkTitles(credits: TmdbPersonCreditsResponse?): Boolean {
+    if (credits == null) return false
+    return credits.cast.orEmpty().any { containsCjkOrHangul(it.title ?: it.name ?: return@any false) } ||
+        credits.crew.orEmpty().any { containsCjkOrHangul(it.title ?: it.name ?: return@any false) }
+}
+
+private fun englishCreditTitlesById(credits: TmdbPersonCreditsResponse?): Map<Int, String> {
+    if (credits == null) return emptyMap()
+    val titles = LinkedHashMap<Int, String>()
+    fun putTitle(id: Int, title: String?, name: String?) {
+        val text = title?.trim()?.takeIf { it.isNotBlank() }
+            ?: name?.trim()?.takeIf { it.isNotBlank() }
+            ?: return
+        if (!containsCjkOrHangul(text)) {
+            titles.putIfAbsent(id, text)
+        }
+    }
+    credits.cast.orEmpty().forEach { putTitle(it.id, it.title, it.name) }
+    credits.crew.orEmpty().forEach { putTitle(it.id, it.title, it.name) }
+    return titles
 }
 
 internal fun containsCjkOrHangul(text: String): Boolean {

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -18,6 +18,8 @@ import com.nuvio.tv.data.remote.api.TmdbImagesResponse
 import com.nuvio.tv.data.remote.api.TmdbMovieReleaseDatesResponse
 import com.nuvio.tv.data.remote.api.TmdbNetwork
 import com.nuvio.tv.data.remote.api.TmdbNetworkDetailsResponse
+import com.nuvio.tv.data.remote.api.TmdbPersonCreditCast
+import com.nuvio.tv.data.remote.api.TmdbPersonCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbPersonResponse
 import com.nuvio.tv.data.remote.api.TmdbSeasonResponse
 import com.nuvio.tv.data.remote.api.TmdbTvContentRatingsResponse
@@ -671,6 +673,67 @@ class TmdbMetadataServiceTest {
         assertNotNull(detail)
         assertEquals("Atsuko Tanaka", detail?.name)
         assertEquals("Atsuko Tanaka was a Japanese voice actress.", detail?.biography)
+    }
+
+    @Test
+    fun `fetchPersonDetail falls back CJK filmography titles to English`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getPersonDetails(500, any(), "pl-PL") } returns Response.success(
+            TmdbPersonResponse(
+                id = 500,
+                name = "Atsuko Tanaka",
+                originalName = "田中敦子"
+            )
+        )
+        coEvery { api.getPersonDetails(500, any(), "en") } returns Response.success(
+            TmdbPersonResponse(
+                id = 500,
+                name = "Atsuko Tanaka",
+                originalName = "田中敦子"
+            )
+        )
+        coEvery { api.getPersonCombinedCredits(500, any(), "pl-PL") } returns Response.success(
+            TmdbPersonCreditsResponse(
+                cast = listOf(
+                    TmdbPersonCreditCast(
+                        id = 255358,
+                        name = "攻殻機動隊 STAND ALONE COMPLEX",
+                        originalName = "攻殻機動隊 STAND ALONE COMPLEX",
+                        mediaType = "tv",
+                        posterPath = "/poster.jpg",
+                        firstAirDate = "2002-10-01"
+                    ),
+                    TmdbPersonCreditCast(
+                        id = 99,
+                        title = "Make My Day",
+                        originalTitle = "Make My Day",
+                        mediaType = "movie",
+                        posterPath = "/mmd.jpg",
+                        releaseDate = "2023-01-01"
+                    )
+                )
+            )
+        )
+        coEvery { api.getPersonCombinedCredits(500, any(), "en") } returns Response.success(
+            TmdbPersonCreditsResponse(
+                cast = listOf(
+                    TmdbPersonCreditCast(
+                        id = 255358,
+                        name = "Ghost in the Shell: Stand Alone Complex",
+                        originalName = "攻殻機動隊 STAND ALONE COMPLEX",
+                        mediaType = "tv",
+                        posterPath = "/poster.jpg"
+                    )
+                )
+            )
+        )
+
+        val service = TmdbMetadataService(api)
+        val detail = service.fetchPersonDetail(personId = 500, language = "pl-PL")
+
+        assertNotNull(detail)
+        assertEquals("Ghost in the Shell: Stand Alone Complex", detail?.tvCredits?.single()?.name)
+        assertEquals("Make My Day", detail?.movieCredits?.single()?.name)
     }
 
     private data class MovieDiscoverCall(


### PR DESCRIPTION
## Summary

Apply the existing TMDB CJK display-name fallback to person filmography titles.

Cast/person names already resolve CJK script to a Latin English fallback when the app language is not Japanese, Korean, or Chinese. Filmography rows did not: `combined_credits` in the user language often returns original-script `title`/`name` when no translation exists, so poster labels stayed in Japanese/Korean/Chinese. This PR reuses `resolvePersonName` for movie and TV credits and loads English combined credits only when CJK titles are present.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

On the person/cast detail screen, filmography poster labels used TMDB original-script titles whenever the selected metadata language had no translation. That is the same localization gap already fixed for cast names. English TMDB titles (official international names) should be used in that case, not a language-specific extra rule.

## Issue or approval

No linked issue: localization-only update. Extends the existing CJK fallback from `fix/tmdb-cast-name-fallback` to filmography titles on the same person detail path.

## Reproduction steps

No reproduction steps - localization-only update.

Manual check used while developing:

1. Set TMDB / app metadata language to a non-CJK locale (for example Turkish or Polish).
2. Open a Japanese voice actor person page (example: Atsuko Tanaka).
3. Before: filmography labels under posters are CJK (for example `攻殻機動隊...`).
4. After: the same items use TMDB English titles (for example `Ghost in the Shell: Stand Alone Complex`). Latin titles such as `Make My Day` stay unchanged. `ja` / `ko` / `zh` locales still keep original-script titles.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to `TmdbMetadataService.fetchPersonDetail` filmography mapping and its unit test. Does not change strings.xml, collection-editor TMDB rows, detail-page enrichment titles, or add romaji transliteration. Does not include `app/src/main/cpp/libde265/`.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest` — passed, including `fetchPersonDetail falls back CJK filmography titles to English`.
- Existing `fetchPersonDetail falls back Japanese person name to English for Turkish locale` still passes.
- Manual: Android TV `192.168.2.13:5555`, Atsuko Tanaka person page, non-CJK metadata language. Before screenshot had CJK filmography labels; after screenshot showed English TMDB titles.

## Screenshots / Video

| Before | After |
|:------:|:-----:|
| <img width="1920" height="1080" alt="nuvio-tv-screenshot" src="https://github.com/user-attachments/assets/8588dde7-a61c-4b4e-8ea1-b7baa1b3fc03" />| <img width="1920" height="1080" alt="nuvio-tv-screenshot-20260825-145445" src="https://github.com/user-attachments/assets/65dca2ef-796c-44f5-b34f-74c3e1e700cb" />|


## Breaking changes

None

## Linked issues

No linked issue - localization-only update.
