### PR TITLE
Fix color banding on images and overlay gradient

### DIFF
--- a/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
+++ b/app/src/main/java/com/nuvio/tv/NuvioApplication.kt
@@ -161,7 +161,7 @@ class NuvioApplication : Application(), SingletonImageLoader.Factory {
             .crossfade(false)
             .precision(coil3.size.Precision.INEXACT)
             .allowHardware(false)
-            .allowRgb565(true)
+            .allowRgb565(false)
             .bitmapFactoryMaxParallelism(4)
             .build()
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeOptionsOverlay.kt
@@ -272,11 +272,17 @@ internal fun EpisodeOptionsOverlay(
                     .drawWithCache {
                         val brush = Brush.horizontalGradient(
                             colorStops = arrayOf(
-                                0.00f to overlayColor.copy(alpha = 0.95f),
-                                0.28f to overlayColor.copy(alpha = 0.90f),
-                                0.48f to overlayColor.copy(alpha = 0.72f),
-                                0.70f to overlayColor.copy(alpha = 0.50f),
-                                1.00f to overlayColor.copy(alpha = 0.40f)
+                                0.00f to overlayColor,
+                                0.10f to overlayColor.copy(alpha = 0.97f),
+                                0.20f to overlayColor.copy(alpha = 0.93f),
+                                0.30f to overlayColor.copy(alpha = 0.87f),
+                                0.40f to overlayColor.copy(alpha = 0.78f),
+                                0.50f to overlayColor.copy(alpha = 0.67f),
+                                0.60f to overlayColor.copy(alpha = 0.55f),
+                                0.70f to overlayColor.copy(alpha = 0.45f),
+                                0.80f to overlayColor.copy(alpha = 0.38f),
+                                0.90f to overlayColor.copy(alpha = 0.34f),
+                                1.00f to overlayColor.copy(alpha = 0.30f)
                             ),
                             startX = if (isRtl) size.width else 0f,
                             endX = if (isRtl) 0f else size.width


### PR DESCRIPTION
## Summary

Two fixes for visible banding/color stepping on Android TV:

- Disable `allowRgb565` in Coil image loader -> forces ARGB_8888 decoding for backdrops and posters, eliminating visible color banding on images with subtle gradients (e.g. sky, dark scenes).
- Increase gradient color stops in EpisodeOptionsOverlay from 5 to 11 -> smoother alpha transitions reduce visible stepping in the overlay gradient on bright backdrops.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Two separate banding issues on Android TV:
1. Coil decoded images in RGB565 (16-bit) which caused visible color banding on backdrops and posters - especially noticeable on images with subtle color transitions (skies, dark gradients). The memory savings are marginal on modern TV hardware.
2. The EpisodeOptionsOverlay had only 5 color stops spanning the full screen width -> on episodes with bright/light backdrops, the alpha jumps between stops were large enough to produce visible bands.

## Issue or approval

No linked issue - visual defects identified during QA testing on physical Android TV hardware.

## Reproduction steps

RGB565:
1. Browse home screen or series detail
2. Observe backdrops/posters with subtle color transitions (sky, dark scenes)
3. Before fix: visible color banding in the images themselves

Overlay gradient:
1. Open any series detail screen
2. Long-press an episode with a bright/light thumbnail
3. Observe the horizontal gradient overlay
4. Before fix: clearly visible color bands/steps in the gradient
5. After fix: noticeably smoother

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Gradient coverage/opacity range intentionally kept the same (full width, similar start/end alpha).
- No other overlays or gradients were modified.
- No behavior or navigation changes.

## Testing

- Tested on physical Android TV device
- RGB565 fix: browsed home/detail screens, confirmed backdrops and posters no longer show color banding on subtle transitions
- Overlay gradient: opened EpisodeOptionsOverlay on multiple episodes with varying backdrop brightness
- On bright/light backdrops banding was very visible before the fix
- Adding more color stops does not fully eliminate banding (8-bit framebuffer limitation) but noticeably improves the situation
- Verified overlay readability, dismiss behavior, and focus navigation unchanged

## Screenshots / Video
Before
<img width="300" alt="screenshot3" src="https://github.com/user-attachments/assets/78fb0b79-2006-457f-86fa-546554605865" />

After
<img width="300" alt="screenshot4" src="https://github.com/user-attachments/assets/b5eca525-5167-4c17-bec9-784a204e6b2b" />


## Breaking changes

None.

## Linked issues

No linked issue - visual defects found during manual QA.
