### PR TITLE
Improve Back button navigation on home and collection screens

### DIFF
--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -936,6 +937,7 @@ class MainActivity : ComponentActivity() {
                         Box(modifier = Modifier.fillMaxSize()) {
                             if (modernSidebarEnabled) {
                                 ModernSidebarScaffold(
+                                    longPressBackHeld = longPressBackHeld,
                                     navController = navController,
                                     startDestination = startDestination,
                                     currentRoute = currentRoute,
@@ -959,6 +961,7 @@ class MainActivity : ComponentActivity() {
                                 )
                             } else {
                                 LegacySidebarScaffold(
+                                    longPressBackHeld = longPressBackHeld,
                                     navController = navController,
                                     startDestination = startDestination,
                                     currentRoute = currentRoute,
@@ -1055,7 +1058,19 @@ class MainActivity : ComponentActivity() {
     // Intercept Back at the Activity level, before any Compose BackHandler, so the auto-next loader
     // can always be dismissed. Compose back-dispatch ordering kept putting the destination screen's
     // handler above the loader's, so Back never reached it.
+    // Tracks whether a long-press Back sequence is in progress. When true, all Back
+    // key events are consumed at the Activity level so that repeated DOWN events from a
+    // held Back key don't cascade through Compose BackHandlers (e.g. opening the sidebar
+    // and then immediately exiting the app).
+    val longPressBackHeld = mutableStateOf(false)
+
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode == KeyEvent.KEYCODE_BACK) {
+            if (longPressBackHeld.value) {
+                if (event.action == KeyEvent.ACTION_UP) longPressBackHeld.value = false
+                return true
+            }
+        }
         if (event.keyCode == KeyEvent.KEYCODE_BACK &&
             externalPlaybackTracker.autoNextOverlay.value != null
         ) {
@@ -1118,6 +1133,7 @@ private fun SidebarFocusRecoveryEffect(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun LegacySidebarScaffold(
+    longPressBackHeld: MutableState<Boolean>,
     navController: NavHostController,
     startDestination: String,
     currentRoute: String?,
@@ -1140,6 +1156,7 @@ private fun LegacySidebarScaffold(
     val showSidebar = currentRoute in rootRoutes
 
     LaunchedEffect(currentRoute) {
+        longPressBackHeld.value = false
         drawerState.setValue(DrawerValue.Closed)
     }
 
@@ -1164,6 +1181,7 @@ private fun LegacySidebarScaffold(
     }
 
     BackHandler(enabled = currentRoute in rootRoutes && drawerState.currentValue == DrawerValue.Open) {
+        if (longPressBackHeld.value) return@BackHandler
         onExitApp()
     }
 
@@ -1344,7 +1362,6 @@ private fun LegacySidebarScaffold(
             animationSpec = tween(NuvioMotion.tokens.durations.medium),
             label = "contentStartPadding"
         )
-        var longPressBackConsumed by remember { mutableStateOf(false) }
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1355,18 +1372,20 @@ private fun LegacySidebarScaffold(
                     if (keyEvent.key == Key.Back) {
                         if (
                             keyEvent.type == KeyEventType.KeyDown &&
-                            keyEvent.nativeKeyEvent.isLongPress &&
                             showSidebar &&
                             drawerState.currentValue == DrawerValue.Closed &&
-                            currentRoute in rootRoutes
+                            currentRoute in rootRoutes &&
+                            keyEvent.nativeKeyEvent.isLongPress
                         ) {
-                            longPressBackConsumed = true
-                            pendingSidebarFocusRequest = true
-                            drawerState.setValue(DrawerValue.Open)
+                            if (!longPressBackHeld.value) {
+                                longPressBackHeld.value = true
+                                pendingSidebarFocusRequest = true
+                                drawerState.setValue(DrawerValue.Open)
+                            }
                             return@onPreviewKeyEvent true
                         }
-                        if (longPressBackConsumed) {
-                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackConsumed = false
+                        if (longPressBackHeld.value) {
+                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackHeld.value = false
                             return@onPreviewKeyEvent true
                         }
                     }
@@ -1507,6 +1526,7 @@ private fun LegacySidebarButton(
 
 @Composable
 private fun ModernSidebarScaffold(
+    longPressBackHeld: MutableState<Boolean>,
     navController: NavHostController,
     startDestination: String,
     currentRoute: String?,
@@ -1571,6 +1591,7 @@ private fun ModernSidebarScaffold(
     }
 
     BackHandler(enabled = currentRoute in rootRoutes && isSidebarExpanded && !sidebarCollapsePending) {
+        if (longPressBackHeld.value) return@BackHandler
         onExitApp()
     }
 
@@ -1747,9 +1768,19 @@ private fun ModernSidebarScaffold(
         sidebarOwnsFocus = showSidebar && isSidebarExpanded
     )
 
-    var longPressBackConsumed by remember { mutableStateOf(false) }
-
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .onPreviewKeyEvent { keyEvent ->
+                // Consume all Back key events after long-press until released,
+                // preventing the exit-app BackHandler from firing during the hold.
+                if (longPressBackHeld.value && keyEvent.key == Key.Back) {
+                    if (keyEvent.type == KeyEventType.KeyUp) longPressBackHeld.value = false
+                    return@onPreviewKeyEvent true
+                }
+                false
+            }
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1759,20 +1790,22 @@ private fun ModernSidebarScaffold(
                     if (keyEvent.key == Key.Back) {
                         if (
                             keyEvent.type == KeyEventType.KeyDown &&
-                            keyEvent.nativeKeyEvent.isLongPress &&
                             showSidebar &&
                             !isSidebarExpanded &&
                             !sidebarCollapsePending &&
-                            currentRoute in rootRoutes
+                            currentRoute in rootRoutes &&
+                            keyEvent.nativeKeyEvent.isLongPress
                         ) {
-                            longPressBackConsumed = true
-                            isSidebarExpanded = true
-                            sidebarCollapsePending = false
-                            pendingSidebarFocusRequest = true
+                            if (!longPressBackHeld.value) {
+                                longPressBackHeld.value = true
+                                isSidebarExpanded = true
+                                sidebarCollapsePending = false
+                                pendingSidebarFocusRequest = true
+                            }
                             return@onPreviewKeyEvent true
                         }
-                        if (longPressBackConsumed) {
-                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackConsumed = false
+                        if (longPressBackHeld.value) {
+                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackHeld.value = false
                             return@onPreviewKeyEvent true
                         }
                     }

--- a/app/src/main/java/com/nuvio/tv/MainActivity.kt
+++ b/app/src/main/java/com/nuvio/tv/MainActivity.kt
@@ -1344,10 +1344,34 @@ private fun LegacySidebarScaffold(
             animationSpec = tween(NuvioMotion.tokens.durations.medium),
             label = "contentStartPadding"
         )
+        var longPressBackConsumed by remember { mutableStateOf(false) }
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(start = contentStartPadding)
+                .onPreviewKeyEvent { keyEvent ->
+                    // Long-press Back on a root route directly opens the sidebar,
+                    // bypassing the "scroll row to start" BackHandler in home content.
+                    if (keyEvent.key == Key.Back) {
+                        if (
+                            keyEvent.type == KeyEventType.KeyDown &&
+                            keyEvent.nativeKeyEvent.isLongPress &&
+                            showSidebar &&
+                            drawerState.currentValue == DrawerValue.Closed &&
+                            currentRoute in rootRoutes
+                        ) {
+                            longPressBackConsumed = true
+                            pendingSidebarFocusRequest = true
+                            drawerState.setValue(DrawerValue.Open)
+                            return@onPreviewKeyEvent true
+                        }
+                        if (longPressBackConsumed) {
+                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackConsumed = false
+                            return@onPreviewKeyEvent true
+                        }
+                    }
+                    false
+                }
                 .onKeyEvent { keyEvent ->
                     val openKey = if (isRtl) Key.DirectionRight else Key.DirectionLeft
                     if (
@@ -1723,11 +1747,35 @@ private fun ModernSidebarScaffold(
         sidebarOwnsFocus = showSidebar && isSidebarExpanded
     )
 
+    var longPressBackConsumed by remember { mutableStateOf(false) }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .onPreviewKeyEvent { keyEvent ->
+                    // Long-press Back on a root route directly opens the sidebar,
+                    // bypassing the "scroll row to start" BackHandler in home content.
+                    if (keyEvent.key == Key.Back) {
+                        if (
+                            keyEvent.type == KeyEventType.KeyDown &&
+                            keyEvent.nativeKeyEvent.isLongPress &&
+                            showSidebar &&
+                            !isSidebarExpanded &&
+                            !sidebarCollapsePending &&
+                            currentRoute in rootRoutes
+                        ) {
+                            longPressBackConsumed = true
+                            isSidebarExpanded = true
+                            sidebarCollapsePending = false
+                            pendingSidebarFocusRequest = true
+                            return@onPreviewKeyEvent true
+                        }
+                        if (longPressBackConsumed) {
+                            if (keyEvent.type == KeyEventType.KeyUp) longPressBackConsumed = false
+                            return@onPreviewKeyEvent true
+                        }
+                    }
                     if (
                         isSidebarExpanded &&
                         !sidebarCollapsePending &&

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -140,6 +140,7 @@ fun ContinueWatchingSection(
     downFocusRequester: FocusRequester? = null,
     entryFocusRequester: FocusRequester? = null,
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
+    rowFocusRequester: FocusRequester = remember { FocusRequester() },
     listState: LazyListState = rememberLazyListState(),
     lastFocusedIndexState: MutableIntState = remember { mutableIntStateOf(-1) },
     cardWidth: Dp = 288.dp,
@@ -227,6 +228,7 @@ fun ContinueWatchingSection(
         LazyRow(
             modifier = Modifier
                 .fillMaxWidth()
+                .focusRequester(rowFocusRequester)
                 .focusRestorer {
                     val visibleIndices = listState.layoutInfo.visibleItemsInfo
                         .map { it.index }
@@ -273,8 +275,10 @@ fun ContinueWatchingSection(
                     modifier = Modifier
                         .onFocusChanged { focusState ->
                             isCardFocused = focusState.isFocused
-                            if (focusState.isFocused && lastFocusedIndex != index) {
-                                lastFocusedIndex = index
+                            if (focusState.isFocused) {
+                                if (lastFocusedIndex != index) {
+                                    lastFocusedIndex = index
+                                }
                                 onItemFocused(index)
                             }
                         }

--- a/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/ContinueWatchingSection.kt
@@ -44,6 +44,7 @@ import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.CardDepthSurface
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -139,6 +140,7 @@ fun ContinueWatchingSection(
     downFocusRequester: FocusRequester? = null,
     entryFocusRequester: FocusRequester? = null,
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
+    listState: LazyListState = rememberLazyListState(),
     lastFocusedIndexState: MutableIntState = remember { mutableIntStateOf(-1) },
     cardWidth: Dp = 288.dp,
     imageHeight: Dp = 162.dp,
@@ -152,8 +154,6 @@ fun ContinueWatchingSection(
     var lastRequestedFocusIndex by remember { mutableIntStateOf(-1) }
     var pendingFocusIndex by remember { mutableStateOf<Int?>(null) }
     var optionsItem by remember { mutableStateOf<ContinueWatchingItem?>(null) }
-
-    val listState = rememberLazyListState()
 
     // Restore focus to specific item if requested
     LaunchedEffect(focusedItemIndex) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
@@ -57,6 +57,7 @@ fun GridContinueWatchingSection(
         initialFirstVisibleItemIndex = (lastFocusedIndex.intValue - 1).coerceAtLeast(0)
     ),
     onItemFocused: (Int) -> Unit = {},
+    rowFocusRequester: FocusRequester = remember { FocusRequester() },
     blurUnwatchedEpisodes: Boolean = false,
     useEpisodeThumbnails: Boolean = true,
     cardStyle: ContinueWatchingCardStyle = ContinueWatchingCardStyle.CARD,
@@ -110,6 +111,7 @@ fun GridContinueWatchingSection(
                     else
                         Modifier.fillMaxWidth()
                 )
+                .focusRequester(rowFocusRequester)
                 .focusRestorer {
                     val idx = if (lastFocusedIndex.intValue >= 0) lastFocusedIndex.intValue else 0
                     focusRequesters[idx]
@@ -149,8 +151,10 @@ fun GridContinueWatchingSection(
                     modifier = focusModifier
                         .onFocusChanged { focusState ->
                             isCardFocused = focusState.isFocused
-                            if (focusState.isFocused && lastFocusedIndex.intValue != index) {
-                                lastFocusedIndex.intValue = index
+                            if (focusState.isFocused) {
+                                if (lastFocusedIndex.intValue != index) {
+                                    lastFocusedIndex.intValue = index
+                                }
                                 onItemFocused(index)
                             }
                         },

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
@@ -53,6 +53,9 @@ fun GridContinueWatchingSection(
     focusedItemIndex: Int = -1,
     lastFocusedIndex: MutableIntState = remember { mutableIntStateOf(-1) },
     focusRequesters: MutableMap<Int, FocusRequester> = remember { mutableMapOf() },
+    listState: androidx.compose.foundation.lazy.LazyListState = androidx.compose.foundation.lazy.rememberLazyListState(
+        initialFirstVisibleItemIndex = (lastFocusedIndex.intValue - 1).coerceAtLeast(0)
+    ),
     onItemFocused: (Int) -> Unit = {},
     blurUnwatchedEpisodes: Boolean = false,
     useEpisodeThumbnails: Boolean = true,
@@ -64,9 +67,6 @@ fun GridContinueWatchingSection(
     var optionsItem by remember { mutableStateOf<ContinueWatchingItem?>(null) }
     var lastRequestedFocusIndex by remember { mutableIntStateOf(-1) }
     var pendingFocusIndex by remember { mutableStateOf<Int?>(null) }
-    val listState = androidx.compose.foundation.lazy.rememberLazyListState(
-        initialFirstVisibleItemIndex = (lastFocusedIndex.intValue - 1).coerceAtLeast(0)
-    )
 
     LaunchedEffect(focusedItemIndex) {
         if (focusedItemIndex >= 0 && focusedItemIndex < items.size) {

--- a/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/GridContinueWatchingSection.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 import com.nuvio.tv.domain.model.ContinueWatchingCardStyle
 import com.nuvio.tv.ui.screens.home.ContinueWatchingItem
+import kotlin.math.abs
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -113,9 +114,17 @@ fun GridContinueWatchingSection(
                 )
                 .focusRequester(rowFocusRequester)
                 .focusRestorer {
-                    val idx = if (lastFocusedIndex.intValue >= 0) lastFocusedIndex.intValue else 0
-                    focusRequesters[idx]
-                        ?: focusRequesters.values.firstOrNull()
+                    // Take the remembered card when it is on screen, otherwise the nearest one
+                    // that is, the way the classic row does it. Falling back to whichever
+                    // requester was registered first can hand focus to a card that is not
+                    // composed, and focus then lands wherever the directional search goes.
+                    val visible = listState.layoutInfo.visibleItemsInfo
+                        .map { it.index }
+                        .filter { it in items.indices }
+                    val remembered = lastFocusedIndex.intValue
+                    val idx = remembered.takeIf { it in visible }
+                        ?: visible.minByOrNull { abs(it - remembered) }
+                    idx?.let { focusRequesters[it] }
                         ?: FocusRequester.Default
                 }
                 .focusGroup(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -43,6 +44,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import com.nuvio.tv.ui.util.dpadVerticalFastScroll
 import com.nuvio.tv.ui.util.localizedContentType
@@ -264,8 +270,9 @@ private fun TabbedGridContent(
 ) {
     val tabFocusRequesters = remember(uiState.tabs.size) { uiState.tabs.indices.map { FocusRequester() } }
     var gridHasFocus by remember { mutableStateOf(false) }
+    var gridScrollToTopTrigger by remember { mutableIntStateOf(0) }
 
-    // Grid Back: focus on grid -> move focus to active tab. Focus on tab -> let onBack handle it.
+    // Grid Back: focus on grid -> move focus to active tab (grid stays scrolled).
     BackHandler(enabled = gridHasFocus) {
         tabFocusRequesters.getOrNull(uiState.selectedTabIndex)?.let { runCatching { it.requestFocus() } }
     }
@@ -321,7 +328,10 @@ private fun TabbedGridContent(
                     Tab(
                         selected = index == uiState.selectedTabIndex,
                         onFocus = { onSelectTab(index) },
-                        onClick = { onSelectTab(index) },
+                        onClick = {
+                            onSelectTab(index)
+                            gridScrollToTopTrigger++
+                        },
                         modifier = if (index < tabFocusRequesters.size) {
                             Modifier.focusRequester(tabFocusRequesters[index])
                         } else Modifier
@@ -387,6 +397,13 @@ private fun TabbedGridContent(
                 initialFirstVisibleItemIndex = tabFocusState.verticalScrollIndex,
                 initialFirstVisibleItemScrollOffset = tabFocusState.verticalScrollOffset
             )
+
+            // Scroll grid to top when OK is pressed on a tab or tab changes
+            LaunchedEffect(gridScrollToTopTrigger, uiState.selectedTabIndex) {
+                if (gridState.firstVisibleItemIndex > 0 || gridState.firstVisibleItemScrollOffset > 0) {
+                    gridState.scrollToItem(0, 0)
+                }
+            }
 
             DisposableEffect(Unit) {
                 onDispose {
@@ -572,6 +589,22 @@ private fun RowsContent(
     val focusedItemByRow = remember { mutableStateMapOf<String, Int>() }
     val currentFocusedRowKey = remember { mutableStateOf(focusState.focusedRowKey) }
     val folderScope = rememberCoroutineScope()
+
+    // Improved Back: scroll to first item in row before exiting collection
+    BackHandler(enabled = run {
+        val rowKey = currentFocusedRowKey.value ?: return@run false
+        val itemIndex = focusedItemByRow[rowKey] ?: rowFocusedItemIndex[rowKey] ?: 0
+        itemIndex > 0
+    }) {
+        val rowKey = currentFocusedRowKey.value ?: return@BackHandler
+        val listState = rowStates[rowKey]
+        rowFocusedItemIndex[rowKey] = 0
+        focusedItemByRow[rowKey] = 0
+        folderScope.launch {
+            listState?.scrollToItem(0, 0)
+            rowFocusRequesters[rowKey]?.let { runCatching { it.requestFocus() } }
+        }
+    }
 
     DisposableEffect(Unit) {
         onDispose {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -273,7 +273,7 @@ private fun TabbedGridContent(
     var gridScrollToTopTrigger by remember { mutableIntStateOf(0) }
 
     // Grid Back: focus on grid -> move focus to active tab (grid stays scrolled).
-    BackHandler(enabled = gridHasFocus) {
+    BackHandler(enabled = gridHasFocus && uiState.tabs.size > 1) {
         tabFocusRequesters.getOrNull(uiState.selectedTabIndex)?.let { runCatching { it.requestFocus() } }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/collection/FolderDetailScreen.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.collection
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -262,6 +263,12 @@ private fun TabbedGridContent(
     onItemLongPress: (MetaPreview, String) -> Unit = { _, _ -> }
 ) {
     val tabFocusRequesters = remember(uiState.tabs.size) { uiState.tabs.indices.map { FocusRequester() } }
+    var gridHasFocus by remember { mutableStateOf(false) }
+
+    // Grid Back: focus on grid -> move focus to active tab. Focus on tab -> let onBack handle it.
+    BackHandler(enabled = gridHasFocus) {
+        tabFocusRequesters.getOrNull(uiState.selectedTabIndex)?.let { runCatching { it.requestFocus() } }
+    }
 
     Row(
         modifier = Modifier
@@ -436,6 +443,7 @@ private fun TabbedGridContent(
                 columns = GridCells.Adaptive(minSize = posterCardStyle.width),
                 modifier = Modifier
                     .fillMaxSize()
+                    .onFocusChanged { gridHasFocus = it.hasFocus }
                     .focusRestorer {
                         lastFocusedItemKey?.let { itemFocusRequesters[it] } ?: FocusRequester.Default
                     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -216,6 +216,8 @@ fun ClassicHomeContent(
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val cwRowFocusRequester = remember { FocusRequester() }
     val upcomingRowFocusRequester = remember { FocusRequester() }
+    val cwListState = remember { LazyListState() }
+    val upcomingListState = remember { LazyListState() }
     val lastFocusedCwIndex = remember { mutableIntStateOf(-1) }
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
 
@@ -278,12 +280,7 @@ fun ClassicHomeContent(
     }
 
     LaunchedEffect(visibleRowKeys) {
-        // Keep CW/upcoming row states alive — they use rowStates.getOrPut but aren't
-        // part of visibleRowKeys (which only tracks catalog/collection rows).
-        val keysToRetain = visibleRowKeys.toMutableSet()
-        if (rowStates.containsKey("continue_watching")) keysToRetain.add("continue_watching")
-        if (rowStates.containsKey("upcoming_section")) keysToRetain.add("upcoming_section")
-        rowStates.keys.retainAll(keysToRetain)
+        rowStates.keys.retainAll(visibleRowKeys)
         rowFocusRequesters.keys.retainAll(visibleRowKeys)
     }
 
@@ -586,7 +583,6 @@ fun ClassicHomeContent(
 
         if (uiState.continueWatchingEnabled && uiState.continueWatchingItems.isNotEmpty()) {
             item(key = "continue_watching", contentType = "continue_watching") {
-                val cwListState = rowStates.getOrPut("continue_watching") { LazyListState() }
                 LaunchedEffect(cwPendingScrollToStart.intValue) {
                     if (cwPendingScrollToStart.intValue > 0) {
                         cwListState.scrollToItem(0, 0)
@@ -664,7 +660,6 @@ fun ClassicHomeContent(
 
         if (uiState.continueWatchingEnabled && uiState.upcomingItems.isNotEmpty()) {
             item(key = "upcoming_section", contentType = "upcoming_section") {
-                val upcomingListState = rowStates.getOrPut("upcoming_section") { LazyListState() }
                 LaunchedEffect(upcomingPendingScrollToStart.intValue) {
                     if (upcomingPendingScrollToStart.intValue > 0) {
                         upcomingListState.scrollToItem(0, 0)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -216,10 +217,13 @@ fun ClassicHomeContent(
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val cwRowFocusRequester = remember { FocusRequester() }
     val upcomingRowFocusRequester = remember { FocusRequester() }
-    val cwListState = remember { LazyListState() }
-    val upcomingListState = remember { LazyListState() }
-    val lastFocusedCwIndex = remember { mutableIntStateOf(-1) }
-    val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
+    // Saveable so the rows come back where they were left after navigating away and
+    // returning. The restorer picks the first visible card when the remembered one is
+    // off screen, so the scroll has to survive too, not just the index.
+    val cwListState = rememberLazyListState()
+    val upcomingListState = rememberLazyListState()
+    val lastFocusedCwIndex = rememberSaveable { mutableIntStateOf(-1) }
+    val lastFocusedUpcomingIndex = rememberSaveable { mutableIntStateOf(-1) }
 
     // Improved Back navigation: when focused item is not the first in a row,
     // scroll the row to the start and focus the first item instead of opening the sidebar.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.home
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 
+import androidx.activity.compose.BackHandler
 import com.nuvio.tv.LocalContentFocusRequester
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.background
@@ -212,6 +213,23 @@ fun ClassicHomeContent(
     val cwItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
+
+    // Improved Back navigation: when focused item is not the first in a row,
+    // scroll the row to the start and focus the first item instead of opening the sidebar.
+    BackHandler(enabled = run {
+        val rowKey = currentFocusSnapshot.rowKey ?: return@run false
+        val itemIndex = rowFocusedItemIndex[rowKey] ?: 0
+        itemIndex > 0
+    }) {
+        val rowKey = currentFocusSnapshot.rowKey ?: return@BackHandler
+        val listState = rowStates[rowKey]
+        rowFocusedItemIndex[rowKey] = 0
+        currentFocusSnapshot.itemIndex = 0
+        scope.launch {
+            listState?.scrollToItem(0, 0)
+            rowFocusRequesters[rowKey]?.let { runCatching { it.requestFocus() } }
+        }
+    }
 
     var restoringFocus by remember { mutableStateOf(focusState.hasSavedFocus) }
     val heroFocusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -207,7 +208,7 @@ fun ClassicHomeContent(
     // Store scroll state for each row to persist position during recycling
     val rowStates = remember { mutableMapOf<String, LazyListState>() }
     val rowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
-    val rowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
+    val rowFocusedItemIndex = remember { mutableStateMapOf<String, Int>() }
     // Item keys of each row as they were when its focused index was last recorded, so the index
     // can be relocated when a refresh shifts the row instead of pointing at a new card.
     val previousRowItemKeys = remember { mutableMapOf<String, List<String>>() }
@@ -215,6 +216,7 @@ fun ClassicHomeContent(
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val cwRowFocusRequester = remember { FocusRequester() }
     val upcomingRowFocusRequester = remember { FocusRequester() }
+    val lastFocusedCwIndex = remember { mutableIntStateOf(-1) }
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
 
     // Improved Back navigation: when focused item is not the first in a row,
@@ -276,7 +278,12 @@ fun ClassicHomeContent(
     }
 
     LaunchedEffect(visibleRowKeys) {
-        rowStates.keys.retainAll(visibleRowKeys)
+        // Keep CW/upcoming row states alive — they use rowStates.getOrPut but aren't
+        // part of visibleRowKeys (which only tracks catalog/collection rows).
+        val keysToRetain = visibleRowKeys.toMutableSet()
+        if (rowStates.containsKey("continue_watching")) keysToRetain.add("continue_watching")
+        if (rowStates.containsKey("upcoming_section")) keysToRetain.add("upcoming_section")
+        rowStates.keys.retainAll(keysToRetain)
         rowFocusRequesters.keys.retainAll(visibleRowKeys)
     }
 
@@ -363,6 +370,7 @@ fun ClassicHomeContent(
 
     val handleHeroFocus: (MetaPreview) -> Unit = remember(uiState.classicFocusGradientEnabled) {
         { item ->
+            activeRowKeyState.value = null
             if (uiState.classicFocusGradientEnabled) {
                 focusedArtwork = null
             }
@@ -643,6 +651,7 @@ fun ClassicHomeContent(
                     useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
                     focusRequesters = cwItemFocusRequesters,
                     rowFocusRequester = cwRowFocusRequester,
+                    lastFocusedIndexState = lastFocusedCwIndex,
                     cardWidth = classicContinueWatchingCardWidth,
                     imageHeight = classicContinueWatchingImageHeight,
                     cardStyle = uiState.continueWatchingCardStyle,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -213,6 +213,8 @@ fun ClassicHomeContent(
     val previousRowItemKeys = remember { mutableMapOf<String, List<String>>() }
     val cwItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingItemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
+    val cwRowFocusRequester = remember { FocusRequester() }
+    val upcomingRowFocusRequester = remember { FocusRequester() }
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
 
     // Improved Back navigation: when focused item is not the first in a row,
@@ -220,15 +222,18 @@ fun ClassicHomeContent(
     // Disabled when content doesn't have focus (e.g. sidebar is open).
     val contentHasFocus = remember { mutableStateOf(false) }
     val cwFocusedIndex = remember { mutableIntStateOf(-1) }
+    // Observable version of currentFocusSnapshot.rowKey so BackHandler recomposes
+    // when focus moves between CW/Upcoming and catalog rows.
+    val activeRowKeyState = remember { mutableStateOf<String?>(null) }
     val cwPendingScrollToStart = remember { mutableIntStateOf(0) }
     val upcomingPendingScrollToStart = remember { mutableIntStateOf(0) }
     BackHandler(enabled = contentHasFocus.value && run {
-        val rowKey = currentFocusSnapshot.rowKey ?: return@run false
+        val rowKey = activeRowKeyState.value ?: return@run false
         val isCwRow = rowKey == "continue_watching" || rowKey == "upcoming_section"
         val itemIndex = if (isCwRow) cwFocusedIndex.intValue else (rowFocusedItemIndex[rowKey] ?: 0)
         itemIndex > 0
     }) {
-        val rowKey = currentFocusSnapshot.rowKey ?: return@BackHandler
+        val rowKey = activeRowKeyState.value ?: return@BackHandler
         val isCw = rowKey == "continue_watching"
         val isUpcoming = rowKey == "upcoming_section"
         if (isCw || isUpcoming) {
@@ -577,7 +582,7 @@ fun ClassicHomeContent(
                 LaunchedEffect(cwPendingScrollToStart.intValue) {
                     if (cwPendingScrollToStart.intValue > 0) {
                         cwListState.scrollToItem(0, 0)
-                        cwItemFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                        cwRowFocusRequester.let { runCatching { it.requestFocus() } }
                     }
                 }
                 ContinueWatchingSection(
@@ -626,6 +631,7 @@ fun ClassicHomeContent(
                         currentFocusSnapshot.rowIndex = -1
                         currentFocusSnapshot.itemIndex = itemIndex
                         currentFocusSnapshot.rowKey = "continue_watching"
+                        activeRowKeyState.value = "continue_watching"
                         cwFocusedIndex.intValue = itemIndex
                         onFocusedRowKeyChanged(null)
                         if (uiState.classicFocusGradientEnabled) {
@@ -636,6 +642,7 @@ fun ClassicHomeContent(
                     blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
                     useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
                     focusRequesters = cwItemFocusRequesters,
+                    rowFocusRequester = cwRowFocusRequester,
                     cardWidth = classicContinueWatchingCardWidth,
                     imageHeight = classicContinueWatchingImageHeight,
                     cardStyle = uiState.continueWatchingCardStyle,
@@ -652,7 +659,7 @@ fun ClassicHomeContent(
                 LaunchedEffect(upcomingPendingScrollToStart.intValue) {
                     if (upcomingPendingScrollToStart.intValue > 0) {
                         upcomingListState.scrollToItem(0, 0)
-                        upcomingItemFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                        upcomingRowFocusRequester.let { runCatching { it.requestFocus() } }
                     }
                 }
                 ContinueWatchingSection(
@@ -696,11 +703,13 @@ fun ClassicHomeContent(
                     blurUnwatchedEpisodes = uiState.blurUnwatchedEpisodes,
                     useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
                     focusRequesters = upcomingItemFocusRequesters,
+                    rowFocusRequester = upcomingRowFocusRequester,
                     lastFocusedIndexState = lastFocusedUpcomingIndex,
                     onItemFocused = { itemIndex ->
                         currentFocusSnapshot.rowIndex = -1
                         currentFocusSnapshot.itemIndex = itemIndex
                         currentFocusSnapshot.rowKey = "upcoming_section"
+                        activeRowKeyState.value = "upcoming_section"
                         cwFocusedIndex.intValue = itemIndex
                     },
                     cardWidth = classicContinueWatchingCardWidth,
@@ -806,6 +815,7 @@ fun ClassicHomeContent(
                                 currentFocusSnapshot.rowIndex = index
                                 currentFocusSnapshot.itemIndex = itemIndex
                                 currentFocusSnapshot.rowKey = catalogKey
+                                activeRowKeyState.value = catalogKey
                                 onFocusedRowKeyChanged(catalogKey)
                                 rowFocusedItemIndex[catalogKey] = itemIndex
                             }
@@ -841,6 +851,7 @@ fun ClassicHomeContent(
                             currentFocusSnapshot.rowIndex = index
                             currentFocusSnapshot.itemIndex = itemIndex
                             currentFocusSnapshot.rowKey = collectionKey
+                            activeRowKeyState.value = collectionKey
                             onFocusedRowKeyChanged(null)
                             rowFocusedItemIndex[collectionKey] = itemIndex
                             if (uiState.classicFocusGradientEnabled) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ClassicHomeContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalDensity
 import com.nuvio.tv.ui.util.dpadVerticalFastScroll
 import com.nuvio.tv.ui.util.asStable
@@ -216,18 +217,32 @@ fun ClassicHomeContent(
 
     // Improved Back navigation: when focused item is not the first in a row,
     // scroll the row to the start and focus the first item instead of opening the sidebar.
-    BackHandler(enabled = run {
+    // Disabled when content doesn't have focus (e.g. sidebar is open).
+    val contentHasFocus = remember { mutableStateOf(false) }
+    val cwFocusedIndex = remember { mutableIntStateOf(-1) }
+    val cwPendingScrollToStart = remember { mutableIntStateOf(0) }
+    val upcomingPendingScrollToStart = remember { mutableIntStateOf(0) }
+    BackHandler(enabled = contentHasFocus.value && run {
         val rowKey = currentFocusSnapshot.rowKey ?: return@run false
-        val itemIndex = rowFocusedItemIndex[rowKey] ?: 0
+        val isCwRow = rowKey == "continue_watching" || rowKey == "upcoming_section"
+        val itemIndex = if (isCwRow) cwFocusedIndex.intValue else (rowFocusedItemIndex[rowKey] ?: 0)
         itemIndex > 0
     }) {
         val rowKey = currentFocusSnapshot.rowKey ?: return@BackHandler
-        val listState = rowStates[rowKey]
-        rowFocusedItemIndex[rowKey] = 0
-        currentFocusSnapshot.itemIndex = 0
-        scope.launch {
-            listState?.scrollToItem(0, 0)
-            rowFocusRequesters[rowKey]?.let { runCatching { it.requestFocus() } }
+        val isCw = rowKey == "continue_watching"
+        val isUpcoming = rowKey == "upcoming_section"
+        if (isCw || isUpcoming) {
+            cwFocusedIndex.intValue = 0
+            currentFocusSnapshot.itemIndex = 0
+            if (isCw) cwPendingScrollToStart.intValue++ else upcomingPendingScrollToStart.intValue++
+        } else {
+            val listState = rowStates[rowKey]
+            rowFocusedItemIndex[rowKey] = 0
+            currentFocusSnapshot.itemIndex = 0
+            scope.launch {
+                listState?.scrollToItem(0, 0)
+                rowFocusRequesters[rowKey]?.let { runCatching { it.requestFocus() } }
+            }
         }
     }
 
@@ -472,6 +487,7 @@ fun ClassicHomeContent(
         state = columnListState,
         modifier = Modifier
             .fillMaxSize()
+            .onFocusChanged { contentHasFocus.value = it.hasFocus }
             .focusRequester(contentFocusRequester)
             .focusRestorer()
             .dpadVerticalFastScroll(
@@ -557,6 +573,13 @@ fun ClassicHomeContent(
 
         if (uiState.continueWatchingEnabled && uiState.continueWatchingItems.isNotEmpty()) {
             item(key = "continue_watching", contentType = "continue_watching") {
+                val cwListState = rowStates.getOrPut("continue_watching") { LazyListState() }
+                LaunchedEffect(cwPendingScrollToStart.intValue) {
+                    if (cwPendingScrollToStart.intValue > 0) {
+                        cwListState.scrollToItem(0, 0)
+                        cwItemFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                    }
+                }
                 ContinueWatchingSection(
                     items = uiState.continueWatchingItems,
                     onItemClick = { item ->
@@ -603,6 +626,7 @@ fun ClassicHomeContent(
                         currentFocusSnapshot.rowIndex = -1
                         currentFocusSnapshot.itemIndex = itemIndex
                         currentFocusSnapshot.rowKey = "continue_watching"
+                        cwFocusedIndex.intValue = itemIndex
                         onFocusedRowKeyChanged(null)
                         if (uiState.classicFocusGradientEnabled) {
                             focusedArtwork = uiState.continueWatchingItems.getOrNull(itemIndex)
@@ -616,13 +640,21 @@ fun ClassicHomeContent(
                     imageHeight = classicContinueWatchingImageHeight,
                     cardStyle = uiState.continueWatchingCardStyle,
                     cornerRadius = posterCardStyle.cornerRadius,
-                    posterTitleOverride = classicPosterTitleStyle
+                    posterTitleOverride = classicPosterTitleStyle,
+                    listState = cwListState
                 )
             }
         }
 
         if (uiState.continueWatchingEnabled && uiState.upcomingItems.isNotEmpty()) {
             item(key = "upcoming_section", contentType = "upcoming_section") {
+                val upcomingListState = rowStates.getOrPut("upcoming_section") { LazyListState() }
+                LaunchedEffect(upcomingPendingScrollToStart.intValue) {
+                    if (upcomingPendingScrollToStart.intValue > 0) {
+                        upcomingListState.scrollToItem(0, 0)
+                        upcomingItemFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                    }
+                }
                 ContinueWatchingSection(
                     items = uiState.upcomingItems,
                     title = stringResource(R.string.upcoming_section_title),
@@ -665,11 +697,18 @@ fun ClassicHomeContent(
                     useEpisodeThumbnails = uiState.useEpisodeThumbnailsInCw,
                     focusRequesters = upcomingItemFocusRequesters,
                     lastFocusedIndexState = lastFocusedUpcomingIndex,
+                    onItemFocused = { itemIndex ->
+                        currentFocusSnapshot.rowIndex = -1
+                        currentFocusSnapshot.itemIndex = itemIndex
+                        currentFocusSnapshot.rowKey = "upcoming_section"
+                        cwFocusedIndex.intValue = itemIndex
+                    },
                     cardWidth = classicContinueWatchingCardWidth,
                     imageHeight = classicContinueWatchingImageHeight,
                     cardStyle = uiState.continueWatchingCardStyle,
                     cornerRadius = posterCardStyle.cornerRadius,
-                    posterTitleOverride = classicPosterTitleStyle
+                    posterTitleOverride = classicPosterTitleStyle,
+                    listState = upcomingListState
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.snapshotFlow
@@ -117,14 +118,17 @@ fun GridHomeContent(
     )
     val focusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val lastFocusedGridItemKey = remember { mutableStateOf(gridFocusState.focusedItemKey) }
-    val lastFocusedCwIndex = remember { mutableIntStateOf(-1) }
-    val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
+    // Saveable so the rows come back where they were left after navigating away and
+    // returning. The restorer falls back to the first card when the remembered one is
+    // off screen, so the scroll has to survive too, not just the index.
+    val lastFocusedCwIndex = rememberSaveable { mutableIntStateOf(-1) }
+    val lastFocusedUpcomingIndex = rememberSaveable { mutableIntStateOf(-1) }
     val cwFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val cwRowFocusRequester = remember { FocusRequester() }
     val upcomingRowFocusRequester = remember { FocusRequester() }
-    val cwListState = remember { androidx.compose.foundation.lazy.LazyListState() }
-    val upcomingListState = remember { androidx.compose.foundation.lazy.LazyListState() }
+    val cwListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val upcomingListState = androidx.compose.foundation.lazy.rememberLazyListState()
 
     // Improved Back navigation for CW/Upcoming rows: scroll to first item
     val contentHasFocus = remember { mutableStateOf(false) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.ExperimentalComposeUiApi
 import com.nuvio.tv.ui.util.asStable
 import com.nuvio.tv.ui.util.dpadRepeatThrottle
 import androidx.compose.ui.res.stringResource
@@ -88,7 +89,7 @@ import com.nuvio.tv.ui.components.collectionFolderCardImageUrl
 import com.nuvio.tv.ui.components.nuvioCardDepth
 import com.nuvio.tv.ui.components.rememberArtworkBackedCardGlow
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun GridHomeContent(
     uiState: HomeUiState,
@@ -120,6 +121,8 @@ fun GridHomeContent(
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
     val cwFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
+    val cwRowFocusRequester = remember { FocusRequester() }
+    val upcomingRowFocusRequester = remember { FocusRequester() }
     val cwListState = remember { androidx.compose.foundation.lazy.LazyListState() }
     val upcomingListState = remember { androidx.compose.foundation.lazy.LazyListState() }
 
@@ -368,9 +371,21 @@ fun GridHomeContent(
             columns = GridCells.Adaptive(minSize = posterCardStyle.width),
             modifier = Modifier
                 .fillMaxSize()
-                .onFocusChanged { contentHasFocus.value = it.hasFocus }
+                .onFocusChanged {
+                    contentHasFocus.value = it.hasFocus
+                }
                 .focusRequester(contentFocusRequester)
-                .focusRestorer()
+                .focusRestorer {
+                    val cwRow = activeCwRowKey.value
+                    val fromCwRow = when (cwRow) {
+                        "continue_watching" -> cwRowFocusRequester
+                        "upcoming_section" -> upcomingRowFocusRequester
+                        else -> null
+                    }
+                    val lastKey = lastFocusedGridItemKey.value
+                    val fromGrid = lastKey?.let { key -> focusRequesters[key] }
+                    fromCwRow ?: fromGrid ?: FocusRequester.Default
+                }
                 .dpadRepeatThrottle(),
             contentPadding = PaddingValues(
                 start = NuvioTheme.spacing.xxxl,
@@ -440,9 +455,10 @@ fun GridHomeContent(
                     LaunchedEffect(cwPendingScrollToStart.intValue) {
                         if (cwPendingScrollToStart.intValue > 0) {
                             cwListState.scrollToItem(0, 0)
-                            cwFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                            cwRowFocusRequester.let { runCatching { it.requestFocus() } }
                         }
                     }
+                    Box(modifier = Modifier) {
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -450,6 +466,7 @@ fun GridHomeContent(
                         focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
                         lastFocusedIndex = lastFocusedCwIndex,
                         focusRequesters = cwFocusRequesters,
+                        rowFocusRequester = cwRowFocusRequester,
                         listState = cwListState,
                         onItemFocused = { lastFocusedCwIndex.intValue = it; activeCwRowKey.value = "continue_watching" },
                         onItemClick = onContinueWatchingClick,
@@ -490,6 +507,7 @@ fun GridHomeContent(
                         cardStyle = uiState.continueWatchingCardStyle,
                         cornerRadius = posterCardStyle.cornerRadius
                     )
+                    } // end Box with focus logging
                 }
             }
 
@@ -503,9 +521,10 @@ fun GridHomeContent(
                     LaunchedEffect(upcomingPendingScrollToStart.intValue) {
                         if (upcomingPendingScrollToStart.intValue > 0) {
                             upcomingListState.scrollToItem(0, 0)
-                            upcomingFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                            upcomingRowFocusRequester.let { runCatching { it.requestFocus() } }
                         }
                     }
+                    Box(modifier = Modifier) {
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -513,6 +532,7 @@ fun GridHomeContent(
                         title = stringResource(R.string.upcoming_section_title),
                         lastFocusedIndex = lastFocusedUpcomingIndex,
                         focusRequesters = upcomingFocusRequesters,
+                        rowFocusRequester = upcomingRowFocusRequester,
                         listState = upcomingListState,
                         onItemFocused = { lastFocusedUpcomingIndex.intValue = it; activeCwRowKey.value = "upcoming_section" },
                         onItemClick = onContinueWatchingClick,
@@ -553,6 +573,7 @@ fun GridHomeContent(
                         cardStyle = uiState.continueWatchingCardStyle,
                         cornerRadius = posterCardStyle.cornerRadius
                     )
+                    } // end Box with upcoming focus logging
                 }
             }
 
@@ -638,6 +659,7 @@ fun GridHomeContent(
                             onFocused = remember(itemKey, gridItem.item) {
                                 {
                                     lastFocusedGridItemKey.value = itemKey
+                                    activeCwRowKey.value = null
                                     // No rows here, but a card still belongs to one.
                                     onFocusedRowKeyChanged(
                                         catalogRowStableKey(
@@ -704,7 +726,7 @@ fun GridHomeContent(
                             focusGlowEnabled = gridItem.focusGlowEnabled,
                             posterCardStyle = posterCardStyle,
                             focusRequester = focusRequesters.getOrPut(itemKey) { FocusRequester() },
-                            onFocused = remember(itemKey) { { lastFocusedGridItemKey.value = itemKey } },
+                            onFocused = remember(itemKey) { { lastFocusedGridItemKey.value = itemKey; activeCwRowKey.value = null } },
                             onClick = remember(gridItem.collectionId, gridItem.folder.id) {
                                 {
                                     onNavigateToFolderDetail(gridItem.collectionId, gridItem.folder.id)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -427,6 +427,7 @@ fun GridHomeContent(
                                 items = gridItem.items.asStable(),
                                 focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
                                 showImdbRatings = uiState.homeImdbRatingsVisibility.showRatings,
+                                onItemFocus = { activeCwRowKey.value = null },
                                 onItemClick = remember(onNavigateToDetail) {
                                     { item ->
                                         onNavigateToDetail(
@@ -458,7 +459,6 @@ fun GridHomeContent(
                             cwRowFocusRequester.let { runCatching { it.requestFocus() } }
                         }
                     }
-                    Box(modifier = Modifier) {
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -507,7 +507,6 @@ fun GridHomeContent(
                         cardStyle = uiState.continueWatchingCardStyle,
                         cornerRadius = posterCardStyle.cornerRadius
                     )
-                    } // end Box with focus logging
                 }
             }
 
@@ -524,7 +523,6 @@ fun GridHomeContent(
                             upcomingRowFocusRequester.let { runCatching { it.requestFocus() } }
                         }
                     }
-                    Box(modifier = Modifier) {
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -573,7 +571,6 @@ fun GridHomeContent(
                         cardStyle = uiState.continueWatchingCardStyle,
                         cornerRadius = posterCardStyle.cornerRadius
                     )
-                    } // end Box with upcoming focus logging
                 }
             }
 
@@ -606,6 +603,7 @@ fun GridHomeContent(
                             items = gridItem.items.asStable(),
                             focusRequester = if (shouldRequestInitialFocus) heroFocusRequester else null,
                             showImdbRatings = uiState.homeImdbRatingsVisibility.showRatings,
+                            onItemFocus = { activeCwRowKey.value = null },
                             onItemClick = remember(onNavigateToDetail) {
                                 { item ->
                                     onNavigateToDetail(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/GridHomeContent.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.home
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.State
 import androidx.compose.foundation.lazy.grid.items
 import com.nuvio.tv.LocalContentFocusRequester
@@ -119,6 +120,28 @@ fun GridHomeContent(
     val lastFocusedUpcomingIndex = remember { mutableIntStateOf(-1) }
     val cwFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val upcomingFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
+    val cwListState = remember { androidx.compose.foundation.lazy.LazyListState() }
+    val upcomingListState = remember { androidx.compose.foundation.lazy.LazyListState() }
+
+    // Improved Back navigation for CW/Upcoming rows: scroll to first item
+    val contentHasFocus = remember { mutableStateOf(false) }
+    val activeCwRowKey = remember { mutableStateOf<String?>(null) }
+    val cwPendingScrollToStart = remember { mutableIntStateOf(0) }
+    val upcomingPendingScrollToStart = remember { mutableIntStateOf(0) }
+    BackHandler(enabled = contentHasFocus.value && run {
+        val key = activeCwRowKey.value ?: return@run false
+        val idx = if (key == "continue_watching") lastFocusedCwIndex.intValue else lastFocusedUpcomingIndex.intValue
+        idx > 0
+    }) {
+        val key = activeCwRowKey.value ?: return@BackHandler
+        if (key == "continue_watching") {
+            lastFocusedCwIndex.intValue = 0
+            cwPendingScrollToStart.intValue++
+        } else {
+            lastFocusedUpcomingIndex.intValue = 0
+            upcomingPendingScrollToStart.intValue++
+        }
+    }
 
     // Scroll to top when triggered from sidebar Home button.
     LaunchedEffect(scrollToTopTrigger) {
@@ -345,6 +368,7 @@ fun GridHomeContent(
             columns = GridCells.Adaptive(minSize = posterCardStyle.width),
             modifier = Modifier
                 .fillMaxSize()
+                .onFocusChanged { contentHasFocus.value = it.hasFocus }
                 .focusRequester(contentFocusRequester)
                 .focusRestorer()
                 .dpadRepeatThrottle(),
@@ -413,6 +437,12 @@ fun GridHomeContent(
                     span = { GridItemSpan(maxLineSpan) },
                     contentType = "continue_watching"
                 ) {
+                    LaunchedEffect(cwPendingScrollToStart.intValue) {
+                        if (cwPendingScrollToStart.intValue > 0) {
+                            cwListState.scrollToItem(0, 0)
+                            cwFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                        }
+                    }
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -420,7 +450,8 @@ fun GridHomeContent(
                         focusedItemIndex = if (shouldRequestInitialFocus && !hasHero) 0 else -1,
                         lastFocusedIndex = lastFocusedCwIndex,
                         focusRequesters = cwFocusRequesters,
-                        onItemFocused = { lastFocusedCwIndex.intValue = it },
+                        listState = cwListState,
+                        onItemFocused = { lastFocusedCwIndex.intValue = it; activeCwRowKey.value = "continue_watching" },
                         onItemClick = onContinueWatchingClick,
                         onStartFromBeginning = onContinueWatchingStartFromBeginning,
                         showManualPlayOption = showContinueWatchingManualPlayOption,
@@ -469,6 +500,12 @@ fun GridHomeContent(
                     span = { GridItemSpan(maxLineSpan) },
                     contentType = "upcoming_section"
                 ) {
+                    LaunchedEffect(upcomingPendingScrollToStart.intValue) {
+                        if (upcomingPendingScrollToStart.intValue > 0) {
+                            upcomingListState.scrollToItem(0, 0)
+                            upcomingFocusRequesters[0]?.let { runCatching { it.requestFocus() } }
+                        }
+                    }
                     GridContinueWatchingSection(
                         modifier = Modifier.fillMaxWidth(),
                         fullWidth = gridWidth,
@@ -476,7 +513,8 @@ fun GridHomeContent(
                         title = stringResource(R.string.upcoming_section_title),
                         lastFocusedIndex = lastFocusedUpcomingIndex,
                         focusRequesters = upcomingFocusRequesters,
-                        onItemFocused = { lastFocusedUpcomingIndex.intValue = it },
+                        listState = upcomingListState,
+                        onItemFocused = { lastFocusedUpcomingIndex.intValue = it; activeCwRowKey.value = "upcoming_section" },
                         onItemClick = onContinueWatchingClick,
                         onStartFromBeginning = onContinueWatchingStartFromBeginning,
                         showManualPlayOption = showContinueWatchingManualPlayOption,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
@@ -88,6 +89,7 @@ import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 // Height of the wide card as a fraction of its width, matching the 2.5:1 shape of the mobile card.
@@ -247,6 +249,27 @@ fun ModernHomeContent(
     var endedCollectionHeroVideoPlaybackKey by remember { mutableStateOf<String?>(null) }
     val expansionInteractionNonce = remember { mutableIntStateOf(0) }
 
+    // Improved Back navigation: when focused item is not the first in a row,
+    // scroll the row to the start and focus the first item instead of opening the sidebar.
+    val backScrollScope = rememberCoroutineScope()
+    val shouldInterceptBack = remember {
+        derivedStateOf {
+            val rowKey = activeRowKey.value ?: return@derivedStateOf false
+            val itemIndex = focusedItemByRow[rowKey] ?: 0
+            itemIndex > 0
+        }
+    }
+    BackHandler(enabled = shouldInterceptBack.value) {
+        val rowKey = activeRowKey.value ?: return@BackHandler
+        val listState = rowListStates[rowKey]
+        focusedItemByRow[rowKey] = 0
+        pendingRowFocusKey.value = rowKey
+        pendingRowFocusIndex.value = 0
+        pendingRowFocusNonce.intValue++
+        backScrollScope.launch {
+            listState?.scrollToItem(0, 0)
+        }
+    }
 
     LaunchedEffect(scrollToTopTrigger) {
         if (scrollToTopTrigger > 0) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeContent.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalView
 import androidx.lifecycle.Lifecycle
@@ -251,9 +252,12 @@ fun ModernHomeContent(
 
     // Improved Back navigation: when focused item is not the first in a row,
     // scroll the row to the start and focus the first item instead of opening the sidebar.
+    // Disabled when the sidebar owns focus (expanded) so Back can exit the app.
     val backScrollScope = rememberCoroutineScope()
+    val contentHasFocus = remember { mutableStateOf(false) }
     val shouldInterceptBack = remember {
         derivedStateOf {
+            if (!contentHasFocus.value) return@derivedStateOf false
             val rowKey = activeRowKey.value ?: return@derivedStateOf false
             val itemIndex = focusedItemByRow[rowKey] ?: 0
             itemIndex > 0
@@ -1170,7 +1174,9 @@ fun ModernHomeContent(
                 onExpansionInteractionNonceChange = onExpansionInteractionNonceChangeLambda,
                 blockLeftOnFirstExpandedItem = blockLeftOnFirstExpandedItem,
                 isVerticalRowsScrollingState = isVerticalRowsScrollingState,
-                modifier = Modifier.align(Alignment.BottomStart)
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .onFocusChanged { contentHasFocus.value = it.hasFocus }
             )
     }
 


### PR DESCRIPTION
## Summary

Improve Back button navigation on home and collection screens.

Home (Modern + Classic + Grid):
- Short Back in a catalog row scrolls to the first item when focus is not already there
- Short Back on CW/Upcoming rows scrolls to the first item (Classic and Grid)
- Short Back when already on the first item opens the sidebar as before
- Long-press Back always opens the sidebar immediately, consuming all key events until released
- Back with sidebar open exits the app 

Collections:
- In tabbed grid collections, Back moves focus from grid to the active tab, then exits
- OK on a tab or switching tabs scrolls grid to top
- In row collections, short Back scrolls to first item, then exits

Technical:
- Long-press Back handled at Activity level via dispatchKeyEvent to prevent cascading through Compose BackHandlers
- ContinueWatchingSection and GridContinueWatchingSection accept external listState parameter for scroll control
- Home content BackHandlers use onFocusChanged to disable when sidebar owns focus
- Separate scroll-to-start triggers for CW and Upcoming rows

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Users reported that pressing Back while browsing a catalog row immediately opens the side menu, forcing them to re-navigate to where they were. The expected TV behavior is that Back first returns focus to the start of the current row, and only then opens the menu. Same issue in collections where Back exits immediately instead of first returning focus to a natural anchor point.

Additionally, long-press Back was cascading through multiple BackHandlers (opening sidebar then immediately exiting the app, or opening sidebar after exiting a collection).

## Issue or approval

User request for improved Back button navigation behavior.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only Back key behavior changed. All other navigation (D-pad, select, menu) unchanged.
- Sidebar open/close logic unchanged - only the trigger path is different.
- No changes to search screen, detail screen, player, or settings Back handling.
- ContinueWatchingSection/GridContinueWatchingSection listState parameter is additive with backward-compatible default

## Testing

- Tested on physical Android TCL TV
- Modern Home: Back scrolls row to first item -> second Back opens sidebar
- Classic Home: same behavior, including catalog rows and CW/Upcoming rows
- Grid Home: CW and Upcoming rows scroll to start on Back
- Long-press Back: opens sidebar immediately from any position
- Long-press Back does not cascade (no exit after sidebar opens, no sidebar after collection exit)
- Back with sidebar open exits the app correctly
- Collection grid with tabs: Back from grid -> tab, Back from tab -> exit, OK on tab -> scroll to top
- Collection rows: Back scrolls to first item -> second Back exits
- Verified normal sidebar open via Left D-pad still works

## Screenshots / Video (UI changes only)

Not a UI change - navigation behavior only.

## Breaking changes

None.

## Linked issues

User request for improved Back button navigation behavior.
