### PR TITLE
Feat(audio): Fix original language fallback in audio track selection

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1881,10 +1881,20 @@ internal fun resolvePreferredAudioLanguages(
                 ).distinct()
             }
         }
-        else -> listOfNotNull(
-            normalize(preferredAudioLanguage),
-            normalize(secondaryPreferredAudioLanguage)
-        ).distinct()
+        else -> {
+            // Specific language is set. Build fallback chain:
+            // 1. Preferred language
+            // 2. Secondary language (if set)
+            // 3. Device/system languages
+            // 4. Original language of the content (if known)
+            // 5. First available track
+            (
+                listOfNotNull(normalize(preferredAudioLanguage))
+                + listOfNotNull(normalize(secondaryPreferredAudioLanguage))
+                + deviceLanguages.mapNotNull(::normalize)
+                + listOfNotNull(normalize(contentOriginalLanguage))
+            ).distinct()
+        }
     }
 }
 


### PR DESCRIPTION
Audio fallback chain.

## Summary

Fix the audio language fallback order during playback so that the original language of the content is correctly considered before falling back to the first available audio track.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

The current fallback chain can result in playback starting with an incorrect language. For example, a series with German as its original language may start with Russian audio instead.

The intended fallback order is:

Preferred language
Secondary language, if set
Device/system languages
Original language of the content, if known
First available audio track

This is intended as a small/simple fix to ensure the original content language is properly respected in the fallback chain. **The change has not been fully verified yet and still needs playback testing across different language configurations.**

## Issue or approval

Fixes #2962 

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

#2962 