### PR TITLE
Fix Addons input field focus after dismissing the keyboard

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/addon/AddonManagerScreen.kt
@@ -4,6 +4,8 @@ import com.nuvio.tv.ui.theme.NuvioTheme
 
 import android.graphics.Bitmap
 import androidx.activity.compose.BackHandler
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
@@ -72,6 +74,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -192,6 +195,34 @@ fun AddonManagerScreen(
         if (isEditing) {
             textFieldFocusRequester.requestFocus()
             keyboardController?.show()
+        }
+    }
+
+    val rootView = LocalView.current
+    var isImeVisible by remember { mutableStateOf(false) }
+    DisposableEffect(rootView) {
+        val listener = android.view.ViewTreeObserver.OnGlobalLayoutListener {
+            isImeVisible = ViewCompat.getRootWindowInsets(rootView)
+                ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+        }
+        rootView.viewTreeObserver.addOnGlobalLayoutListener(listener)
+        listener.onGlobalLayout()
+        onDispose {
+            rootView.viewTreeObserver.removeOnGlobalLayoutListener(listener)
+        }
+    }
+    var hasShownKeyboardThisEdit by remember { mutableStateOf(false) }
+    LaunchedEffect(isEditing, isImeVisible) {
+        if (isEditing) {
+            if (isImeVisible) {
+                hasShownKeyboardThisEdit = true
+            } else if (hasShownKeyboardThisEdit) {
+                hasShownKeyboardThisEdit = false
+                isEditing = false
+                installButtonFocusRequester.requestFocus()
+            }
+        } else {
+            hasShownKeyboardThisEdit = false
         }
     }
 


### PR DESCRIPTION
Fix Addon Input Field

## Summary

Fix an issue in Settings → Content & Discovery → Addons where pressing Down after dismissing the on-screen keyboard moves focus back to the input field instead of the next available element.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

After the keyboard is dismissed, focus should continue following the normal navigation order. When focus returns to the input field, users can get stuck and are unable to navigate to the elements below it as expected. This fix ensures pressing Down correctly moves focus to the next available element.

## Issue or approval

Fixes #3050 

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
