### PR TITLE
Fix post-play overlay focus and trailer video when paging

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.ui.theme.NuvioTheme
 import android.util.Log
 import android.view.KeyEvent
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.RawRes
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -1583,12 +1584,15 @@ private fun MpvPlayerSurface(
     val context = LocalContext.current
     val latestAspectMode by rememberUpdatedState(aspectMode)
     val mpvView = remember(context) {
-        NuvioMpvSurfaceView(context)
+        NuvioMpvSurfaceView(context).apply {
+            isFocusable = false
+            isFocusableInTouchMode = false
+        }
     }
 
     AndroidView(
         factory = { mpvView },
-        modifier = modifier
+        modifier = modifier.focusProperties { canFocus = false }
     )
 
     DisposableEffect(viewModel, mpvView) {
@@ -1644,6 +1648,9 @@ private fun ExoPlayerSurface(
     val playerView = remember(context, player) {
         PlayerView(context).apply {
             useController = false
+            isFocusable = false
+            isFocusableInTouchMode = false
+            descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
             keepScreenOn = false
             resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
             setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
@@ -1654,7 +1661,7 @@ private fun ExoPlayerSurface(
 
     AndroidView(
         factory = { playerView },
-        modifier = modifier,
+        modifier = modifier.focusProperties { canFocus = false },
         update = {
             it.syncLibassOverlay(
                 player = player,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationOverlay.kt
@@ -97,6 +97,7 @@ import com.nuvio.tv.ui.util.formatHeroRuntime
 import com.nuvio.tv.ui.util.localizedGenreLabel
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import java.util.Locale
+import kotlinx.coroutines.delay
 
 @Composable
 fun PostPlayRecommendationOverlay(
@@ -167,7 +168,7 @@ fun PostPlayRecommendationOverlay(
         showPlayOptionsDialog
     ) {
         if (!state.isVisible || showPlayOptionsDialog) return@LaunchedEffect
-        repeat(2) { withFrameNanos { } }
+        delay(POST_PLAY_RECOMMENDATION_TRANSITION_MS.toLong())
         runCatching { playFocusRequester.requestFocus() }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationOverlay.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -235,14 +236,16 @@ fun PostPlayRecommendationOverlay(
                 )
             }
 
-            TrailerPlayer(
-                trailerUrl = recommendation.trailerVideoUrl,
-                trailerAudioUrl = recommendation.trailerAudioUrl,
-                isPlaying = state.isTrailerPlaying,
-                onEnded = onTrailerEnded,
-                cropToFill = true,
-                modifier = Modifier.fillMaxSize()
-            )
+            key(recommendation.trailerVideoUrl ?: recommendation.id) {
+                TrailerPlayer(
+                    trailerUrl = recommendation.trailerVideoUrl,
+                    trailerAudioUrl = recommendation.trailerAudioUrl,
+                    isPlaying = state.isTrailerPlaying,
+                    onEnded = onTrailerEnded,
+                    cropToFill = true,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
 
             Box(
                 modifier = Modifier


### PR DESCRIPTION
## Summary

Fix two post-play bugs on `#3218`: D-pad focus stays dead until the current title finishes, and paging to the next recommendation plays trailer audio with no video.

Player surfaces no longer steal TV focus while the overlay is visible, and overlay focus is requested after the mini-player shrink animation. Trailer `PlayerView` remounts per recommendation URL the same way homepage hero/row trailers do (`key(trailerUrl)`), so the shared pool ExoPlayer keeps a live TextureView for each item.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Post-play overlay can appear before playback ends. While the movie or episode is still running, Exo `PlayerView` / MPV keep native focus, so Play / Trailer / paging keys do nothing until `playbackEnded`. After the first trailer plays, paging to the next recommendation reuses the same TextureView; `onRenderedFirstFrame` does not fire again, the view stays at alpha 0, and only audio is heard.

## Issue or approval

Fixes #3218

## Reproduction steps

Focus while title is still playing:

1. Play a movie or an ended series until the post-play recommendation overlay appears and the player is still a mini window.
2. Press D-pad on Play, Trailer, or next/previous.
3. Before: keys do nothing until the title reaches the end. After: overlay buttons take focus as soon as the overlay is shown.

Trailer after paging:

1. Let the first recommendation trailer play with video and audio.
2. Move to the next recommendation and play its trailer.
3. Before: audio only, overlay stays on the artwork. After: video and audio both play, matching homepage trailer paging.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to post-play overlay focus routing and trailer view identity. Does not change TrailerPlayer internals, homepage trailer playback, MetaDetails trailers, recommendation candidate resolution, or `app/src/main/cpp/libde265/`.

## Testing

- Physical Android TV: post-play overlay before title end — D-pad moves between Play, Trailer, and paging controls.
- Physical Android TV: first recommendation trailer plays with video; next recommendation trailer also plays with video.
- Homepage trailer paging still uses the shared pool plus `key(trailerUrl)`; TrailerPlayer.kt was left unchanged.

## Screenshots / Video

UI glitch only: overlay buttons must show focus before the title ends, and the second recommendation trailer must show video rather than artwork-plus-audio. Capture those two flows on device if attaching media.

## Breaking changes

None

## Linked issues

#3218
