### PR TITLE
Fix player OSD requiring two Back presses.

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -517,8 +517,11 @@ fun PlayerScreen(
                     return@onPreviewKeyEvent true
                 }
 
-                if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_BACK ||
-                    keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ESCAPE
+                val postPlayHandlesBack = postPlayRecommendationState.isVisible ||
+                    postPlayRecommendationState.isLoadingRecommendation ||
+                    postPlayRecommendationState.isTrailerPlaying
+                if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ESCAPE ||
+                    (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_BACK && !postPlayHandlesBack)
                 ) {
                     return@onPreviewKeyEvent when (keyEvent.nativeKeyEvent.action) {
                         KeyEvent.ACTION_DOWN -> true

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -517,7 +517,9 @@ fun PlayerScreen(
                     return@onPreviewKeyEvent true
                 }
 
-                if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ESCAPE) {
+                if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_BACK ||
+                    keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ESCAPE
+                ) {
                     return@onPreviewKeyEvent when (keyEvent.nativeKeyEvent.action) {
                         KeyEvent.ACTION_DOWN -> true
                         KeyEvent.ACTION_UP -> {


### PR DESCRIPTION
## Summary

Player OSD panels (subtitles, audio, streams, and the other control-bar items) needed two Back presses before they would close. The first press only dropped focus from the open item; the second press actually dismissed the panel. Back is now handled on the first press so the open OSD item closes immediately.

Post-play still owns Back while its overlay is visible: if a trailer is playing, Back stops the trailer and leaves the overlay open.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On Android TV, with a focused OSD item, the first Back is consumed as a focus exit / clear-focus instead of dismissing the panel. Users have to press Back twice to leave subtitles, audio, streams, and similar OSD items. Handling Back in the player preview key path makes the first press dismiss the open item. That intercept is skipped while post-play is visible, loading, or playing a trailer so the overlay can stop the trailer instead of closing.

## Issue or approval

Player OSD items (subtitles, audio, streams, etc.) require two Back presses before you can go back. The first press does not close the panel.

## Reproduction steps

1. Start playback and open the player OSD.
2. Open Subtitles, Audio, or Streams (or another OSD item).
3. Press Back once.
4. Before: the panel stays open (the focused item only loses focus). After: the open OSD item closes on the first Back press.
5. On post-play, start a trailer and press Back once. The trailer stops; the overlay stays open.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to intercepting Back in the player preview key handler when post-play is not visible. No OSD layout, overlay UI, or other player behavior changes.

## Testing

- Code path: player `onPreviewKeyEvent` handles `KEYCODE_BACK` for OSD dismiss, and skips that intercept while post-play is visible, loading, or playing a trailer.
- Manual: open OSD during playback, open Subtitles / Audio / Streams, press Back once — panel should close. Press Back again — OSD should hide.
- Manual: post-play trailer playing, press Back once — trailer stops, overlay remains.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Player OSD items such as subtitles, audio, and streams need two Back presses before you can go back. The first press only clears focus; the second press closes the panel.
