### PR TITLE
i18n(vi): update latest missing strings

### DIFF
--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -469,7 +469,7 @@
     <string name="essential_autoplay_next_episode">Tự động phát tập tiếp theo</string>
     <string name="essential_autoplay_next_episode_subtitle">Tiếp tục phát tập tiếp theo sau khi luồng kết thúc.</string>
     <string name="external_auto_next_loading">Đang tải tập tiếp theo…</string>
-    <string name="essential_p2p_streams">Phát qua P2P</string>
+    <string name="essential_p2p_streams">Luồng P2P</string>
     <string name="essential_p2p_streams_subtitle">Cho phép các nguồn luồng ngang hàng.</string>
     <string name="essential_subtitle_language_subtitle">Ngôn ngữ phụ đề ưu tiên.</string>
     <string name="essential_audio_language_subtitle">Ngôn ngữ âm thanh ưu tiên.</string>
@@ -660,7 +660,7 @@
     <string name="playback_pause_overlay">Lớp phủ Tạm dừng</string>
     <string name="playback_pause_overlay_sub">Hiển thị lớp phủ thông tin sau 5 giây khi đang tạm dừng.</string>
     <string name="playback_show_clock_sub">Hiển thị thời gian hiện tại và thời gian kết thúc khi các thanh điều khiển đang hiện.</string>
-    <string name="playback_osd_clock">Đồng hồ OSD</string>
+    <string name="playback_osd_clock">Đồng hồ hiển thị trên màn hình</string>
     <string name="playback_skip_intro">Bỏ qua Giới thiệu</string>
     <string name="playback_skip_intro_sub">Dùng introdb.app để tự động nhận diện phần giới thiệu và tóm tắt.</string>
     <string name="playback_parental_guide">Cảnh báo nội dung</string>
@@ -716,7 +716,7 @@
     <string name="playback_player_auto">Tự động (Tốt nhất cho Nội dung)</string>
     <string name="playback_player_auto_desc">ExoPlayer cho Phim &amp; Chương trình TV · MPV cho Anime</string>
     <string name="playback_engine_exoplayer_desc">Tương thích tốt nhất với các tính năng hiện có của Nuvio.</string>
-    <string name="playback_engine_mvplayer_desc">Sử dụng libmpv với các điều khiển OSD của Nuvio. Tính năng thử nghiệm.</string>
+    <string name="playback_engine_mvplayer_desc">Sử dụng libmpv với các điều khiển hiển thị trên màn hình của Nuvio. Tính năng thử nghiệm.</string>
 
     <string name="video_section">Video</string>
     <string name="audio_trailer_section">Trailer</string>
@@ -840,7 +840,7 @@
 
     <string name="autoplay_reuse_last_link">Dùng lại liên kết cuối</string>
     <string name="autoplay_reuse_last_link_sub">Tự động phát luồng hoạt động gần nhất cho cùng một phim điện ảnh/tập phim khi bộ nhớ đệm vẫn còn hiệu lực.</string>
-    <string name="autoplay_last_link_cache">Thời gian lưu bộ nhớ đệm của liên kết cuối</string>
+    <string name="autoplay_last_link_cache">Thời gian lưu bộ nhớ đệm liên kết cuối</string>
     <string name="cache_duration_hour_one">%1$d giờ</string>
     <string name="cache_duration_hour_other">%1$d giờ</string>
     <string name="cache_duration_day_one">%1$d ngày</string>
@@ -850,6 +850,8 @@
     <string name="autoplay_mode_first">Tự động phát nguồn đầu tiên</string>
     <string name="autoplay_mode_regex">Tự động phát theo biểu thức chính quy</string>
     <string name="autoplay_stream_selection">Tự động chọn luồng</string>
+    <string name="autoplay_post_play_recommendations">Đề xuất sau khi phát</string>
+    <string name="autoplay_post_play_recommendations_sub">Hiển thị phim và loạt phim được đề xuất khi phát đến cuối.</string>
     <string name="autoplay_next_episode">Tự động phát tập tiếp theo</string>
     <string name="autoplay_next_episode_sub">Tự động phát tập tiếp theo khi lời nhắc xuất hiện.</string>
     <string name="autoplay_next_episode_fallback">Dự phòng khi nhóm phát liên tục bị lỗi</string>
@@ -898,16 +900,16 @@
     <string name="layout_grid">Giao diện lưới</string>
     <string name="layout_modern">Giao diện hiện đại</string>
     <string name="layout_classic_desc">Cuộn qua các danh mục theo chiều ngang</string>
-    <string name="layout_grid_desc">Duyệt toàn bộ nội dung trong lưới dọc với mục Nội dung nổi bật.</string>
-    <string name="layout_modern_desc">Cố định Nội dung nổi bật cùng một hàng đang hoạt động để duyệt nhanh hơn.</string>
+    <string name="layout_grid_desc">Duyệt toàn bộ nội dung trong lưới dọc với Khu vực Nổi bật.</string>
+    <string name="layout_modern_desc">Cố định Khu vực Nổi bật với một hàng đang hoạt động để duyệt nhanh hơn.</string>
     <string name="layout_section_home">Bố cục Trang chủ</string>
-    <string name="layout_section_home_desc">Chọn bố cục và nguồn Nội dung nổi bật.</string>
+    <string name="layout_section_home_desc">Chọn bố cục và nguồn Khu vực Nổi bật.</string>
     <string name="layout_landscape_posters">Poster ngang</string>
     <string name="layout_landscape_posters_sub">Chuyển đổi giữa thẻ dọc và ngang cho kiểu hiển thị Hiện đại.</string>
     <string name="layout_preview_row">Hiển thị hàng xem trước</string>
     <string name="layout_preview_row_sub">Hiển thị một phần bản xem trước của hàng bên dưới trong bố cục Trang chủ Hiện đại.</string>
-    <string name="layout_hero_catalogs">Danh mục Nội dung nổi bật</string>
-    <string name="layout_hero_catalogs_sub">Chọn một hoặc nhiều danh mục cho Nội dung nổi bật.</string>
+    <string name="layout_hero_catalogs">Danh mục Khu vực Nổi bật</string>
+    <string name="layout_hero_catalogs_sub">Chọn một hoặc nhiều danh mục cho nội dung Khu vực Nổi bật.</string>
     <string name="layout_section_content">Nội dung Trang chủ</string>
     <string name="layout_section_content_desc">Kiểm soát nội dung hiển thị trên Trang chủ và tìm kiếm.</string>
     <string name="layout_collapse_sidebar">Thu gọn thanh bên</string>
@@ -916,12 +918,12 @@
     <string name="layout_modern_sidebar_sub">Bật thanh điều hướng nổi.</string>
     <string name="layout_modern_sidebar_blur">Làm mờ Thanh bên Hiện đại</string>
     <string name="layout_modern_sidebar_blur_sub">Bật/tắt hiệu ứng làm mờ thanh bên trong giao diện Hiện đại.</string>
-    <string name="layout_fullscreen_hero_backdrop">Phông nền Nội dung nổi bật toàn màn hình</string>
-    <string name="layout_fullscreen_hero_backdrop_sub">Mở rộng phông nền Nội dung nổi bật để lấp đầy toàn bộ màn hình.</string>
+    <string name="layout_fullscreen_hero_backdrop">Phông nền Khu vực Nổi bật toàn màn hình</string>
+    <string name="layout_fullscreen_hero_backdrop_sub">Mở rộng phông nền Khu vực Nổi bật để lấp đầy toàn bộ màn hình.</string>
     <string name="layout_classic_focus_gradient">Dải màu mục được chọn</string>
     <string name="layout_classic_focus_gradient_sub">Hoà trộn màu ảnh bìa vào phần bên phải của Trang chủ Cổ điển.</string>
-    <string name="layout_show_hero">Hiển thị mục Nội dung nổi bật</string>
-    <string name="layout_show_hero_sub">Hiển thị Nội dung nổi bật dạng vòng quay ở đầu Trang chủ.</string>
+    <string name="layout_show_hero">Hiển thị Khu vực Nổi bật</string>
+    <string name="layout_show_hero_sub">Hiển thị Khu vực Nổi bật dạng vòng quay ở đầu Trang chủ.</string>
     <string name="layout_show_discover">Hiển thị/ẩn mục Khám phá</string>
     <string name="layout_show_discover_sub">Thêm mục Khám phá để duyệt nội dung.</string>
     <string name="layout_discover_location_action">Vị trí Khám phá</string>
@@ -954,10 +956,10 @@
     <string name="layout_section_continue_watching_desc">Cài đặt cho mục Tiếp tục xem</string>
     <string name="layout_cw_enabled">Hiển thị mục Tiếp tục xem</string>
     <string name="layout_cw_enabled_sub">Hiển thị hàng Tiếp tục xem trên màn hình chính.</string>
-    <string name="layout_use_episode_thumbnails_cw">Dùng ảnh thu nhỏ của tập trong Tiếp tục xem.</string>
-    <string name="layout_use_episode_thumbnails_cw_sub">Dùng ảnh thu nhỏ của tập làm hình ảnh mặc định. Khi tắt, sẽ dùng phông nền.</string>
-    <string name="layout_blur_unwatched">Làm mờ tập chưa xem.</string>
-    <string name="layout_blur_unwatched_sub">Làm mờ ảnh thu nhỏ các tập chưa xem để tránh tiết lộ nội dung.</string>
+    <string name="layout_use_episode_thumbnails_cw">Dùng ảnh thu nhỏ của tập phim trong Tiếp tục xem.</string>
+    <string name="layout_use_episode_thumbnails_cw_sub">Dùng ảnh thu nhỏ của tập phim làm hình ảnh mặc định. Khi tắt, sẽ dùng phông nền.</string>
+    <string name="layout_blur_unwatched">Làm mờ tập phim chưa xem.</string>
+    <string name="layout_blur_unwatched_sub">Làm mờ ảnh thu nhỏ các tập phim chưa xem để tránh tiết lộ nội dung.</string>
     <string name="layout_episode_options_overlay">Lớp phủ tùy chọn tập phim</string>
     <string name="layout_episode_options_overlay_sub">Chọn giao diện hiển thị khi nhấn giữ một tập phim.</string>
     <string name="layout_episode_options_overlay_none">Không có</string>
@@ -966,7 +968,7 @@
     <string name="layout_episode_options_overlay_artwork_desc">Sử dụng bố cục toàn màn hình với ảnh bìa tập phim.</string>
     <string name="layout_episode_options_overlay_blur">Làm mờ</string>
     <string name="layout_episode_options_overlay_blur_desc">Sử dụng bố cục toàn màn hình với ảnh bìa tập phim được làm mờ.</string>
-    <string name="layout_blur_cw_next_up">Làm mờ chưa xem trong Tiếp tục xem</string>
+    <string name="layout_blur_cw_next_up">Làm mờ Chưa xem trong Tiếp tục xem</string>
     <string name="layout_blur_cw_next_up_sub">Làm mờ ảnh thu nhỏ tập tiếp theo trong Tiếp tục xem để tránh tiết lộ nội dung.</string>
     <string name="layout_next_up_furthest_episode">Tiếp theo từ tập xa nhất</string>
     <string name="layout_next_up_furthest_episode_sub">Hiển thị tập tiếp theo dựa trên tập xa nhất đã xem. Tắt khi xem lại để dùng tập vừa xem gần nhất.</string>
@@ -1037,7 +1039,7 @@
     <string name="layout_trailer_location">Vị trí phát trailer (Hiện đại)</string>
     <string name="layout_trailer_location_sub">Chọn nơi phát bản xem trước trailer trong Trang chủ Hiện đại..</string>
     <string name="layout_trailer_expanded_card">Thẻ mở rộng</string>
-    <string name="layout_trailer_hero_media">Nội dung nổi bật</string>
+    <string name="layout_trailer_hero_media">Phương tiện Khu vực Nổi bật</string>
     <string name="layout_preset_compact">Thu gọn</string>
     <string name="layout_preset_dense">Dày đặc</string>
     <string name="layout_preset_standard">Tiêu chuẩn</string>
@@ -1058,7 +1060,7 @@
 
 
     <string name="mdblist_title">Điểm đánh giá MDBList</string>
-    <string name="mdblist_subtitle">Cấu hình các điểm đánh giá bên ngoài hiển thị trong chi tiết nổi bật</string>
+    <string name="mdblist_subtitle">Cấu hình các điểm đánh giá bên ngoài hiển thị trong chi tiết của Khu vực Nổi bật</string>
     <string name="mdblist_enable_title">Bật điểm đánh giá MDBList</string>
     <string name="mdblist_enable_subtitle">Lấy điểm đánh giá từ các nhà cung cấp bên ngoài trên màn hình chi tiết siêu dữ liệu</string>
     <string name="mdblist_api_key_title">Khóa API</string>
@@ -1265,7 +1267,7 @@
     <string name="tmdb_enable_title">Bật bổ sung dữ liệu TMDB</string>
     <string name="tmdb_enable_subtitle">Dùng TMDB làm nguồn siêu dữ liệu để bổ sung dữ liệu cho tiện ích</string>
     <string name="tmdb_modern_home_title">Bật trên Trang chủ Hiện đại</string>
-    <string name="tmdb_modern_home_subtitle">Đồng thời áp dụng bổ sung dữ liệu TMDB cho banner Trang chủ Hiện đại và các thẻ được chọn</string>
+    <string name="tmdb_modern_home_subtitle">Đồng thời áp dụng bổ sung dữ liệu TMDB cho Khu vực Nổi bật Trang chủ Hiện đại và các thẻ được chọn</string>
     <string name="tmdb_enrich_continue_watching_title">Bổ sung dữ liệu cho Tiếp tục Xem</string>
     <string name="tmdb_enrich_continue_watching_subtitle">Áp dụng bổ sung dữ liệu TMDB cho các mục Tiếp tục Xem</string>
     <string name="tmdb_language_title">Ngôn ngữ</string>
@@ -1766,6 +1768,15 @@
     <string name="player_next_episode_prompt_message">Bạn có muốn phát tập tiếp theo không?</string>
     <string name="player_next_episode_prompt_yes">Có</string>
     <string name="player_next_episode_prompt_no">Không, quay lại phần chi tiết</string>
+    <string name="player_post_play_because">Vì bạn đã xem %1$s</string>
+    <string name="player_post_play_recommended">Đề xuất cho bạn</string>
+    <string name="player_post_play_play">Phát</string>
+    <string name="player_post_play_previous_recommendation">Đề xuất trước đó</string>
+    <string name="player_post_play_next_recommendation">Đề xuất tiếp theo</string>
+    <string name="player_post_play_return_to_player">Quay lại trình phát</string>
+    <string name="player_post_play_trailer_countdown">Trailer sẽ phát sau %1$d</string>
+    <string name="player_post_play_trailer_playing">Đang phát trailer</string>
+    <string name="player_post_play_trailer">Trailer</string>
     <string name="next_episode_unaired">Chưa phát sóng</string>
     <string name="next_episode_not_aired_yet">Tập tiếp theo chưa phát sóng</string>
     <string name="still_watching_title">Bạn vẫn đang xem chứ?</string>
@@ -2552,10 +2563,10 @@
     <string name="collections_editor_placeholder_cover_image">URL ảnh bìa</string>
     <string name="collections_editor_placeholder_folder">Tên thư mục</string>
     <string name="collections_editor_placeholder_gif">URL ảnh động GIF (chỉ phát khi được chọn)</string>
-    <string name="collections_editor_hero_backdrop">Ảnh phông nền Nội dung nổi bật (Trang chủ Hiện đại)</string>
-    <string name="collections_editor_placeholder_hero_backdrop">URL phông nền Nội dung nổi bật tùy chỉnh (tùy chọn)</string>
-    <string name="collections_editor_hero_video">Video phông nền Nội dung nổi bật (Trang chủ Hiện đại)</string>
-    <string name="collections_editor_placeholder_hero_video">URL video phông nền Nội dung nổi bật tùy chỉnh (tùy chọn)</string>
+    <string name="collections_editor_hero_backdrop">Ảnh phông nền Khu vực Nổi bật (Trang chủ Hiện đại)</string>
+    <string name="collections_editor_placeholder_hero_backdrop">URL phông nền tùy chỉnh Khu vực Nổi bật (tùy chọn)</string>
+    <string name="collections_editor_hero_video">Video phông nền Khu vực Nổi bật (Trang chủ Hiện đại)</string>
+    <string name="collections_editor_placeholder_hero_video">URL video phông nền tùy chỉnh Khu vực Nổi bật (tùy chọn)</string>
     <string name="collections_editor_title_logo">Logo tiêu đề (Trang chủ Hiện đại)</string>
     <string name="collections_editor_placeholder_title_logo">URL logo tiêu đề tùy chỉnh (tùy chọn)</string>
     <string name="collections_editor_search_emoji_placeholder">Tìm kiếm biểu tượng cảm xúc...</string>


### PR DESCRIPTION
## Summary 

Vietnamese (vi) localization update: add the latest missing strings in values-vi/strings.xml. 

## PR type 

- [x] Translation/localization only
- [ ] Critical bug fix 

## Why 

English values/strings.xml on dev added new strings that were missing from Vietnamese. This PR adds those translations so the vi locale stays aligned with dev. 

## Issue or approval 

No linked issue: localization-only update. 

## Reproduction steps 

No reproduction steps - localization-only update. 

## UI / behavior impact 

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval 

## Policy check 

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below. 

## Scope boundaries 

Only app/src/main/res/values-vi/strings.xml was changed. No code, layout, or behavior changes. 

## Testing 

Localization-only update. Verified new strings against English values/strings.xml on dev. Placeholders and translatable="false" strings left unchanged. 

## Screenshots / Video 

Not a UI change 

## Breaking changes 

None 

## Linked issues 

No linked issue - localization-only update.