### PR TITLE
fix(home): refresh home catalogs when returning to Home

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/StartupSyncService.kt
@@ -22,6 +22,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -158,6 +161,11 @@ class StartupSyncService @Inject constructor(
         )
     }
 
+    private val _manualAddonRefreshes = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    /** Emits after a manual addon refresh, so screens holding catalogs can re-request them. */
+    val manualAddonRefreshes: SharedFlow<Unit> = _manualAddonRefreshes.asSharedFlow()
+
     fun requestAddonSyncNow() {
         val profileId = profileManager.activeProfileId.value
         Log.d(TAG, "Manual addon sync enqueued for profile $profileId")
@@ -178,6 +186,9 @@ class StartupSyncService @Inject constructor(
                 Log.e(TAG, "Manual addon sync failed for profile $profileId", e)
             } finally {
                 addonRepository.isSyncingFromRemote = false
+                // The user asked for a refresh, so let screens holding catalogs re-request them
+                // even when the addon list itself came back unchanged.
+                _manualAddonRefreshes.tryEmit(Unit)
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/domain/model/CatalogRow.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/CatalogRow.kt
@@ -35,8 +35,24 @@ fun CatalogRow.legacyKey(): String {
     return catalogRowLegacyKey(addonId, apiType, catalogId)
 }
 
-fun CatalogRow.stableItemKey(index: Int): String {
-    return "${stableKey()}_$index"
+/**
+ * Identity-based item key, so a key follows its item when the list shifts instead of staying
+ * pinned to a slot. [occurrence] disambiguates an id appearing twice in the same row.
+ */
+fun CatalogRow.stableItemKey(item: MetaPreview, occurrence: Int = 0): String {
+    val identity = "${stableKey()}_${item.apiType}:${item.id}"
+    return if (occurrence == 0) identity else "$identity#$occurrence"
+}
+
+/** Item keys for the whole row, aligned with [items], for callers that only have an index. */
+fun CatalogRow.stableItemKeys(): List<String> {
+    val seen = HashMap<String, Int>()
+    return items.map { item ->
+        val identity = "${item.apiType}:${item.id}"
+        val occurrence = seen.getOrDefault(identity, 0)
+        seen[identity] = occurrence + 1
+        stableItemKey(item, occurrence)
+    }
 }
 
 fun catalogRowStableKey(

--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -66,6 +66,7 @@ import com.nuvio.tv.domain.model.CatalogRow
 import com.nuvio.tv.domain.model.CardDepthSurface
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.stableItemKey
+import com.nuvio.tv.domain.model.stableItemKeys
 import com.nuvio.tv.domain.model.PLACEHOLDER_IMAGE_URL
 import com.nuvio.tv.ui.util.formatAddonTypeLabel
 import com.nuvio.tv.ui.util.localizedContentType
@@ -110,8 +111,9 @@ fun CatalogRowSection(
     upFocusRequester: FocusRequester? = null,
     listState: LazyListState = rememberLazyListState(initialFirstVisibleItemIndex = initialScrollIndex)
 ) {
+    val rowItemKeys = remember(catalogRow.items) { catalogRow.stableItemKeys() }
     fun rowItemFocusKey(index: Int, item: MetaPreview): String {
-        return catalogRow.stableItemKey(index)
+        return rowItemKeys.getOrElse(index) { catalogRow.stableItemKey(item) }
     }
 
     val seeAllCardShape = RoundedCornerShape(posterCardStyle.cornerRadius)
@@ -120,6 +122,22 @@ fun CatalogRowSection(
     val itemFocusRequestersByKey = remember { mutableMapOf<String, FocusRequester>() }
     var lastRequestedFocusItemKey by remember { mutableStateOf<String?>(null) }
     val lastFocusedItemIndex = remember { mutableIntStateOf(-1) }
+    // Item keys as they were when lastFocusedItemIndex was recorded, so the index can be
+    // relocated when the row changes instead of pointing at whatever took that slot.
+    val previousRowItemKeys = remember { mutableStateOf<List<String>>(emptyList()) }
+    // Runs during composition, not in an effect: focusRestorer below is driven by the user and
+    // can fire before an effect would have relocated the index, which would restore focus onto
+    // whatever took that slot.
+    if (previousRowItemKeys.value !== rowItemKeys) {
+        val storedIndex = lastFocusedItemIndex.intValue
+        val previousKeys = previousRowItemKeys.value
+        if (storedIndex >= 0 && previousKeys.isNotEmpty()) {
+            val wanted = previousKeys.getOrNull(storedIndex)
+            val relocated = wanted?.let { rowItemKeys.indexOf(it) } ?: -1
+            if (relocated != storedIndex) lastFocusedItemIndex.intValue = relocated
+        }
+        previousRowItemKeys.value = rowItemKeys
+    }
 
     val blockingFocusExit = remember { mutableStateOf(false) }
     val rowHasFocusRef = remember { mutableStateOf(false) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/CatalogSeeAllScreen.kt
@@ -62,7 +62,8 @@ import com.nuvio.tv.ui.screens.search.SearchEvent
 import com.nuvio.tv.ui.screens.search.SearchViewModel
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.legacyKey
-import com.nuvio.tv.domain.model.stableItemKey
+import com.nuvio.tv.domain.model.stableItemKeys
+import com.nuvio.tv.domain.model.stableKey
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
 
@@ -221,6 +222,9 @@ fun CatalogSeeAllScreen(
         val isCatalogLoading = catalogRow == null || catalogRow.isLoading
 
         if (hasItems) {
+            val seeAllItemKeys = remember(catalogRow?.items) {
+                catalogRow?.stableItemKeys().orEmpty()
+            }
             Box(modifier = Modifier.fillMaxSize()) {
                 LazyVerticalGrid(
                     state = gridState,
@@ -237,7 +241,7 @@ fun CatalogSeeAllScreen(
                 ) {
                     itemsIndexed(
                         items = catalogRow.items,
-                        key = { index, item -> catalogRow.stableItemKey(index) }
+                        key = { index, _ -> seeAllItemKeys.getOrElse(index) { "${catalogRow.stableKey()}_$index" } }
                     ) { index, item ->
                         val isWatched = if (isSearchMode) {
                             val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -50,6 +50,7 @@ import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.domain.model.Collection
 import com.nuvio.tv.domain.model.CollectionFolder
 import com.nuvio.tv.domain.model.legacyKey
+import com.nuvio.tv.domain.model.stableItemKeys
 import com.nuvio.tv.domain.model.stableKey
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -100,6 +101,7 @@ fun ClassicHomeContent(
     onItemFocus: (MetaPreview) -> Unit = {},
     catalogSeeAllLabel: String? = null,
     onSaveFocusState: (Int, Int, String?, Map<String, String>, Map<String, Int>, Int, Int) -> Unit,
+    onFocusedRowKeyChanged: (String?) -> Unit = {},
     scrollToTopTrigger: Int = 0,
     onRequestLazyCatalogLoad: (String) -> Unit = {}
 ) {
@@ -204,6 +206,9 @@ fun ClassicHomeContent(
     val rowStates = remember { mutableMapOf<String, LazyListState>() }
     val rowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val rowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
+    // Item keys of each row as they were when its focused index was last recorded, so the index
+    // can be relocated when a refresh shifts the row instead of pointing at a new card.
+    val previousRowItemKeys = remember { mutableMapOf<String, List<String>>() }
     val cwItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
@@ -580,6 +585,7 @@ fun ClassicHomeContent(
                         currentFocusSnapshot.rowIndex = -1
                         currentFocusSnapshot.itemIndex = itemIndex
                         currentFocusSnapshot.rowKey = "continue_watching"
+                        onFocusedRowKeyChanged(null)
                         if (uiState.classicFocusGradientEnabled) {
                             focusedArtwork = uiState.continueWatchingItems.getOrNull(itemIndex)
                                 ?.toClassicFocusArtwork(uiState.focusedPosterBackdropExpandEnabled)
@@ -674,6 +680,15 @@ fun ClassicHomeContent(
                 is HomeRow.Catalog -> {
                     val catalogRow = homeRow.row
                     val catalogKey = catalogRow.stableKey()
+                    val currentItemKeys = catalogRow.stableItemKeys()
+                    rowFocusedItemIndex[catalogKey]?.let { storedIdx ->
+                        previousRowItemKeys[catalogKey]
+                            ?.getOrNull(storedIdx)
+                            ?.let { currentItemKeys.indexOf(it) }
+                            ?.takeIf { it >= 0 && it != storedIdx }
+                            ?.let { rowFocusedItemIndex[catalogKey] = it }
+                    }
+                    previousRowItemKeys[catalogKey] = currentItemKeys
                     // Match by saved row key first, fall back to index
                     val shouldRestoreFocus = restoringFocus &&
                         (currentFocusSnapshot.rowKey == catalogKey || index == focusState.focusedRowIndex)
@@ -734,6 +749,7 @@ fun ClassicHomeContent(
                                 currentFocusSnapshot.rowIndex = index
                                 currentFocusSnapshot.itemIndex = itemIndex
                                 currentFocusSnapshot.rowKey = catalogKey
+                                onFocusedRowKeyChanged(catalogKey)
                                 rowFocusedItemIndex[catalogKey] = itemIndex
                             }
                         }
@@ -768,6 +784,7 @@ fun ClassicHomeContent(
                             currentFocusSnapshot.rowIndex = index
                             currentFocusSnapshot.itemIndex = itemIndex
                             currentFocusSnapshot.rowKey = collectionKey
+                            onFocusedRowKeyChanged(null)
                             rowFocusedItemIndex[collectionKey] = itemIndex
                             if (uiState.classicFocusGradientEnabled) {
                                 focusedArtwork = homeRow.collection.folders.getOrNull(itemIndex)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -74,6 +74,7 @@ import coil3.compose.AsyncImage
 import com.nuvio.tv.domain.model.CollectionFolder
 import com.nuvio.tv.domain.model.CardDepthSurface
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.catalogRowStableKey
 import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.ui.components.GridContentCard
 import com.nuvio.tv.ui.components.LocalCardDepthStyle
@@ -105,6 +106,7 @@ fun GridHomeContent(
     onItemFocus: (com.nuvio.tv.domain.model.MetaPreview) -> Unit = {},
     catalogSeeAllLabel: String? = null,
     onSaveGridFocusState: (Int, Int, String?) -> Unit,
+    onFocusedRowKeyChanged: (String?) -> Unit = {},
     scrollToTopTrigger: Int = 0
 ) {
     val gridState = rememberLazyGridState(
@@ -598,6 +600,15 @@ fun GridHomeContent(
                             onFocused = remember(itemKey, gridItem.item) {
                                 {
                                     lastFocusedGridItemKey.value = itemKey
+                                    // No rows here, but a card still belongs to one.
+                                    onFocusedRowKeyChanged(
+                                        catalogRowStableKey(
+                                            gridItem.addonId,
+                                            gridItem.addonBaseUrl,
+                                            gridItem.item.apiType,
+                                            gridItem.catalogId
+                                        )
+                                    )
                                     onItemFocus(gridItem.item)
                                 }
                             },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -20,6 +20,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -90,6 +94,19 @@ fun HomeScreen(
     onNavigateToFolderDetail: (String, String) -> Unit = { _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Home was the only major screen without a lifecycle observer, so nothing ever told it to
+    // look at its catalogs again.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshHomeCatalogsIfStale()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     val modernPresentation by viewModel.modernHomePresentation.collectAsStateWithLifecycle()
     val initialCwResolved by viewModel.initialCwResolved.collectAsStateWithLifecycle()
     val scrollToTopTrigger by viewModel.scrollToTopTrigger.collectAsStateWithLifecycle()
@@ -530,6 +547,11 @@ private fun ClassicHomeRoute(
         },
         onSaveFocusState = { vi, vo, rk, ikm, m, ri, ii ->
             viewModel.saveFocusState(vi, vo, rk, ikm, m, ri, ii)
+            // Authoritative: this is the row that actually held focus when Home went away.
+            viewModel.setLiveFocusedRowKey(rk)
+        },
+        onFocusedRowKeyChanged = remember(viewModel) {
+            { key: String? -> viewModel.setLiveFocusedRowKey(key) }
         },
         onRequestLazyCatalogLoad = remember(viewModel) {
             { catalogKey: String -> viewModel.requestLazyCatalogLoad(catalogKey) }
@@ -555,6 +577,9 @@ private fun GridHomeRoute(
     val gridFocusState by viewModel.gridFocusState.collectAsStateWithLifecycle()
     val scrollToTopTrigger by viewModel.scrollToTopTrigger.collectAsStateWithLifecycle()
     GridHomeContent(
+        onFocusedRowKeyChanged = remember(viewModel) {
+            { key: String? -> viewModel.setLiveFocusedRowKey(key) }
+        },
         uiState = uiState,
         posterCardStyle = posterCardStyle,
         gridFocusState = gridFocusState,
@@ -624,6 +649,8 @@ private fun ModernHomeRoute(
     val saveModernFocusState = remember(viewModel) {
         { vi: Int, vo: Int, rk: String?, ikm: Map<String, String>, m: Map<String, Int>, ri: Int, ii: Int ->
             viewModel.saveFocusState(vi, vo, rk, ikm, m, ri, ii)
+            // Authoritative: this is the row that actually held focus when Home went away.
+            viewModel.setLiveFocusedRowKey(rk)
         }
     }
     val preloadAdjacentItem = remember(viewModel) {
@@ -658,6 +685,9 @@ private fun ModernHomeRoute(
         },
         onPreloadAdjacentItem = preloadAdjacentItem,
         onSaveFocusState = saveModernFocusState,
+        onFocusedRowKeyChanged = remember(viewModel) {
+            { key: String? -> viewModel.setLiveFocusedRowKey(key) }
+        },
         onRequestLazyCatalogLoad = remember(viewModel) {
             { catalogKey: String -> viewModel.requestLazyCatalogLoad(catalogKey) }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeUiState.kt
@@ -161,7 +161,9 @@ sealed class GridItem {
         val item: MetaPreview,
         val addonBaseUrl: String,
         val catalogId: String,
-        val catalogName: String
+        val catalogName: String,
+        /** Row this card belongs to, so the grid can report which row holds focus. */
+        val addonId: String = ""
     ) : GridItem()
     @Immutable
     data class SeeAll(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -91,6 +91,9 @@ class HomeViewModel @Inject constructor(
         private const val MAX_NEXT_UP_LOOKUPS = 24
         private const val MAX_NEXT_UP_CONCURRENCY = 4
         private const val MAX_CATALOG_LOAD_CONCURRENCY = 3
+
+        /** How long a home catalog is left alone before a return to Home re-requests it. */
+        private const val HOME_CATALOG_REFRESH_TTL_MS = 30L * 60L * 1000L
         internal const val EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS = 220L
         internal const val EXTERNAL_META_PREFETCH_ADJACENT_DEBOUNCE_MS = 120L
         private const val MAX_ENRICHMENT_CACHE_SIZE = 64
@@ -710,6 +713,43 @@ class HomeViewModel @Inject constructor(
     private fun observeCollections() = observeCollectionsPipeline()
 
     private fun observeInstalledAddons() = observeInstalledAddonsPipeline()
+
+    /**
+     * Set when the catalogs were last loaded or refreshed, so returning to Home right after
+     * the initial load does not immediately re-request everything. Monotonic, so a clock
+     * correction cannot block or force a refresh.
+     */
+    internal var lastHomeCatalogRefreshAtMs: Long = 0L
+
+    /**
+     * Row the user currently has focus on, reported by the Home content as it changes. Kept out
+     * of [focusState] on purpose: that one is passed down to the Home composables, and emitting
+     * on every vertical move would recompose the whole row list.
+     *
+     * It deliberately survives leaving Home: the refresh runs on the way back in, before the row
+     * list has had a chance to report focus again, so clearing it there would shield nothing.
+     */
+    @Volatile
+    internal var liveFocusedRowKey: String? = null
+
+    /** Called by the Home content when the focused row changes. */
+    fun setLiveFocusedRowKey(rowKey: String?) {
+        liveFocusedRowKey = rowKey
+    }
+
+    /**
+     * Called when Home comes back to the foreground, whether from another screen or from
+     * outside the app.  Re-requests page 1 of the catalogs already loaded when the last
+     * refresh is older than [HOME_CATALOG_REFRESH_TTL_MS], at most once per interval, and
+     * merges each result into the row that is already on screen.
+     */
+    fun refreshHomeCatalogsIfStale() {
+        if (addonsCache.isEmpty()) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (now - lastHomeCatalogRefreshAtMs < HOME_CATALOG_REFRESH_TTL_MS) return
+        lastHomeCatalogRefreshAtMs = now
+        refreshVisibleCatalogsPipeline()
+    }
 
     private suspend fun loadAllCatalogs(addons: List<Addon>, forceReload: Boolean = false) =
         loadAllCatalogsPipeline(addons, forceReload)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -94,7 +94,7 @@ class HomeViewModel @Inject constructor(
         private const val MAX_CATALOG_LOAD_CONCURRENCY = 3
 
         /** How long a home catalog is left alone before a return to Home re-requests it. */
-        private const val HOME_CATALOG_REFRESH_TTL_MS = 30L * 60L * 1000L
+        private const val HOME_CATALOG_REFRESH_TTL_MS = 15L * 60L * 1000L
         internal const val EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS = 220L
         internal const val EXTERNAL_META_PREFETCH_ADJACENT_DEBOUNCE_MS = 120L
         private const val MAX_ENRICHMENT_CACHE_SIZE = 64

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -62,6 +62,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     @ApplicationContext internal val appContext: Context,
     internal val addonRepository: AddonRepository,
+    internal val startupSyncService: com.nuvio.tv.core.sync.StartupSyncService,
     internal val catalogRepository: CatalogRepository,
     internal val watchProgressRepository: WatchProgressRepository,
     internal val libraryRepository: LibraryRepository,
@@ -328,6 +329,7 @@ class HomeViewModel @Inject constructor(
             observeProgressSourceChanges()
             observeCollections()
             observeInstalledAddons()
+            observeManualAddonRefresh()
 
             // Clear CW state when profile changes so items don't leak between profiles.
             var previousProfileId = profileManager.activeProfileId.value
@@ -743,6 +745,21 @@ class HomeViewModel @Inject constructor(
      * refresh is older than [HOME_CATALOG_REFRESH_TTL_MS], at most once per interval, and
      * merges each result into the row that is already on screen.
      */
+    /**
+     * The user pressed refresh in addon settings. Home is still on the back stack, so its
+     * catalogs are re-requested right away rather than waiting for the interval or for the
+     * user to come back. The same merge rules apply, so a row is never rebuilt under focus.
+     */
+    private fun observeManualAddonRefresh() {
+        viewModelScope.launch {
+            startupSyncService.manualAddonRefreshes.collect {
+                if (addonsCache.isEmpty()) return@collect
+                lastHomeCatalogRefreshAtMs = android.os.SystemClock.elapsedRealtime()
+                refreshVisibleCatalogsPipeline(requestedByUser = true)
+            }
+        }
+    }
+
     fun refreshHomeCatalogsIfStale() {
         if (addonsCache.isEmpty()) return
         val now = android.os.SystemClock.elapsedRealtime()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -15,6 +15,7 @@ import com.nuvio.tv.domain.model.legacyKey
 import com.nuvio.tv.domain.model.mergeCatalogPage
 import com.nuvio.tv.domain.model.nextCatalogSkip
 import com.nuvio.tv.domain.model.skipStep
+import com.nuvio.tv.domain.model.stableKey
 import com.nuvio.tv.domain.model.WatchedItem
 import com.nuvio.tv.domain.model.supportsExtra
 import kotlinx.coroutines.Dispatchers
@@ -153,6 +154,8 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
 
     activeCatalogLoadSignature = signature
     catalogsLoadInProgress = true
+    // A full load leaves every catalog fresh, so the next return to Home has nothing to do.
+    lastHomeCatalogRefreshAtMs = android.os.SystemClock.elapsedRealtime()
     catalogLoadGeneration += 1
     val generation = catalogLoadGeneration
     cancelInFlightCatalogLoads()
@@ -403,7 +406,9 @@ internal fun HomeViewModel.loadHeroCatalogsPipeline() {
 internal fun HomeViewModel.loadCatalogPipeline(
     addon: Addon,
     catalog: CatalogDescriptor,
-    generation: Long
+    generation: Long,
+    /** True only for the ON_RESUME refresh, where a row already on screen must be merged into. */
+    isRefresh: Boolean = false
 ) {
     val loadJob = viewModelScope.launch {
         var hasCountedCompletion = false
@@ -434,7 +439,9 @@ internal fun HomeViewModel.loadCatalogPipeline(
                             type = catalog.apiType,
                             catalogId = catalog.id
                         )
-                        replaceCatalogRow(key, result.data)
+                        if (!isRefresh || !mergeRefreshedCatalogRow(key, result.data)) {
+                            replaceCatalogRow(key, result.data)
+                        }
                         // Remove placeholder descriptor now that real data is available
                         synchronized(catalogStateLock) {
                             placeholderDescriptors.removeAll { it.catalogKey == key }
@@ -818,7 +825,8 @@ internal suspend fun HomeViewModel.updateCatalogRowsPipeline() {
                                     item = item,
                                     addonBaseUrl = row.addonBaseUrl,
                                     catalogId = row.catalogId,
-                                    catalogName = row.catalogName
+                                    catalogName = row.catalogName,
+                                    addonId = row.addonId
                                 ))
                             }
                             if (showSeeAll) {
@@ -1073,4 +1081,97 @@ private fun HomeViewModel.reconcileFullyWatchedFromLocalItems(
         fullyWatchedSeriesIds.updateWithValidation(mergedHolderIds, cacheResolvedIds)
     }
     return mergedHolderIds
+}
+
+/**
+ * Re-request page 1 of every catalog that is already on screen and swap each result in
+ * place.  Unlike [loadAllCatalogsPipeline] with `forceReload`, this leaves the row list,
+ * its order and the loading placeholders untouched, so the vertical layout never reflows
+ * and focus stays on the card the user left it on.
+ */
+/**
+ * Merges a freshly fetched page 1 into the row that is already on screen.
+ *
+ * Returns true when the row has been dealt with here, false when the caller should just replace
+ * it.  Three outcomes, in order:
+ *
+ *  - **nothing changed**: keep the row, and with it the pages the user has already paginated in;
+ *  - **a pure prepend**: the addon put items in front and what follows still matches the head of
+ *    the row, in order.  Nothing disappears and no card changes identity, so this is applied
+ *    straight away even while the row holds focus.  The pagination window moves by the same
+ *    amount, otherwise the next page would re-serve items the row already has;
+ *  - **a real restructuring**: reorder, removal or turnover.  Rebuilding drops the cards under
+ *    the focus ring, so the row the user has focus on is left alone and picked up on a later
+ *    pass, once focus has moved on.
+ */
+internal fun HomeViewModel.mergeRefreshedCatalogRow(key: String, fresh: CatalogRow): Boolean {
+    val current = readCatalogRow(key) ?: return false
+    if (current.items.isEmpty()) return false
+    // An addon answering 200 with no items (rate limit, partial outage) must not wipe a row the
+    // user can see; keep what is on screen and try again on the next pass.
+    if (fresh.items.isEmpty()) return true
+
+    val identity = { item: com.nuvio.tv.domain.model.MetaPreview -> item.apiType + ":" + item.id }
+    val currentIds = current.items.map(identity)
+    val freshIds = fresh.items.map(identity)
+
+    if (freshIds == currentIds.take(freshIds.size)) {
+        return true
+    }
+
+    val existing = currentIds.toHashSet()
+    val added = fresh.items.takeWhile { identity(it) !in existing }
+    val rest = freshIds.drop(added.size)
+    val isPrepend = added.isNotEmpty() && rest.isNotEmpty() &&
+        rest.size <= currentIds.size &&
+        rest.indices.all { rest[it] == currentIds[it] }
+
+    val focusedRowKey = liveFocusedRowKey
+    val rowHasFocus = focusedRowKey != null && focusedRowKey == fresh.stableKey()
+
+    if (isPrepend) {
+        // Nothing is removed, so the focused card only shifts along. That holds in the modern
+        // layout, which keeps the whole row; the others cut it at a fixed length, where the
+        // focused card can be pushed past the cut.
+        if (rowHasFocus && _uiState.value.homeLayout != HomeLayout.MODERN) return true
+        val shiftedSkip = if (current.supportsSkip && current.nextSkip > 0) {
+            current.nextSkip + added.size
+        } else {
+            current.nextSkip
+        }
+        replaceCatalogRow(key, current.copy(items = added + current.items, nextSkip = shiftedSkip))
+        Log.d(
+            HomeViewModel.TAG,
+            "Home catalog refresh: +${added.size} item(s) catalogId=${fresh.catalogId}"
+        )
+        return true
+    }
+
+    // The row was restructured. Rebuilding it drops the cards under the focus ring, so leave the
+    // focused row alone and pick it up once focus has moved on.
+    return rowHasFocus
+}
+
+
+internal fun HomeViewModel.refreshVisibleCatalogsPipeline() {
+    val loadedKeys = synchronized(catalogStateLock) { catalogsMap.keys.toSet() }
+    if (loadedKeys.isEmpty()) return
+
+    val toRefresh = addonsCache.flatMap { addon ->
+        addon.catalogs
+            .filter { catalog ->
+                !catalog.isSearchOnlyCatalog() && catalogKey(
+                    addonId = addon.id,
+                    type = catalog.apiType,
+                    catalogId = catalog.id
+                ) in loadedKeys
+            }
+            .map { catalog -> addon to catalog }
+    }
+    if (toRefresh.isEmpty()) return
+
+    Log.d(HomeViewModel.TAG, "Refreshing ${toRefresh.size} home catalogs in place")
+    val generation = catalogLoadGeneration
+    pendingCatalogLoads += toRefresh.size
+    toRefresh.forEach { (addon, catalog) -> loadCatalogPipeline(addon, catalog, generation, isRefresh = true) }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -408,7 +408,8 @@ internal fun HomeViewModel.loadCatalogPipeline(
     catalog: CatalogDescriptor,
     generation: Long,
     /** True only for the ON_RESUME refresh, where a row already on screen must be merged into. */
-    isRefresh: Boolean = false
+    isRefresh: Boolean = false,
+    requestedByUser: Boolean = false
 ) {
     val loadJob = viewModelScope.launch {
         var hasCountedCompletion = false
@@ -439,7 +440,7 @@ internal fun HomeViewModel.loadCatalogPipeline(
                             type = catalog.apiType,
                             catalogId = catalog.id
                         )
-                        if (!isRefresh || !mergeRefreshedCatalogRow(key, result.data)) {
+                        if (!isRefresh || !mergeRefreshedCatalogRow(key, result.data, requestedByUser)) {
                             replaceCatalogRow(key, result.data)
                         }
                         // Remove placeholder descriptor now that real data is available
@@ -1104,7 +1105,13 @@ private fun HomeViewModel.reconcileFullyWatchedFromLocalItems(
  *    the focus ring, so the row the user has focus on is left alone and picked up on a later
  *    pass, once focus has moved on.
  */
-internal fun HomeViewModel.mergeRefreshedCatalogRow(key: String, fresh: CatalogRow): Boolean {
+internal fun HomeViewModel.mergeRefreshedCatalogRow(
+    key: String,
+    fresh: CatalogRow,
+    /** True when the user asked for the refresh, in which case seeing the change wins over
+     *  keeping their place in the row they happen to be on. */
+    requestedByUser: Boolean = false
+): Boolean {
     val current = readCatalogRow(key) ?: return false
     if (current.items.isEmpty()) return false
     // An addon answering 200 with no items (rate limit, partial outage) must not wipe a row the
@@ -1133,7 +1140,9 @@ internal fun HomeViewModel.mergeRefreshedCatalogRow(key: String, fresh: CatalogR
         // Nothing is removed, so the focused card only shifts along. That holds in the modern
         // layout, which keeps the whole row; the others cut it at a fixed length, where the
         // focused card can be pushed past the cut.
-        if (rowHasFocus && _uiState.value.homeLayout != HomeLayout.MODERN) return true
+        if (!requestedByUser && rowHasFocus && _uiState.value.homeLayout != HomeLayout.MODERN) {
+            return true
+        }
         val shiftedSkip = if (current.supportsSkip && current.nextSkip > 0) {
             current.nextSkip + added.size
         } else {
@@ -1149,11 +1158,11 @@ internal fun HomeViewModel.mergeRefreshedCatalogRow(key: String, fresh: CatalogR
 
     // The row was restructured. Rebuilding it drops the cards under the focus ring, so leave the
     // focused row alone and pick it up once focus has moved on.
-    return rowHasFocus
+    return rowHasFocus && !requestedByUser
 }
 
 
-internal fun HomeViewModel.refreshVisibleCatalogsPipeline() {
+internal fun HomeViewModel.refreshVisibleCatalogsPipeline(requestedByUser: Boolean = false) {
     val loadedKeys = synchronized(catalogStateLock) { catalogsMap.keys.toSet() }
     if (loadedKeys.isEmpty()) return
 
@@ -1173,5 +1182,7 @@ internal fun HomeViewModel.refreshVisibleCatalogsPipeline() {
     Log.d(HomeViewModel.TAG, "Refreshing ${toRefresh.size} home catalogs in place")
     val generation = catalogLoadGeneration
     pendingCatalogLoads += toRefresh.size
-    toRefresh.forEach { (addon, catalog) -> loadCatalogPipeline(addon, catalog, generation, isRefresh = true) }
+    toRefresh.forEach { (addon, catalog) ->
+        loadCatalogPipeline(addon, catalog, generation, isRefresh = true, requestedByUser = requestedByUser)
+    }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -118,6 +118,7 @@ fun ModernHomeContent(
     onItemFocus: (MetaPreview) -> Unit = {},
     onPreloadAdjacentItem: (MetaPreview) -> Unit = {},
     onSaveFocusState: (Int, Int, String?, Map<String, String>, Map<String, Int>, Int, Int) -> Unit,
+    onFocusedRowKeyChanged: (String?) -> Unit = {},
     scrollToTopTrigger: Int = 0,
     onRequestLazyCatalogLoad: (String) -> Unit = {},
     onRowItemFocusedCallback: (String, Int, Boolean) -> Unit = { _, _, _ -> },
@@ -194,6 +195,9 @@ fun ModernHomeContent(
     val loadMoreRequestedTotals = remember { mutableStateMapOf<String, Int>() }
 
     val focusedItemByRow = remember { mutableStateMapOf<String, Int>() }
+    // Item keys of each row as they were when its focused index was last recorded, so the index
+    // can be relocated when an in-place refresh shifts the row instead of pointing at a new item.
+    val previousItemKeysByRow = remember { mutableMapOf<String, List<String>>() }
     val stableFocusedItemByRow = remember { StableRef<MutableMap<String, Int>>(focusedItemByRow) }
     val stableRowListStates = remember { StableRef<MutableMap<String, LazyListState>>(rowListStates) }
     val stableLoadMoreRequestedTotals = remember { StableRef<MutableMap<String, Int>>(loadMoreRequestedTotals) }
@@ -320,6 +324,25 @@ fun ModernHomeContent(
             payload.trailerApiType
         )
         lastRequestedTrailerFocusKey = selection.focusKey
+    }
+
+    // During composition, not in an effect: an effect only lands after the new list is drawn,
+    // so the row would briefly show focus on whatever sits at the old index. The write is
+    // guarded by an inequality, so it settles after one extra pass.
+    previousItemKeysByRow.keys.retainAll(activeRowKeys)
+    carouselRows.list.forEach { row ->
+        val currentKeys = row.items.list.map { it.key }
+        val storedIdx = focusedItemByRow[row.key]
+        val relocated = if (storedIdx != null) {
+            previousItemKeysByRow[row.key]
+                ?.getOrNull(storedIdx)
+                ?.let { currentKeys.indexOf(it) }
+                ?.takeIf { it >= 0 }
+        } else null
+        if (relocated != null && relocated != storedIdx) {
+            focusedItemByRow[row.key] = relocated
+        }
+        previousItemKeysByRow[row.key] = currentKeys
     }
 
     LaunchedEffect(carouselRows, focusState.hasSavedFocus) {
@@ -1008,7 +1031,16 @@ fun ModernHomeContent(
                 modifier = heroMetadataModifier
             )
 
-            val onActiveRowKeyChangeLambda = remember { { key: String? -> focusHolder.activeRowKey = key; activeRowKey.value = key } }
+            val latestOnFocusedRowKeyChanged by rememberUpdatedState(onFocusedRowKeyChanged)
+            val onActiveRowKeyChangeLambda = remember {
+                { key: String? ->
+                    focusHolder.activeRowKey = key
+                    activeRowKey.value = key
+                    // saveFocusState only runs on dispose, which a system Home press never
+                    // triggers, so report the focused row as it changes instead.
+                    latestOnFocusedRowKeyChanged(key)
+                }
+            }
             val onActiveItemIndexChangeLambda = remember { { index: Int -> focusHolder.activeItemIndex = index; activeItemIndex.intValue = index } }
             val onLastHeroNavigationAtMsChangeLambda = remember { { ms: Long -> lastHeroNavigationAtMs.longValue = ms } }
             val onHeroFocusSettleDelayChangeLambda = remember { { delay: Long -> heroFocusSettleDelayMs.longValue = delay } }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -183,7 +183,7 @@ internal fun buildModernHomePresentation(
                                     cachedItem.showImdbRatings == input.showImdbRatings
                                 ) {
                                     cachedItem.carouselItem.let { cached ->
-                                        val stableItemKey = row.stableItemKey(itemIndex)
+                                        val stableItemKey = row.stableItemKey(item, occurrence)
                                         if (cached.key == stableItemKey) cached
                                         else cached.copy(key = stableItemKey)
                                     }
@@ -198,7 +198,7 @@ internal fun buildModernHomePresentation(
                                         showFullReleaseDate = input.showFullReleaseDate,
                                         showImdbRatings = input.showImdbRatings,
                                         previousCachedItem = cachedItem?.carouselItem
-                                    ).copy(key = row.stableItemKey(itemIndex))
+                                    ).copy(key = row.stableItemKey(item, occurrence))
                                     rowItemCache[cacheKey] = CachedCarouselItem(
                                         source = item,
                                         useLandscapePosters = input.useLandscapePosters,


### PR DESCRIPTION
> [!NOTE]
> Draft on purpose, and not a request to merge. I know the policy is translation
> or critical bug fixes, and this is neither: nothing crashes, the home screen
> just shows data that can be hours old for a whole session, which is #3152. I
> hit it, fixed it on my own device, and would rather document it here than
> leave it in a branch nobody can find. Take any part of it, or none. Neither PR
> type box is ticked for the same reason.

## Summary

Home catalogs are requested once at launch and never again for as long as the
HomeViewModel lives, so the rows stay frozen for the whole session. This adds an
ON_RESUME observer on Home that, at most once an hour, re-requests page 1 of the
catalogs already loaded.

The results are merged into the rows on screen rather than replacing them.
Rebuilding a row is invisible on a phone; on a TV the D-pad sits on one specific
card, so it means losing your place mid-browse, and throwing away the pages you
had scrolled in.

Fixes #3152.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix

See the note at the top.

## Why it happens today

The catalog load returns early once any row exists, and its signature is built
only from addon manifest fields, so nothing in normal use invalidates it. Home
is also the only major screen without a lifecycle observer: nine others have
one, seven purely for focus restoration, none for data.

`forceReload` exists and works, but its only call site is the retry button,
which renders only on the total-failure error screen. A user who sees content
can never reach it.

## What the merge does

| The addon | What happens |
|---|---|
| changed nothing | row untouched, extra pages kept |
| added items in front | inserted at the start, pagination offset moved to match |
| removed or reordered items | row rebuilt, unless it currently holds focus |
| replaced the whole page | same, nothing can be preserved |
| answered with no items | ignored: a rate limit or a brief outage must not wipe a visible row |

A row holding focus is picked up on a later return, once focus has moved on.
Every other row updates meanwhile.

## Layouts

| | Modern | Classic | Grid |
|---|---|---|---|
| Row length on Home | whole row | cut at 24 | cut to the visible slots |
| Items added while it holds focus | applied, the card shifts along | held back | held back |
| Focus finds a card that moved | yes | yes | yes |

Modern keeps the whole row, so an addition cannot push the focused card out of
it. The other two cut rows short, so it can, and there it waits.

## Why item keys changed

`stableItemKey` returned a position despite its name. Compose uses those keys to
tell whether a card is still the same card, so any change to a row rebound every
slot and the card under the focus ring silently became a different title. They
are now built from the item identity.

Two things follow. Each layout now reports which row holds focus, since none of
them did. And the remembered position inside a row is an index, so it is moved
to wherever its card went.

## What this costs

The interval only decides when it is worth asking. Below it is the shared HTTP
cache, which already honours `max-age` and validators, so an addon that declares
a window is not contacted at all and one that sends a validator answers with a
`304` and no body. The interval is there for the device: without it, every
return to Home would re-parse and re-merge every loaded catalog, even straight
from cache.

A more precise version would read those headers itself, which would also let a
row refill without leaving Home. I have it on a branch if you prefer that.

## What is not touched

Only the resume refresh goes through the merge; cold start, forced reloads and
addon changes replace rows exactly as before. Nothing is scheduled or polled, so
an idle app does nothing. The interval uses a monotonic clock. Three of the
eleven files are four to eight line call-site updates following the key change.

## Reproduction steps

1. Open the app and let the home catalogs load.
2. Keep using it, or navigate away and back, for as long as you like.
3. Have an addon publish new items in the meantime.

They never appear until the app is restarted.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

Rows update on return to Home instead of staying frozen. No layout or styling
change.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

See "What is not touched" above. No styling, no renames, no drive-by cleanups.

## Testing

Built `fullDebug` and ran it on a TCL Google TV (Android 12, armeabi-v7a),
against a local addon serving a catalog that can be changed on demand, in all
three home layouts:

- a row holding focus stays put while its catalog is replaced underneath it, and
  picks up the change once focus has moved away
- a row keeps its items when the addon answers with an empty list
- items added in front appear at the start, and the next page does not repeat
- after a row shifts, going back to it puts focus on the same card as before
- cold start, addon enable/disable and the retry button behave as before

Search shares the row component and behaves as it does on the current build.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3152.
