### PR TITLE
ix: CW launcher intent, Simkl anime type, discover posterShape, episode description, library localization

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -274,6 +274,7 @@ class MainActivity : ComponentActivity() {
     lateinit var deepLinkHandler: DeepLinkHandler
 
     private val pendingDeepLinkUrl = MutableStateFlow<String?>(null)
+    private val pendingLaunchIntent = MutableStateFlow<Intent?>(null)
 
     private lateinit var jankStats: JankStats
 
@@ -746,6 +747,43 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    val pendingLaunch by pendingLaunchIntent.collectAsState()
+                    LaunchedEffect(navController, layoutChosen, pendingLaunch) {
+                        val intent = pendingLaunch ?: return@LaunchedEffect
+                        if (!layoutChosen) return@LaunchedEffect
+                        pendingLaunchIntent.value = null
+                        val contentId = intent.getStringExtra("contentId") ?: return@LaunchedEffect
+                        val contentType = intent.getStringExtra("contentType") ?: return@LaunchedEffect
+                        val videoId = intent.getStringExtra("videoId")
+                        val name = intent.getStringExtra("name")
+                        if (videoId != null && name != null) {
+                            navController.navigate(
+                                Screen.Stream.createRoute(
+                                    videoId = videoId,
+                                    contentType = contentType,
+                                    title = name,
+                                    poster = intent.getStringExtra("poster"),
+                                    backdrop = intent.getStringExtra("backdrop"),
+                                    logo = intent.getStringExtra("logo"),
+                                    season = intent.getIntExtra("season", -1).takeIf { it >= 0 },
+                                    episode = intent.getIntExtra("episode", -1).takeIf { it >= 0 },
+                                    episodeName = intent.getStringExtra("episodeTitle"),
+                                    contentId = contentId,
+                                    contentName = name,
+                                    returnToDetailOnBack = contentType.equals("series", ignoreCase = true),
+                                    returnToHomeOnBack = true
+                                )
+                            )
+                        } else {
+                            navController.navigate(
+                                Screen.Detail.createRoute(
+                                    itemId = contentId,
+                                    itemType = contentType
+                                )
+                            )
+                        }
+                    }
+
                     LaunchedEffect(navController, layoutChosen, pendingDeepLink) {
                         val url = pendingDeepLink ?: return@LaunchedEffect
                         if (!layoutChosen) return@LaunchedEffect
@@ -982,11 +1020,19 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         captureDeepLinkIntent(intent)
+        captureLaunchIntent(intent)
     }
 
     private fun captureDeepLinkIntent(intent: Intent?) {
         val url = intent?.dataString?.trim()?.takeIf(String::isNotBlank) ?: return
         pendingDeepLinkUrl.value = url
+    }
+
+    private fun captureLaunchIntent(intent: Intent?) {
+        val contentId = intent?.getStringExtra("contentId") ?: return
+        val launchMode = intent.getStringExtra("launchMode") ?: return
+        if (launchMode != "stream") return
+        pendingLaunchIntent.value = intent
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReceipt.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReceipt.kt
@@ -37,7 +37,9 @@ internal sealed interface SimklCommittedMutation {
 internal data class SimklResolvedListMutation(
     val request: TrackingMediaReference,
     val status: SimklListStatus,
-    val responseMedia: SimklMedia
+    val responseMedia: SimklMedia,
+    val resolvedMediaType: SimklMediaType? = null,
+    val animeType: String? = null
 )
 
 internal data class SimklResolvedHistoryMutation(
@@ -69,6 +71,12 @@ internal fun SimklApiResponse.toListMutationReceipt(
                 val status = response.stringValue("to")?.toSimklListStatus()
                     ?: return@forEach
                 val responseMedia = response.toResponseMedia()
+                val animeType = response.stringValue("anime_type")
+                val resolvedMediaType = if (animeType != null) {
+                    SimklMediaType.ANIME
+                } else {
+                    response.stringValue("type")?.toSimklMediaType()
+                }
                 val index = unmatched.indexOfFirst { candidate ->
                     (candidate.kind == TrackingMediaKind.MOVIE) == expectedMovie &&
                         responseMedia.matchesTarget(candidate.toSimklMedia())
@@ -78,7 +86,9 @@ internal fun SimklApiResponse.toListMutationReceipt(
                         SimklResolvedListMutation(
                             request = unmatched.removeAt(index),
                             status = status,
-                            responseMedia = responseMedia
+                            responseMedia = responseMedia,
+                            resolvedMediaType = resolvedMediaType,
+                            animeType = animeType
                         )
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReconciliation.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklMutationReconciliation.kt
@@ -29,10 +29,13 @@ private fun SimklSyncSnapshot.withListMutations(
         val media = mutation.responseMedia.mergeMissing(requestMedia)
         val index = updated.indexOfMatchingMedia(media)
         val existing = updated.getOrNull(index)
-        val mediaType = existing?.mediaType ?: mutation.request.kind.toSimklMediaType()
+        val mediaType = existing?.mediaType
+            ?: mutation.resolvedMediaType
+            ?: mutation.request.kind.toSimklMediaType()
         val mergedMedia = media.mergeMissing(existing?.media)
         val entry = (existing ?: SimklLibraryEntry()).copy(
             mediaType = mediaType,
+            animeType = mutation.animeType ?: existing?.animeType,
             localPosterUrl = existing?.localPosterUrl
                 ?: mutation.request.posterUrl?.trim()?.takeIf(String::isNotBlank),
             addedToWatchlistAt = existing?.addedToWatchlistAt ?: committedAt,

--- a/app/src/main/java/com/nuvio/tv/domain/model/LibraryListTabLocalization.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/LibraryListTabLocalization.kt
@@ -1,0 +1,20 @@
+package com.nuvio.tv.domain.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.nuvio.tv.R
+import com.nuvio.tv.core.tracking.LOCAL_LIBRARY_LIST_KEY
+
+@Composable
+fun LibraryListTab.localizedTitle(): String {
+    return when {
+        key == LOCAL_LIBRARY_LIST_KEY -> title
+        key == "simkl:status:watching" -> stringResource(R.string.library_status_watching)
+        key == "simkl:status:plantowatch" -> stringResource(R.string.library_status_plan_to_watch)
+        key == "simkl:status:hold" -> stringResource(R.string.library_status_on_hold)
+        key == "simkl:status:completed" -> stringResource(R.string.library_status_completed)
+        key == "simkl:status:dropped" -> stringResource(R.string.library_status_dropped)
+        type == LibraryListTab.Type.WATCHLIST -> stringResource(R.string.library_watchlist)
+        else -> title
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContentCard.kt
@@ -46,6 +46,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
 import com.nuvio.tv.domain.model.CardDepthSurface
 import androidx.compose.ui.platform.LocalContext
 import com.nuvio.tv.ui.util.recompositionHighlighter
@@ -75,8 +76,17 @@ fun GridContentCard(
     val cardShape = remember(posterCardStyle.cornerRadius) { RoundedCornerShape(posterCardStyle.cornerRadius) }
     val cardDepthStyle = LocalCardDepthStyle.current
     val density = LocalDensity.current
+
+    // Derive card height from item's posterShape aspect ratio while keeping width from posterCardStyle.
+    // This ensures grids and rows display landscape/square shapes correctly.
+    val cardHeight = when (item.posterShape) {
+        PosterShape.POSTER -> posterCardStyle.height
+        PosterShape.LANDSCAPE -> posterCardStyle.width / PosterShape.LANDSCAPE.aspectRatio()
+        PosterShape.SQUARE -> posterCardStyle.width
+    }
+
     val requestWidthPx = remember(density, posterCardStyle.width) { with(density) { posterCardStyle.width.roundToPx() }.coerceAtLeast(1) }
-    val requestHeightPx = remember(density, posterCardStyle.height) { with(density) { posterCardStyle.height.roundToPx() }.coerceAtLeast(1) }
+    val requestHeightPx = remember(density, cardHeight) { with(density) { cardHeight.roundToPx() }.coerceAtLeast(1) }
     var isFocused by remember { mutableStateOf(false) }
     var longPressTriggered by remember { mutableStateOf(false) }
     val longPressKeyTracker = rememberLongPressKeyTracker()
@@ -97,7 +107,7 @@ fun GridContentCard(
             },
             modifier = Modifier
                 .width(posterCardStyle.width)
-                .height(posterCardStyle.height)
+                .height(cardHeight)
                 .then(
                     if (focusRequester != null) Modifier.focusRequester(focusRequester)
                     else Modifier
@@ -206,7 +216,7 @@ fun GridContentCard(
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
                             .fillMaxWidth()
-                            .height(posterCardStyle.height * 0.45f)
+                            .height(cardHeight * 0.45f)
                             .background(
                                 Brush.verticalGradient(
                                     listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
@@ -226,7 +236,7 @@ fun GridContentCard(
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
                             .fillMaxWidth()
-                            .heightIn(max = posterCardStyle.height * 0.35f)
+                            .heightIn(max = cardHeight * 0.35f)
                             .padding(horizontal = NuvioTheme.spacing.lg, vertical = 14.dp)
                     )
                 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
@@ -31,6 +31,7 @@ import com.nuvio.tv.core.tracking.TrackingMembershipRemovalConfirmation
 import com.nuvio.tv.core.tracking.LOCAL_LIBRARY_LIST_KEY
 import com.nuvio.tv.core.tracking.supportsMembershipFor
 import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.localizedTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.ui.components.NuvioDialog
 
@@ -158,7 +159,7 @@ fun PosterListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "✓ ${tab.title}" else tab.title
+                val titleText = if (selected) "✓ ${tab.localizedTitle()}" else tab.localizedTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -111,6 +111,7 @@ import com.nuvio.tv.domain.model.ContentType
 import com.nuvio.tv.domain.model.DetailImdbRatingsVisibility
 import com.nuvio.tv.domain.model.HomeImdbRatingsVisibility
 import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.localizedTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaCastMember
@@ -2611,7 +2612,7 @@ private fun LibraryListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "\u2713 ${tab.title}" else tab.title
+                val titleText = if (selected) "\u2713 ${tab.localizedTitle()}" else tab.localizedTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -43,6 +43,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.localizedTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ErrorState
@@ -788,7 +789,7 @@ private fun HomeLibraryListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "\u2713 ${tab.title}" else tab.title
+                val titleText = if (selected) "\u2713 ${tab.localizedTitle()}" else tab.localizedTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -676,7 +676,8 @@ class HomeViewModel @Inject constructor(
                         isReleaseAlert = cached.isReleaseAlert,
                         isNewSeasonRelease = cached.isNewSeasonRelease,
                         seedSeason = cached.seedSeason,
-                        seedEpisode = cached.seedEpisode
+                        seedEpisode = cached.seedEpisode,
+                        contentLanguage = cached.contentLanguage
                     )
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -536,7 +536,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                             isReleaseAlert = freshIsReleaseAlert,
                             isNewSeasonRelease = freshIsNewSeasonRelease,
                             seedSeason = cached.seedSeason,
-                            seedEpisode = cached.seedEpisode
+                            seedEpisode = cached.seedEpisode,
+                            contentLanguage = cached.contentLanguage
                         )
                     )
                 }
@@ -1001,7 +1002,8 @@ internal fun HomeViewModel.loadContinueWatchingPipeline() {
                                 isReleaseAlert = freshIsReleaseAlert,
                                 isNewSeasonRelease = freshIsNewSeasonRelease,
                                 seedSeason = cached.seedSeason,
-                                seedEpisode = cached.seedEpisode
+                                seedEpisode = cached.seedEpisode,
+                                contentLanguage = cached.contentLanguage
                             )
                         )
                     }
@@ -1889,7 +1891,8 @@ private suspend fun HomeViewModel.buildNextUpItem(
         isReleaseAlert = releaseState.isReleaseAlert,
         isNewSeasonRelease = releaseState.isNewSeasonRelease,
         seedSeason = progress.season,
-        seedEpisode = progress.episode
+        seedEpisode = progress.episode,
+        contentLanguage = normalizeLanguageCode(seedMeta?.language) ?: countryToLanguageCode(seedMeta?.country)
     )
     logNextUpDecision(
         "built contentId=${progress.contentId} name=${progress.name} next=${nextUp.season}x${nextUp.episode} " +

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -97,6 +97,7 @@ import com.nuvio.tv.ui.screens.stream.PlayerChoiceDialog
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.nuvio.tv.ui.components.PosterCardDefaults
+import com.nuvio.tv.domain.model.localizedTitle
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioTheme
@@ -118,19 +119,6 @@ private enum class LibraryViewMode {
 private fun localizedTypeLabel(key: String): String = when (key.lowercase()) {
     LibraryTypeTab.ALL_KEY -> stringResource(R.string.library_type_all)
     else -> localizedContentType(key)
-}
-
-@Composable
-private fun LibraryListTab.localizedTitle(): String {
-    return when {
-        key == "simkl:status:watching" -> stringResource(R.string.library_status_watching)
-        key == "simkl:status:plantowatch" -> stringResource(R.string.library_status_plan_to_watch)
-        key == "simkl:status:hold" -> stringResource(R.string.library_status_on_hold)
-        key == "simkl:status:completed" -> stringResource(R.string.library_status_completed)
-        key == "simkl:status:dropped" -> stringResource(R.string.library_status_dropped)
-        type == LibraryListTab.Type.WATCHLIST -> stringResource(R.string.library_watchlist)
-        else -> title
-    }
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -91,9 +91,8 @@ internal fun PlayerRuntimeController.updateEpisodeDescription() {
         video.season == currentSeason && video.episode == currentEpisode
     }?.overview
 
-    if (!overview.isNullOrBlank()) {
-        _uiState.update { it.copy(description = overview) }
-    }
+    // Always update description when switching episodes - clear stale description
+    _uiState.update { it.copy(description = overview) }
 
     // Push episode metadata to the MediaSession so Google Home shows the new episode.
     updateMediaSessionMetadata()

--- a/app/src/main/java/com/nuvio/tv/ui/util/TypeLabelFormatter.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/TypeLabelFormatter.kt
@@ -15,7 +15,8 @@ fun formatAddonTypeLabel(value: String): String {
 
 fun localizedContentType(context: Context, contentType: String?): String = when (contentType?.lowercase()?.trim()) {
     "movie" -> context.getString(R.string.type_movie)
-    "series", "tv" -> context.getString(R.string.type_series)
+    "series" -> context.getString(R.string.type_series)
+    "tv" -> "TV"
     else -> contentType?.let { formatAddonTypeLabel(it) } ?: ""
 }
 


### PR DESCRIPTION
## Summary

Six fixes:

1. Launcher CW cards ignored when app is in background (home button exit)
2. Simkl library: anime stored as "series" instead of "anime" when adding from detail view
3. Continue Watching NextUp items missing contentLanguage -> original audio setting ignored
4. Discover grid ignores posterShape from addon (landscape items rendered as poster)
5. Episode description on pause screen stale during binge-watch autoplay
6. Simkl library list names (Watching, Plan to Watch, etc.) not translated in list picker dialogs

## PR type

- [x] Critical bug fix

## Why

Each fix addresses a user-reported regression or missing functionality:
1. Launcher integration broken for backgrounded app
2. Simkl anime classification incorrect
3. Original audio preference not applied when resuming from CW
4. Addon posterShape not respected in discover grid
5. Wrong episode info shown during binge-watch
6. Missing localization in library list picker

## Issue or approval

Multiple user-reported bugs from Discord and GitHub issues.

## Reproduction steps

1. **CW launcher**: Open app, press Home, click CW card from launcher -> goes to homepage instead of episode
2. **Simkl anime**: Add anime to Simkl library from detail -> shows as "series" in library
3. **Original audio**: Set original audio, watch something, change audio manually, play next from CW -> wrong audio
4. **PosterShape**: Install addon with posterShape:"landscape", open discover -> posters show as portrait
5. **Episode description**: Start series, let autoplay continue 2+ episodes, pause -> description from first episode
6. **Library list names**: Set app to Polish, open list picker from detail -> "Watching" etc. in English

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- CW launcher fix only handles "stream" launchMode intents (not deep links)
- Simkl fix depends on new anime_type field in Simkl API response (deployed server-side)
- PosterShape fix only affects GridContentCard (used in discover/TMDB/actors); ContentCard in catalog rows already handled posterShape
- Episode description fix clears stale description unconditionally; TMDB enrichment refills async
- Library localization limited to Simkl status keys; Trakt personal list names remain as-is (user-defined)

## Testing

- CW launcher: minimized app, clicked CW card -> navigates to stream screen
- Simkl anime: added anime to library, verified local snapshot has mediaType=ANIME
- ContentLanguage: launched NextUp from CW, verified original audio selected
- PosterShape: installed landscape addon, opened discover -> cards render 16:9
- Episode description: autoplay 3 episodes, paused -> correct episode description shown
- Library localization: Polish locale, opened list picker from detail -> translated status names
- Verified "Biblioteka Nuvio" tab keeps its title (not overwritten to "Lista do obejrzenia")
- "tv" type displayed as "TV" (not translated to "Serial")
- Tested on TCL Android TV

## Screenshots / Video

UI changes are minimal: poster aspect ratio in discover grid, translated list names in picker dialog.

## Breaking changes

None.

## Linked issues

Multiple user-reported bugs fixed in this batch.
