### PR TITLE
Fix Library focus returning to the wrong mode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -362,6 +362,7 @@ fun LibraryScreen(
                     selectedYear = uiState.selectedYear,
                     selectedWatchedFilter = uiState.selectedWatchedFilter,
                     primaryFocusRequester = selectorFocusRequester,
+                    upFocusRequester = primaryFocusRequester,
                     expandedPicker = expandedPicker,
                     onExpandedChange = { picker, shouldExpand ->
                         expandedPicker = if (shouldExpand) picker else null
@@ -465,6 +466,7 @@ fun LibraryScreen(
                     typeOptions = uiState.availableCloudTypes,
                     selectedProviderId = uiState.selectedCloudProviderId,
                     selectedType = uiState.selectedCloudType,
+                    upFocusRequester = primaryFocusRequester,
                     expandedPicker = expandedPicker,
                     onExpandedChange = { picker, shouldExpand ->
                         expandedPicker = if (shouldExpand) picker else null
@@ -663,12 +665,12 @@ private fun LibraryViewModeRow(
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)) {
-            LibraryViewMode.entries.forEachIndexed { index, mode ->
+            LibraryViewMode.entries.forEach { mode ->
                 val selected = mode == selectedMode
                 Button(
                     onClick = { onSelected(mode) },
                     modifier = Modifier
-                        .then(if (index == 0) Modifier.focusRequester(primaryFocusRequester) else Modifier),
+                        .then(if (selected) Modifier.focusRequester(primaryFocusRequester) else Modifier),
                     colors = ButtonDefaults.colors(
                         containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
                         contentColor = NuvioTheme.colors.TextPrimary
@@ -694,6 +696,7 @@ private fun CloudLibrarySelectorsRow(
     typeOptions: List<FilterOption>,
     selectedProviderId: String?,
     selectedType: CloudLibraryItemType?,
+    upFocusRequester: FocusRequester,
     expandedPicker: String?,
     onExpandedChange: (String, Boolean) -> Unit,
     onSelectProvider: (String?) -> Unit,
@@ -710,6 +713,7 @@ private fun CloudLibrarySelectorsRow(
     ) {
         LibraryDropdownPicker(
             modifier = Modifier.weight(1f),
+            upFocusRequester = upFocusRequester,
             title = stringResource(R.string.cloud_library_select_provider),
             value = selectedProviderLabel,
             selectedValue = selectedProviderId ?: "__all__",
@@ -725,6 +729,7 @@ private fun CloudLibrarySelectorsRow(
 
         LibraryDropdownPicker(
             modifier = Modifier.weight(1f),
+            upFocusRequester = upFocusRequester,
             title = stringResource(R.string.cloud_library_select_type),
             value = selectedTypeLabel,
             selectedValue = selectedType?.name ?: "__all__",
@@ -1079,6 +1084,7 @@ private fun LibrarySelectorsRow(
     selectedYear: String?,
     selectedWatchedFilter: LibraryWatchedFilter,
     primaryFocusRequester: FocusRequester,
+    upFocusRequester: FocusRequester,
     expandedPicker: String?,
     onExpandedChange: (String, Boolean) -> Unit,
     onSelectList: (String) -> Unit,
@@ -1111,6 +1117,7 @@ private fun LibrarySelectorsRow(
                     modifier = Modifier
                         .weight(1f)
                         .focusRequester(primaryFocusRequester),
+                    upFocusRequester = upFocusRequester,
                     title = stringResource(R.string.library_filter_list),
                     value = selectedListLabel,
                     selectedValue = selectedListKey,
@@ -1129,6 +1136,7 @@ private fun LibrarySelectorsRow(
                         .weight(1f)
                         .focusRequester(primaryFocusRequester)
                 },
+                upFocusRequester = upFocusRequester,
                 title = stringResource(R.string.library_filter_type),
                 value = selectedTypeLabel,
                 selectedValue = selectedTypeTab?.key,
@@ -1150,6 +1158,7 @@ private fun LibrarySelectorsRow(
             if (sortOptions.isNotEmpty()) {
                 LibraryDropdownPicker(
                     modifier = Modifier.weight(1f),
+                    upFocusRequester = upFocusRequester,
                     title = stringResource(R.string.library_filter_sort),
                     value = selectedSortLabel,
                     selectedValue = selectedSortOption.key,
@@ -1227,6 +1236,7 @@ private fun LibrarySelectorsRow(
 @Composable
 private fun LibraryDropdownPicker(
     modifier: Modifier = Modifier,
+    upFocusRequester: FocusRequester? = null,
     title: String,
     value: String,
     selectedValue: String?,
@@ -1271,6 +1281,13 @@ private fun LibraryDropdownPicker(
             onClick = { onExpandedChange(!expanded) },
             modifier = Modifier
                 .fillMaxWidth()
+                .then(
+                    if (upFocusRequester != null) {
+                        Modifier.focusProperties { up = upFocusRequester }
+                    } else {
+                        Modifier
+                    }
+                )
                 .onSizeChanged { anchorSize = it }
                 .onFocusChanged { isFocused = it.isFocused },
             shape = CardDefaults.shape(shape = RoundedCornerShape(14.dp)),


### PR DESCRIPTION
## Summary

Attach Library's existing stable `FocusRequester` to the selected mode and route every first-row filter's Up direction through it.

This prevents Saved filters from focusing Cloud while Saved remains active, and preserves the correct Cloud return path.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Library previously attached its stable requester only to the first mode button. Moving Up from a filter therefore relied on spatial focus search, which could focus Cloud even though Saved remained selected. Pressing Select at that point unintentionally switched modes.

The fix moves the same requester to whichever mode is selected, restoring deterministic remote navigation without changing layout, styling, or mode-selection behavior.

## Issue or approval

Fixes #3204

## Reproduction steps

1. Open Library with Saved selected and focused.
2. Press Down to focus Type.
3. Press Up.
4. Before this fix, focus moves to Cloud while Saved content remains active.
5. After this fix, focus returns to Saved.
6. Repeat with Cloud and either Select provider or Select type; focus returns to Cloud.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- No layout, styling, strings, settings, persistence, or mode-selection changes.
- Only the Saved and Cloud mode focus targets and first filter-row Up destinations change.
- The existing initial Saved focus path remains unchanged.
- No unrelated Android test infrastructure fixes are included.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — passed.
- `./gradlew :app:assembleFullDebug` — passed with the same temporary signing configuration used by PR CI, including lint vital and APK packaging.
- Direct installed-app D-pad validation on `AndroidTV_API36_QA` (`sdk_google_atv64_x86_64`, Android 16 / API 36):
  - Saved -> Type -> Up passed 3/3 consecutive cycles.
  - Cloud -> Select provider -> Up passed 3/3 consecutive cycles.
  - Saved Sort and Cloud Select type also returned to their selected modes.
  - No app fatal exception, ANR, or `VerifyError` was observed.
- The full unit task reached 989 tests but the current `dev` suite reported 13 unrelated failures and 1 skipped test; no failure involved Library focus code.

## Screenshots / Video

Not applicable: this changes directional focus routing only; it does not change layout, styling, or rendered content. The affected remote-navigation paths are covered by the repeated installed-app D-pad validation above.

## Breaking changes

None.

## Linked issues

Fixes #3204
