### PR TITLE
Fix scraper IO thread exhaustion on low ram devices (NUVIO-TV-FS)

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -221,6 +221,10 @@ class PluginManager @Inject constructor(
                 isDaemon = true
             }
         }.asCoroutineDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val scraperOrchestrationDispatcher: CoroutineDispatcher =
+        Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_SCRAPERS)
     
     // Flow of all repositories
     val repositories: Flow<List<PluginRepository>> = dataStore.repositories
@@ -674,7 +678,7 @@ class PluginManager @Inject constructor(
         }
 
         val results = enabledScraperList.mapIndexed { index, scraper ->
-            async {
+            async(scraperOrchestrationDispatcher) {
                 if (index > 0) {
                     kotlinx.coroutines.delay(index * 60L)
                 }
@@ -717,9 +721,8 @@ class PluginManager @Inject constructor(
             }
         }
  
-        // Launch all scrapers concurrently within the channelFlow scope
         enabledList.forEachIndexed { index, scraper ->
-            launch {
+            launch(scraperOrchestrationDispatcher) {
                 if (index > 0) {
                     kotlinx.coroutines.delay(index * 60L)
                 }


### PR DESCRIPTION
## Summary

Bound scraper orchestration in `PluginManager` to `MAX_CONCURRENT_SCRAPERS` via a dedicated `Dispatchers.IO.limitedParallelism` dispatcher. Streaming and batch scraper paths now launch work on this bounded dispatcher instead of unbounded `Dispatchers.IO`, preventing native thread exhaustion on low-RAM Fire TV devices during stream search.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On low-RAM Fire TV (AFTMM), stream search could crash with `OutOfMemoryError: pthread_create failed` when many enabled scrapers each launched a coroutine on `Dispatchers.IO`. The semaphore limited scraper execution but not orchestration launches, so the IO pool still tried to create too many native threads. This fix caps orchestration concurrency to the existing scraper limit without changing streaming behavior or result delivery.

## Issue or approval

Fixes NUVIO-TV-FS

## Reproduction steps

1. Use a low-RAM Fire TV device with many enabled scrapers/plugins.
2. Open stream search for a series episode while playback or related network requests are active.
3. Before fix: app can force-close with `CoroutinesInternalError` / `pthread_create` OOM.
4. After fix: stream search continues; scraper results arrive incrementally without process crash.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt` changed.
- No changes to scraper timeout, result limits, stagger delay, or UI.
- No changes to OkHttp thread pools or `StreamSearchSessionCache` in this PR.

## Testing

Tested on my own device (TCL TV): stream search with many enabled scrapers during playback completes without crash. Scraper results still arrive incrementally as before; no regression observed.

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes NUVIO-TV-FS
