### PR TITLE
Fix live IPTV crash and VOD style timeline on live channels

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/LivePlaybackUiPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/LivePlaybackUiPolicy.kt
@@ -1,0 +1,68 @@
+package com.nuvio.tv.ui.screens.player
+
+/**
+ * Live TV and VOD both commonly use HLS (.m3u8). The URL is not a reliable
+ * discriminator. Use the player's live-window signal (ExoPlayer
+ * [androidx.media3.common.Player.isCurrentMediaItemLive], or MPV unseekable)
+ * plus the Stremio catalog type `channel`.
+ *
+ * Do not treat `tv` as live: in this app it is the series synonym.
+ */
+object LivePlaybackUiPolicy {
+    fun isLiveContentType(contentType: String?): Boolean {
+        return contentType.equals("channel", ignoreCase = true)
+    }
+
+    fun nextLiveLatch(playerReportsLive: Boolean, previouslyLatched: Boolean): Boolean {
+        return previouslyLatched || playerReportsLive
+    }
+
+    fun isLivePlayback(
+        playerReportsLive: Boolean,
+        contentType: String?,
+        latchedLive: Boolean = false
+    ): Boolean {
+        return latchedLive ||
+            playerReportsLive ||
+            isLiveContentType(contentType)
+    }
+}
+
+/** Accumulates wall-clock time spent actually playing a live stream. */
+class LivePlaybackWatchClock {
+    private var accumulatedMs = 0L
+    private var segmentStartedAtElapsedMs: Long? = null
+
+    fun reset() {
+        accumulatedMs = 0L
+        segmentStartedAtElapsedMs = null
+    }
+
+    fun watchedDurationMs(
+        isLive: Boolean,
+        isPlaying: Boolean,
+        nowElapsedMs: Long
+    ): Long {
+        if (!isLive) {
+            if (accumulatedMs != 0L || segmentStartedAtElapsedMs != null) {
+                reset()
+            }
+            return 0L
+        }
+        if (isPlaying) {
+            if (segmentStartedAtElapsedMs == null) {
+                segmentStartedAtElapsedMs = nowElapsedMs
+            }
+        } else {
+            val started = segmentStartedAtElapsedMs
+            if (started != null) {
+                accumulatedMs += (nowElapsedMs - started).coerceAtLeast(0L)
+                segmentStartedAtElapsedMs = null
+            }
+        }
+        val running = segmentStartedAtElapsedMs
+            ?.let { (nowElapsedMs - it).coerceAtLeast(0L) }
+            ?: 0L
+        return accumulatedMs + running
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -191,6 +191,12 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         return (seconds * 1000.0).roundToLong().coerceAtLeast(0L)
     }
 
+    /** Live HLS/DASH in mpv is typically reported as not seekable. VOD HLS is seekable. */
+    fun isLiveStreamNow(): Boolean {
+        if (!initialized) return false
+        return mpv.getPropertyBoolean("seekable") == false
+    }
+
     fun hasVideoTrackSelectedNow(): Boolean {
         if (!initialized) return false
         val vid = mpv.getPropertyString("vid")?.trim()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PauseOverlay.kt
@@ -65,7 +65,8 @@ fun PauseOverlay(
     type: String?,
     description: String?,
     cast: List<MetaCastMember>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showClock: Boolean = true
 ) {
     var selectedCastMember by remember { mutableStateOf<MetaCastMember?>(null) }
 
@@ -82,7 +83,9 @@ fun PauseOverlay(
             bottom = 120.dp
         ),
         topEndContent = {
-            PauseOverlayClock()
+            if (showClock) {
+                PauseOverlayClock()
+            }
         }
     ) {
         Column(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackAnalyticsDiagnostics.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackAnalyticsDiagnostics.kt
@@ -201,7 +201,10 @@ internal class PlayerPlaybackAnalyticsDiagnostics {
         positionMs = position
         bufferedPositionMs = player.bufferedPosition.coerceAtLeast(position)
         durationMs = player.duration.takeIf { it > 0L }
-        bufferedPercentage = player.bufferedPercentage.takeIf { it >= 0 }
+        bufferedPercentage = safeBufferedPercentage(
+            bufferedPositionMs = player.bufferedPosition,
+            durationMs = player.duration
+        )
         recordHealthSnapshotIfNeeded(
             now = now,
             rebufferCount = rebufferCount,
@@ -986,6 +989,15 @@ private fun Throwable.findHttpStatus(): Int? {
 
 private fun Long?.safeTimeMs(): Long? =
     this?.takeIf { it != C.TIME_UNSET && it >= 0L }
+
+internal fun safeBufferedPercentage(bufferedPositionMs: Long, durationMs: Long): Int? {
+    if (durationMs == 0L) return 100
+    if (durationMs < 0L || bufferedPositionMs < 0L) return null
+    if (bufferedPositionMs >= durationMs) return 100
+    return ((bufferedPositionMs.toDouble() / durationMs.toDouble()) * 100.0)
+        .toInt()
+        .coerceIn(0, 100)
+}
 
 private fun AnalyticsListener.EventTime.bufferedPositionMs(): Long? {
     val position = currentPlaybackPositionMs.safeTimeMs() ?: return null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -264,21 +264,60 @@ class PlayerRuntimeController(
     internal val _playbackTimeline = MutableStateFlow(PlaybackTimelineState())
     val playbackTimeline: StateFlow<PlaybackTimelineState> = _playbackTimeline.asStateFlow()
 
+    internal val liveWatchClock = LivePlaybackWatchClock()
+    internal var livePlaybackLatched: Boolean = false
+
     internal fun updatePlaybackTimeline(
         currentPosition: Long = _playbackTimeline.value.currentPosition,
         duration: Long = _playbackTimeline.value.duration,
-        bufferedPosition: Long = _playbackTimeline.value.bufferedPosition
+        bufferedPosition: Long = _playbackTimeline.value.bufferedPosition,
+        isLive: Boolean = _playbackTimeline.value.isLive,
+        watchedDurationMs: Long = _playbackTimeline.value.watchedDurationMs
     ) {
         _playbackTimeline.update {
             it.copy(
                 currentPosition = currentPosition.coerceAtLeast(0L),
                 duration = duration.coerceAtLeast(0L),
-                bufferedPosition = bufferedPosition.coerceAtLeast(0L)
+                bufferedPosition = bufferedPosition.coerceAtLeast(0L),
+                isLive = isLive,
+                watchedDurationMs = watchedDurationMs.coerceAtLeast(0L)
             )
         }
     }
 
+    internal fun publishPlaybackTimeline(
+        currentPosition: Long,
+        duration: Long,
+        bufferedPosition: Long,
+        playerReportsLive: Boolean,
+        isPlaying: Boolean
+    ) {
+        livePlaybackLatched = LivePlaybackUiPolicy.nextLiveLatch(
+            playerReportsLive = playerReportsLive,
+            previouslyLatched = livePlaybackLatched
+        )
+        val isLive = LivePlaybackUiPolicy.isLivePlayback(
+            playerReportsLive = playerReportsLive,
+            contentType = contentType,
+            latchedLive = livePlaybackLatched
+        )
+        val watched = liveWatchClock.watchedDurationMs(
+            isLive = isLive,
+            isPlaying = isPlaying,
+            nowElapsedMs = android.os.SystemClock.elapsedRealtime()
+        )
+        updatePlaybackTimeline(
+            currentPosition = currentPosition,
+            duration = duration,
+            bufferedPosition = bufferedPosition,
+            isLive = isLive,
+            watchedDurationMs = watched
+        )
+    }
+
     internal fun resetPlaybackTimeline() {
+        livePlaybackLatched = false
+        liveWatchClock.reset()
         _playbackTimeline.value = PlaybackTimelineState()
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -315,6 +315,7 @@ internal fun PlayerRuntimeController.resetPostPlayOverlayState(clearEpisode: Boo
 }
 
 internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionMs: Long, durationMs: Long) {
+    if (_playbackTimeline.value.isLive) return
     if (!hasRenderedFirstFrame) return
     // Short debrid/error clips must never arm next-episode auto-play (see #2819).
     val effectiveDurationEarly = durationMs.takeIf { it > 0L } ?: lastKnownDuration

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -217,14 +217,17 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         lastKnownDuration = playerDuration
                     }
                     val displayPosition = pendingPreviewSeekPosition ?: pos
-                    updatePlaybackTimeline(
+                    val playingForWatchClock = playingNow && !cacheBuffering
+                    publishPlaybackTimeline(
                         currentPosition = displayPosition,
                         duration = playerDuration,
                         bufferedPosition = (pos + (view.demuxerCacheDurationSec() * 1000.0).toLong())
-                            .coerceAtLeast(displayPosition)
+                            .coerceAtLeast(displayPosition),
+                        playerReportsLive = view.isLiveStreamNow(),
+                        isPlaying = playingForWatchClock
                     )
                     val nearEnd = playerDuration > 0L && pos >= (playerDuration - 500L)
-                    val naturalEnded = nearEnd && shouldTreatAsNaturalPlaybackCompletion(
+                    val naturalEnded = !view.isLiveStreamNow() && nearEnd && shouldTreatAsNaturalPlaybackCompletion(
                         hasRenderedFirstFrame = firstFrameReady,
                         hasFatalError = !_uiState.value.error.isNullOrBlank(),
                         durationMs = playerDuration
@@ -243,10 +246,12 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     }
                     updateMpvAvailableTracks()
                     updateActiveSkipInterval(pos)
-                    evaluatePostPlayOverlayVisibility(
-                        positionMs = pos,
-                        durationMs = playerDuration
-                    )
+                    if (!_playbackTimeline.value.isLive) {
+                        evaluatePostPlayOverlayVisibility(
+                            positionMs = pos,
+                            durationMs = playerDuration
+                        )
+                    }
                     if (naturalEnded && !wasEnded) {
                         // Short placeholders never set naturalEnded, so they cannot mark
                         // watched or auto-advance (see #2819).
@@ -264,10 +269,12 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     lastKnownDuration = playerDuration
                 }
                 val displayPosition = pendingPreviewSeekPosition ?: pos
-                updatePlaybackTimeline(
+                publishPlaybackTimeline(
                     currentPosition = displayPosition,
                     duration = playerDuration.coerceAtLeast(0L),
-                    bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition)
+                    bufferedPosition = player.bufferedPosition.coerceAtLeast(displayPosition),
+                    playerReportsLive = player.isCurrentMediaItemLive,
+                    isPlaying = player.isPlaying
                 )
                 playbackAnalyticsDiagnostics.recordProgressSnapshot(
                     player = player,
@@ -306,10 +313,12 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     }
                 }
                 updateActiveSkipInterval(pos)
-                evaluatePostPlayOverlayVisibility(
-                    positionMs = pos,
-                    durationMs = playerDuration.coerceAtLeast(0L)
-                )
+                if (!_playbackTimeline.value.isLive) {
+                    evaluatePostPlayOverlayVisibility(
+                        positionMs = pos,
+                        durationMs = playerDuration.coerceAtLeast(0L)
+                    )
+                }
 
                 if (player.isPlaying) {
                     val now = System.currentTimeMillis()
@@ -1159,12 +1168,15 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             showControlsTemporarily()
         }
         PlayerEvent.OnSeekForward -> {
+            if (_playbackTimeline.value.isLive) return
             onEvent(PlayerEvent.OnSeekBy(deltaMs = PlayerScrubRates.STEP_SHORT_MS))
         }
         PlayerEvent.OnSeekBackward -> {
+            if (_playbackTimeline.value.isLive) return
             onEvent(PlayerEvent.OnSeekBy(deltaMs = -PlayerScrubRates.STEP_SHORT_MS))
         }
         is PlayerEvent.OnSeekBy -> {
+            if (_playbackTimeline.value.isLive) return
             pendingPreviewSeekPosition = null
             val current = currentPlaybackPositionMs() ?: 0L
             val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
@@ -1186,6 +1198,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnPreviewSeekBy -> {
+            if (_playbackTimeline.value.isLive) return
             val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
             val basePosition = pendingPreviewSeekPosition ?: currentPlaybackPositionMs()?.coerceAtLeast(0L) ?: 0L
             val target = (basePosition + event.deltaMs)
@@ -1200,6 +1213,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         PlayerEvent.OnCommitPreviewSeek -> {
+            if (_playbackTimeline.value.isLive) return
             val target = pendingPreviewSeekPosition
             if (target != null) {
                 seekPlaybackTo(target, SeekParameters.CLOSEST_SYNC)
@@ -1214,6 +1228,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             }
         }
         is PlayerEvent.OnSeekTo -> {
+            if (_playbackTimeline.value.isLive) return
             pendingPreviewSeekPosition = null
             seekPlaybackTo(event.position, SeekParameters.CLOSEST_SYNC)
             updatePlaybackTimeline(currentPosition = event.position)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -171,7 +171,8 @@ fun PlayerScreen(
         exitDispatched = true
         val timeline = viewModel.playbackTimeline.value
         viewModel.stopAndRelease()
-        val completed = timeline.duration > 0L &&
+        val completed = !timeline.isLive &&
+            timeline.duration > 0L &&
             (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
         onBackPress(uiState.currentVideoId, uiState.currentSeason, uiState.currentEpisode, uiState.streamAutoPlayMode != StreamAutoPlayMode.MANUAL, completed)
     }
@@ -857,6 +858,7 @@ fun PlayerScreen(
             type = uiState.contentType,
             description = uiState.description,
             cast = uiState.castMembers,
+            showClock = !viewModel.playbackTimeline.collectAsState().value.isLive,
             modifier = Modifier
                 .fillMaxSize()
                 .zIndex(2.5f)
@@ -1097,7 +1099,8 @@ fun PlayerScreen(
                     if (!externalHandoffInProgress) {
                         externalHandoffInProgress = true
                         val timeline = viewModel.playbackTimeline.value
-                        val completed = timeline.duration > 0L &&
+                        val completed = !timeline.isLive &&
+                            timeline.duration > 0L &&
                             (timeline.currentPosition.toFloat() / timeline.duration.toFloat()) >= WatchProgress.COMPLETED_THRESHOLD
                         viewModel.launchInExternalPlayer(context, timeline.currentPosition) { launched ->
                             externalHandoffInProgress = false
@@ -1212,7 +1215,8 @@ fun PlayerScreen(
             visible = uiState.showSeekOverlay && !uiState.showControls && uiState.error == null &&
                 !uiState.showLoadingOverlay && !uiState.showPauseOverlay &&
                 !uiState.showSubtitleDelayOverlay && !uiState.showSubtitleTimingDialog &&
-                !uiState.showMoreDialog,
+                !uiState.showMoreDialog &&
+                !viewModel.playbackTimeline.collectAsState().value.isLive,
             enter = fadeIn(animationSpec = tween(150)),
             exit = fadeOut(animationSpec = tween(150)),
             modifier = Modifier.align(Alignment.BottomCenter)
@@ -1790,6 +1794,13 @@ private fun PlayerControlsOverlay(
     val customSourcePainter = rememberRawSvgPainter(R.raw.ic_player_source)
     val customAspectPainter = rememberRawSvgPainter(R.raw.ic_player_aspect_ratio)
     val customEpisodesPainter = rememberRawSvgPainter(R.raw.ic_player_episodes)
+    val playbackTimeline by viewModel.playbackTimeline.collectAsState()
+    val isLivePlayback = playbackTimeline.isLive
+    val progressUpTarget = if (isLivePlayback) {
+        progressBarUpFocusRequester ?: playPauseFocusRequester
+    } else {
+        progressBarFocusRequester
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Top gradient
@@ -1910,19 +1921,23 @@ private fun PlayerControlsOverlay(
 
             Spacer(modifier = Modifier.height(NuvioTheme.spacing.md))
 
-            // Progress bar — always LTR regardless of locale
-            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                PlayerControlsProgressBarHost(
-                    viewModel = viewModel,
-                    focusRequester = progressBarFocusRequester,
-                    upFocusRequester = progressBarUpFocusRequester,
-                    downFocusRequester = playPauseFocusRequester,
-                    onUpKey = onHideControls,
-                    onFocused = onResetHideTimer
-                )
-            }
+            if (!isLivePlayback) {
+                // Progress bar — always LTR regardless of locale
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    PlayerControlsProgressBarHost(
+                        viewModel = viewModel,
+                        focusRequester = progressBarFocusRequester,
+                        upFocusRequester = progressBarUpFocusRequester,
+                        downFocusRequester = playPauseFocusRequester,
+                        onUpKey = onHideControls,
+                        onFocused = onResetHideTimer
+                    )
+                }
 
-            Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
+                Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
+            } else {
+                Spacer(modifier = Modifier.height(NuvioTheme.spacing.lg))
+            }
 
             // Control buttons row — always LTR regardless of locale
             CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
@@ -1949,7 +1964,7 @@ private fun PlayerControlsOverlay(
                         contentDescription = if (uiState.isPlaying) stringResource(R.string.cd_pause) else stringResource(R.string.cd_play),
                         onClick = onPlayPause,
                         focusRequester = playPauseFocusRequester,
-                        upFocusRequester = progressBarFocusRequester,
+                        upFocusRequester = progressUpTarget,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer
                     )
@@ -1959,7 +1974,7 @@ private fun PlayerControlsOverlay(
                             icon = Icons.Default.SkipNext,
                             contentDescription = stringResource(R.string.next_episode_label),
                             onClick = onPlayNextEpisode,
-                            upFocusRequester = progressBarFocusRequester,
+                            upFocusRequester = progressUpTarget,
                             onDownKey = onHideControls,
                             onFocused = onResetHideTimer
                         )
@@ -1971,7 +1986,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customSubtitlePainter,
                             contentDescription = stringResource(R.string.cd_subtitles),
                             onClick = onShowSubtitleDialog,
-                            upFocusRequester = progressBarFocusRequester,
+                            upFocusRequester = progressUpTarget,
                             onDownKey = onHideControls,
                             onFocused = onResetHideTimer
                         )
@@ -1983,7 +1998,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customAudioPainter,
                             contentDescription = stringResource(R.string.cd_audio_tracks),
                             onClick = onShowAudioDialog,
-                            upFocusRequester = progressBarFocusRequester,
+                            upFocusRequester = progressUpTarget,
                             onDownKey = onHideControls,
                             onFocused = onResetHideTimer
                         )
@@ -1994,7 +2009,7 @@ private fun PlayerControlsOverlay(
                         iconPainter = customSourcePainter,
                         contentDescription = stringResource(R.string.cd_sources),
                         onClick = onShowSourcesPanel,
-                        upFocusRequester = progressBarFocusRequester,
+                        upFocusRequester = progressUpTarget,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer
                     )
@@ -2003,7 +2018,7 @@ private fun PlayerControlsOverlay(
                         icon = Icons.Default.SwapHoriz,
                         contentDescription = stringResource(R.string.cd_switch_player_engine),
                         onClick = onSwitchPlayerEngine,
-                        upFocusRequester = progressBarFocusRequester,
+                        upFocusRequester = progressUpTarget,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer
                     )
@@ -2014,7 +2029,7 @@ private fun PlayerControlsOverlay(
                             iconPainter = customEpisodesPainter,
                             contentDescription = stringResource(R.string.cd_episodes),
                             onClick = onShowEpisodesPanel,
-                            upFocusRequester = progressBarFocusRequester,
+                            upFocusRequester = progressUpTarget,
                             onDownKey = onHideControls,
                             onFocused = onResetHideTimer
                         )
@@ -2041,7 +2056,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onShowSpeedDialog()
                                 },
-                                upFocusRequester = progressBarFocusRequester,
+                                upFocusRequester = progressUpTarget,
                                 onDownKey = onHideControls,
                                 onFocused = onResetHideTimer
                             )
@@ -2052,7 +2067,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onToggleAspectRatio()
                                 },
-                                upFocusRequester = progressBarFocusRequester,
+                                upFocusRequester = progressUpTarget,
                                 onDownKey = onHideControls,
                                 onFocused = onResetHideTimer
                             )
@@ -2062,7 +2077,7 @@ private fun PlayerControlsOverlay(
                                 onClick = {
                                     onOpenInExternalPlayer()
                                 },
-                                upFocusRequester = progressBarFocusRequester,
+                                upFocusRequester = progressUpTarget,
                                 onDownKey = onHideControls,
                                 onFocused = onResetHideTimer
                             )
@@ -2073,7 +2088,7 @@ private fun PlayerControlsOverlay(
                                     onShowStreamInfo()
                                 },
                                 focusRequester = streamInfoFocusRequester,
-                                upFocusRequester = progressBarFocusRequester,
+                                upFocusRequester = progressUpTarget,
                                 onDownKey = onHideControls,
                                 onFocused = onResetHideTimer
                             )
@@ -2084,7 +2099,7 @@ private fun PlayerControlsOverlay(
                                     onClick = onReportPlaybackIssue,
                                     enabled = uiState.playbackIssueReportStatus != PlaybackIssueReportStatus.Sending &&
                                         uiState.playbackIssueReportStatus != PlaybackIssueReportStatus.Sent,
-                                    upFocusRequester = progressBarFocusRequester,
+                                    upFocusRequester = progressUpTarget,
                                     onDownKey = onHideControls,
                                     onFocused = onResetHideTimer
                                 )
@@ -2100,7 +2115,7 @@ private fun PlayerControlsOverlay(
                         },
                         contentDescription = if (uiState.showMoreDialog) stringResource(R.string.cd_close_more_actions) else stringResource(R.string.cd_more_actions),
                         onClick = onToggleMoreActions,
-                        upFocusRequester = progressBarFocusRequester,
+                        upFocusRequester = progressUpTarget,
                         onDownKey = onHideControls,
                         onFocused = onResetHideTimer
                     )
@@ -2146,9 +2161,14 @@ private fun PlayerControlsProgressBarHost(
 @Composable
 private fun PlayerControlsTimeTextHost(viewModel: PlayerViewModel) {
     val playbackTimeline by viewModel.playbackTimeline.collectAsState()
+    val timeText = if (playbackTimeline.isLive) {
+        stringResource(R.string.player_live_watched, formatTime(playbackTimeline.watchedDurationMs))
+    } else {
+        "${formatTime(playbackTimeline.currentPosition)} / ${formatTime(playbackTimeline.duration)}"
+    }
 
     Text(
-        text = "${formatTime(playbackTimeline.currentPosition)} / ${formatTime(playbackTimeline.duration)}",
+        text = timeText,
         style = MaterialTheme.typography.bodyMedium,
         color = Color.White.copy(alpha = 0.9f)
     )
@@ -2477,7 +2497,8 @@ private fun SeekOverlayHost(viewModel: PlayerViewModel) {
 private fun PlayerClockOverlay(
     currentPosition: Long,
     duration: Long,
-    playbackSpeed: Float
+    playbackSpeed: Float,
+    isLive: Boolean = false
 ) {
     var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
     val context = LocalContext.current
@@ -2514,11 +2535,13 @@ private fun PlayerClockOverlay(
             ),
             color = Color.White.copy(alpha = 0.96f)
         )
-        Text(
-            text = stringResource(R.string.player_ends_at, endTimeText),
-            style = MaterialTheme.typography.bodyMedium.copy(fontSize = 10.sp),
-            color = Color.White.copy(alpha = 0.78f)
-        )
+        if (!isLive) {
+            Text(
+                text = stringResource(R.string.player_ends_at, endTimeText),
+                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 10.sp),
+                color = Color.White.copy(alpha = 0.78f)
+            )
+        }
     }
 }
 
@@ -2529,7 +2552,8 @@ private fun PlayerClockOverlayHost(viewModel: PlayerViewModel, playbackSpeed: Fl
     PlayerClockOverlay(
         currentPosition = playbackTimeline.currentPosition,
         duration = playbackTimeline.duration,
-        playbackSpeed = playbackSpeed
+        playbackSpeed = playbackSpeed,
+        isLive = playbackTimeline.isLive
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -226,7 +226,11 @@ data class PlaybackTimelineState(
     val currentPosition: Long = 0L,
     val duration: Long = 0L,
     /** Position (ms) up to which the player has buffered ahead of the playhead. */
-    val bufferedPosition: Long = 0L
+    val bufferedPosition: Long = 0L,
+    /** True for live windows (Live TV / live HLS), not VOD HLS. */
+    val isLive: Boolean = false,
+    /** Wall-clock time spent playing the current live stream. */
+    val watchedDurationMs: Long = 0L
 )
 
 data class TrackInfo(

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1625,6 +1625,7 @@
     <string name="parental_severity_moderate">Orta</string>
     <string name="parental_severity_mild">Hafif</string>
     <string name="player_ends_at">Bitiş saati: %1$s</string>
+    <string name="player_live_watched">CANLI  %1$s</string>
     <string name="player_via">Sağlayıcı: %1$s</string>
     <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
     <string name="season_episode_format">S%1$d B%2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1615,6 +1615,7 @@
     <string name="parental_severity_moderate">Moderate</string>
     <string name="parental_severity_mild">Mild</string>
     <string name="player_ends_at">Ends at %1$s</string>
+    <string name="player_live_watched">LIVE  %1$s</string>
     <string name="player_via">via %1$s</string>
     <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
     <string name="season_episode_format">S%1$d E%2$d</string>

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/LivePlaybackUiPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/LivePlaybackUiPolicyTest.kt
@@ -1,0 +1,107 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LivePlaybackUiPolicyTest {
+
+    @Test
+    fun `vod hls is not live without player flag or channel type`() {
+        assertFalse(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = false,
+                contentType = "movie"
+            )
+        )
+        assertFalse(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = false,
+                contentType = "series"
+            )
+        )
+        assertFalse(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = false,
+                contentType = "tv"
+            )
+        )
+    }
+
+    @Test
+    fun `channel catalog type is live even before player reports`() {
+        assertTrue(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = false,
+                contentType = "channel"
+            )
+        )
+    }
+
+    @Test
+    fun `player live window flag marks live hls regardless of movie type`() {
+        assertTrue(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = true,
+                contentType = "movie"
+            )
+        )
+    }
+
+    @Test
+    fun `live latch sticks after the player reported live once`() {
+        val latched = LivePlaybackUiPolicy.nextLiveLatch(
+            playerReportsLive = true,
+            previouslyLatched = false
+        )
+        assertTrue(latched)
+        assertTrue(
+            LivePlaybackUiPolicy.isLivePlayback(
+                playerReportsLive = false,
+                contentType = "movie",
+                latchedLive = latched
+            )
+        )
+    }
+
+    @Test
+    fun `watch clock accumulates only while playing live`() {
+        val clock = LivePlaybackWatchClock()
+        assertEquals(
+            0L,
+            clock.watchedDurationMs(isLive = true, isPlaying = true, nowElapsedMs = 1_000L)
+        )
+        assertEquals(
+            6_000L,
+            clock.watchedDurationMs(isLive = true, isPlaying = true, nowElapsedMs = 7_000L)
+        )
+        assertEquals(
+            6_000L,
+            clock.watchedDurationMs(isLive = true, isPlaying = false, nowElapsedMs = 7_000L)
+        )
+        assertEquals(
+            6_000L,
+            clock.watchedDurationMs(isLive = true, isPlaying = false, nowElapsedMs = 20_000L)
+        )
+        assertEquals(
+            6_000L,
+            clock.watchedDurationMs(isLive = true, isPlaying = true, nowElapsedMs = 22_000L)
+        )
+        assertEquals(
+            8_000L,
+            clock.watchedDurationMs(isLive = true, isPlaying = true, nowElapsedMs = 24_000L)
+        )
+    }
+
+    @Test
+    fun `watch clock resets when leaving live`() {
+        val clock = LivePlaybackWatchClock()
+        clock.watchedDurationMs(isLive = true, isPlaying = true, nowElapsedMs = 0L)
+        clock.watchedDurationMs(isLive = true, isPlaying = false, nowElapsedMs = 4_000L)
+        assertEquals(
+            0L,
+            clock.watchedDurationMs(isLive = false, isPlaying = true, nowElapsedMs = 10_000L)
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackAnalyticsDiagnosticsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerPlaybackAnalyticsDiagnosticsTest.kt
@@ -1,0 +1,43 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.C
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PlayerPlaybackAnalyticsDiagnosticsTest {
+
+    @Test
+    fun `vod buffer below duration reports integer percent`() {
+        assertEquals(0, safeBufferedPercentage(bufferedPositionMs = 0L, durationMs = 10_000L))
+        assertEquals(25, safeBufferedPercentage(bufferedPositionMs = 2_500L, durationMs = 10_000L))
+        assertEquals(99, safeBufferedPercentage(bufferedPositionMs = 9_999L, durationMs = 10_000L))
+    }
+
+    @Test
+    fun `fully buffered or empty duration reports 100`() {
+        assertEquals(100, safeBufferedPercentage(bufferedPositionMs = 10_000L, durationMs = 10_000L))
+        assertEquals(100, safeBufferedPercentage(bufferedPositionMs = 12_000L, durationMs = 10_000L))
+        assertEquals(100, safeBufferedPercentage(bufferedPositionMs = 0L, durationMs = 0L))
+    }
+
+    @Test
+    fun `unset or negative times are omitted`() {
+        assertNull(safeBufferedPercentage(bufferedPositionMs = 1_000L, durationMs = C.TIME_UNSET))
+        assertNull(safeBufferedPercentage(bufferedPositionMs = C.TIME_UNSET, durationMs = 10_000L))
+        assertNull(safeBufferedPercentage(bufferedPositionMs = -1L, durationMs = 10_000L))
+        assertNull(safeBufferedPercentage(bufferedPositionMs = 1_000L, durationMs = -5L))
+    }
+
+    @Test
+    fun `live iptv timestamps that overflow Media3 percentInt clamp to 100`() {
+        assertEquals(
+            100,
+            safeBufferedPercentage(bufferedPositionMs = 1_535_769_691_039L, durationMs = 10L)
+        )
+        assertEquals(
+            100,
+            safeBufferedPercentage(bufferedPositionMs = 1_243_001_841_137L, durationMs = 25L)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Stops a fatal Media3 1.8 crash during live IPTV playback, and stops treating a live HLS/DASH sliding window as a VOD movie length.

1. Playback analytics no longer reads `Player.bufferedPercentage` (throws when buffered position ≫ duration). The snapshot computes a clamped 0–100 percentage itself.
2. Live playback is detected from ExoPlayer `isCurrentMediaItemLive`, mpv `seekable == false`, plus catalog type `channel`. The player then shows elapsed watch time only: no seek bar, no “ends at”, no pause-overlay clock, no live seeks / post-play.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Production crash NUVIO-TV-67: uncaught `IllegalArgumentException: Out of range: 15357696910390` on `full` release `0.8.5-beta` (1046). `PlayerPlaybackAnalyticsDiagnostics.recordProgressSnapshot` calls `player.bufferedPercentage` every 500ms. Media3 1.8 `BasePlayer.getBufferedPercentage` uses `Util.percentInt` / `Ints.checkedCast`, which crashes when live/IPTV timelines report a buffered position much larger than duration.

Separately, live HLS `.m3u8` duration is the sliding window, not a title runtime. The player was showing that window as `current / duration`, an end time, a seekable bar, and a pause clock — all wrong for live TV. URL-only HLS detection is not enough (VOD HLS looks the same); `tv` in this app means series, not live. Live catalog type is `channel`.

## Issue or approval

Fixes NUVIO-TV-67

## Reproduction steps

Crash:

1. Play a live IPTV stream (DASH/HLS) where ExoPlayer reports a buffered position much larger than duration.
2. Leave playback running so analytics snapshots progress (about every 500ms).
3. Without this fix: fatal `IllegalArgumentException: Out of range: …` from `Player.bufferedPercentage`.
4. With this fix: playback continues; buffered percentage is omitted when duration is unset, otherwise clamped to 0–100.

Live timeline UI:

1. Play a `channel` live stream (HLS or DASH).
2. Open player controls / pause overlay.
3. Without this fix: time reads like VOD (`12:04 / 12:30` or similar window length), seek bar is enabled, “ends at” and pause clock appear.
4. With this fix: label is elapsed watch time only (`LIVE  mm:ss`); seek bar, “ends at”, pause clock, live seeks, and post-play are off. Starting a VOD title still shows the normal duration/seek UI.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Does not upgrade Media3 or change ExoPlayer buffering internals. Does not add a live-TV product, EPG, or DVR. Does not change VOD/series (`movie` / `tv`) timeline UI.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.ui.screens.player.PlayerPlaybackAnalyticsDiagnosticsTest` — passed (normal VOD percents, unset/negative times omitted, live IPTV overflow values clamp to 100).
- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.ui.screens.player.LivePlaybackUiPolicyTest` — passed (latch, `channel` type, VOD not treated as live).
- Manual: live `channel` shows watch clock / no seek; VOD still shows position/duration and seek.

## Screenshots / Video

Live player: elapsed watch time only; seek bar and “ends at” hidden. Pause overlay has no clock.
<img width="2560" height="1342" alt="e3d12774-9a85-42b8-a9a3-4b04a7680d92" src="https://github.com/user-attachments/assets/cc78eb0e-ef2b-4f40-8acf-cb127337bec8" />

## Breaking changes


None

## Linked issues

Fixes NUVIO-TV-67
