### PR TITLE
Reuse CJK name fallback for TMDB network browse titles.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -979,11 +979,11 @@ class TmdbMetadataService(
         val today = LocalDate.now().toString()
         val voteCountFloor = if (railType == TmdbEntityRailType.TOP_RATED) TOP_RATED_VOTE_COUNT_FLOOR else null
         val result = try {
-            val response = when (mediaType) {
+            suspend fun loadDiscover(requestLanguage: String) = when (mediaType) {
                 TmdbEntityMediaType.MOVIE -> {
                     tmdbApi.discoverMovies(
                         apiKey = TMDB_API_KEY,
-                        language = language,
+                        language = requestLanguage,
                         page = page,
                         sortBy = movieSortBy(railType),
                         withCompanies = entityId.toString(),
@@ -995,7 +995,7 @@ class TmdbMetadataService(
                 TmdbEntityMediaType.TV -> {
                     tmdbApi.discoverTv(
                         apiKey = TMDB_API_KEY,
-                        language = language,
+                        language = requestLanguage,
                         page = page,
                         sortBy = tvSortBy(railType),
                         withCompanies = if (entityKind == TmdbEntityKind.COMPANY) entityId.toString() else null,
@@ -1007,15 +1007,31 @@ class TmdbMetadataService(
                 }
             }
 
+            val response = loadDiscover(language)
             val results = response?.results.orEmpty()
             val totalPages = response?.totalPages ?: page
+
+            val isCjkLanguage = language.startsWith("ja") ||
+                language.startsWith("ko") ||
+                language.startsWith("zh")
+            val englishTitlesById = if (
+                language != "en" &&
+                !isCjkLanguage &&
+                discoverResultsContainCjkTitles(results)
+            ) {
+                englishDiscoverTitlesById(loadDiscover("en")?.results.orEmpty())
+            } else {
+                emptyMap()
+            }
 
             val mappedItems = results
                 .filter { it.id > 0 }
                 .mapNotNull { discoverItem ->
                     mapEntityDiscoverResult(
                         result = discoverItem,
-                        mediaType = mediaType
+                        mediaType = mediaType,
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById
                     )
                 }
                 .take(ENTITY_RAIL_MAX_ITEMS)
@@ -1040,13 +1056,16 @@ class TmdbMetadataService(
 
     private fun mapEntityDiscoverResult(
         result: TmdbDiscoverResult,
-        mediaType: TmdbEntityMediaType
+        mediaType: TmdbEntityMediaType,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>
     ): MetaPreview? {
-        val title = result.title?.takeIf { it.isNotBlank() }
-            ?: result.name?.takeIf { it.isNotBlank() }
-            ?: result.originalTitle?.takeIf { it.isNotBlank() }
-            ?: result.originalName?.takeIf { it.isNotBlank() }
-            ?: return null
+        val title = resolvePersonName(
+            localizedName = result.title ?: result.name,
+            originalName = result.originalTitle ?: result.originalName,
+            fallbackEnglishName = englishTitlesById[result.id],
+            preferredLanguage = preferredLanguage
+        ) ?: return null
 
         val poster = buildImageUrl(result.posterPath, size = "w500")
             ?: buildImageUrl(result.backdropPath, size = "w780")
@@ -1661,6 +1680,25 @@ private fun TmdbEpisode.toEnrichment(): TmdbEpisodeEnrichment {
         airDate = airDate,
         runtimeMinutes = runtime
     )
+}
+
+private fun discoverResultsContainCjkTitles(results: List<TmdbDiscoverResult>): Boolean {
+    return results.any { result ->
+        containsCjkOrHangul(result.title ?: result.name ?: return@any false)
+    }
+}
+
+private fun englishDiscoverTitlesById(results: List<TmdbDiscoverResult>): Map<Int, String> {
+    val titles = LinkedHashMap<Int, String>()
+    results.forEach { result ->
+        val text = result.title?.trim()?.takeIf { it.isNotBlank() }
+            ?: result.name?.trim()?.takeIf { it.isNotBlank() }
+            ?: return@forEach
+        if (!containsCjkOrHangul(text)) {
+            titles.putIfAbsent(result.id, text)
+        }
+    }
+    return titles
 }
 
 private fun personCreditsContainCjkTitles(credits: TmdbPersonCreditsResponse?): Boolean {

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -397,6 +397,60 @@ class TmdbMetadataServiceTest {
     }
 
     @Test
+    fun `network browse falls back CJK titles to English`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery {
+            api.discoverTv(any(), "tr-TR", any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns Response.success(
+            TmdbDiscoverResponse(
+                results = listOf(
+                    TmdbDiscoverResult(
+                        id = 57775,
+                        name = "ちびまる子ちゃん",
+                        originalName = "ちびまる子ちゃん",
+                        posterPath = "/maruko.jpg",
+                        firstAirDate = "1990-01-07"
+                    ),
+                    TmdbDiscoverResult(
+                        id = 37854,
+                        name = "One Piece",
+                        originalName = "ワンピース",
+                        posterPath = "/op.jpg",
+                        firstAirDate = "1999-10-20"
+                    )
+                )
+            )
+        )
+        coEvery {
+            api.discoverTv(any(), "en", any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns Response.success(
+            TmdbDiscoverResponse(
+                results = listOf(
+                    TmdbDiscoverResult(
+                        id = 57775,
+                        name = "Chibi Maruko-chan",
+                        originalName = "ちびまる子ちゃん",
+                        posterPath = "/maruko.jpg"
+                    )
+                )
+            )
+        )
+
+        val service = TmdbMetadataService(api)
+        val page = service.fetchEntityRailPage(
+            entityKind = TmdbEntityKind.NETWORK,
+            entityId = 1,
+            mediaType = TmdbEntityMediaType.TV,
+            railType = TmdbEntityRailType.POPULAR,
+            language = "tr-TR",
+            page = 1
+        )
+
+        assertEquals("Chibi Maruko-chan", page.items.single { it.id == "tmdb:57775" }.name)
+        assertEquals("One Piece", page.items.single { it.id == "tmdb:37854" }.name)
+    }
+
+    @Test
     fun `containsCjkOrHangul detects Asian scripts correctly`() {
         assertTrue(containsCjkOrHangul("木村拓哉"))
         assertTrue(containsCjkOrHangul("田中 敦子"))


### PR DESCRIPTION
## Summary

Apply the existing TMDB CJK display-name fallback to network browse rail titles.

Person filmography already resolves CJK script to a Latin English fallback when the app language is not Japanese, Korean, or Chinese (`#3192`). Network browse did not: `discover/tv` in the user language often returns original-script `name`/`title` when no translation exists, so poster labels on the network screen stayed in Japanese/Korean/Chinese. This PR reuses `resolvePersonName` for entity discover mapping and loads the same discover page in English only when CJK titles are present.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

On the TMDB network browse screen (tap a network on the detail page), poster labels used TMDB original-script titles whenever the selected metadata language had no translation. That is the same localization gap already fixed for person filmography in `#3192`. English TMDB titles (official international names) should be used in that case, not a language-specific extra rule.

## Issue or approval

No linked issue: localization-only update. Continuation of `#3192` (`Reuse CJK name fallback for TMDB filmography titles.`): same CJK fallback, now on network browse rails.

## Reproduction steps

No reproduction steps - localization-only update.

Manual check used while developing:

1. Set TMDB / app metadata language to a non-CJK locale (for example Turkish).
2. Open a Japanese series (for example THE GHOST IN THE SHELL), then open a network from the Network row (for example Fuji TV).
3. Before: rail poster labels are CJK when no Turkish translation exists (for example `ちびまる子ちゃん`, `頭文字D`, `らんま1/2`, `サザエさん`, `ちいかわ`). Latin titles such as `Dragon Ball Z` and `One Piece` stay unchanged.
4. After: the same CJK items use TMDB English titles (for example `Chibi Maruko-chan`, `Initial D`, `Ranma ½`, `Sazae-san`, `Chiikawa`). `ja` / `ko` / `zh` locales still keep original-script titles.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to `TmdbMetadataService.fetchEntityRailPage` / `mapEntityDiscoverResult` title mapping and its unit test. Company browse shares that mapper, so it gets the same title fallback. Does not change network/company logos, header names, strings.xml, person filmography (already covered by `#3192`), detail-page enrichment titles, or add romaji transliteration. Does not include `app/src/main/cpp/libde265/`.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest` — passed, including `network browse falls back CJK titles to English`.
- Existing `network browse only requests tv rails and scopes by network id` still passes.
- Existing `fetchPersonDetail falls back CJK filmography titles to English` still passes.
- TMDB check: Fuji TV discover `tr-TR` returns CJK names (`ちびまる子ちゃん`); `en-US` returns Latin (`Chibi Maruko-chan`).

## Screenshots / Video



| Before | After |
|:------:|:-----:|
|<img width="3840" height="2160" alt="Screenshot_20260826_161228" src="https://github.com/user-attachments/assets/9f34d451-fc93-479d-879f-44a16aa87632" />|<img width="3840" height="2160" alt="Screenshot_20260826_161805" src="https://github.com/user-attachments/assets/62c89fec-1cdd-43b4-980a-b5c0ad58f75b" />|



## Breaking changes

None

## Linked issues

Continuation of `#3192`. That PR applied the CJK English fallback to person filmography titles; this PR applies the same fallback to TMDB network browse rails. No separate issue: localization-only update.
