### PR TITLE
Fix forward seeking near the end of playback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1179,7 +1179,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             if (_playbackTimeline.value.isLive) return
             pendingPreviewSeekPosition = null
             val current = currentPlaybackPositionMs() ?: 0L
-            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 500).coerceAtLeast(0L)
+            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 1000).coerceAtLeast(0L)
             val target = (current + event.deltaMs)
                 .coerceAtLeast(0L)
                 .coerceAtMost(maxDuration)
@@ -1199,7 +1199,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnPreviewSeekBy -> {
             if (_playbackTimeline.value.isLive) return
-            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 500).coerceAtLeast(0L)
+            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 1000).coerceAtLeast(0L)
             val basePosition = pendingPreviewSeekPosition ?: currentPlaybackPositionMs()?.coerceAtLeast(0L) ?: 0L
             val target = (basePosition + event.deltaMs)
                 .coerceAtLeast(0L)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1179,7 +1179,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             if (_playbackTimeline.value.isLive) return
             pendingPreviewSeekPosition = null
             val current = currentPlaybackPositionMs() ?: 0L
-            val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
+            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 500).coerceAtLeast(0L)
             val target = (current + event.deltaMs)
                 .coerceAtLeast(0L)
                 .coerceAtMost(maxDuration)
@@ -1199,7 +1199,7 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         is PlayerEvent.OnPreviewSeekBy -> {
             if (_playbackTimeline.value.isLive) return
-            val maxDuration = currentPlaybackDurationMs().takeIf { it >= 0 } ?: Long.MAX_VALUE
+            val maxDuration = (maxOf(currentPlaybackDurationMs().takeIf { it >= 0 } ?: 0L, _exoPlayer?.bufferedPosition ?: 0L) - 500).coerceAtLeast(0L)
             val basePosition = pendingPreviewSeekPosition ?: currentPlaybackPositionMs()?.coerceAtLeast(0L) ?: 0L
             val target = (basePosition + event.deltaMs)
                 .coerceAtLeast(0L)


### PR DESCRIPTION
## Summary

Fix forward seeking near the end of playback.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

When only a few seconds remain in a video, pressing the Right button to seek forward could unexpectedly move the playback position backward instead.

This fix ensures that seeking forward always moves the playback position forward, even when close to the end of the video.

## Issue or approval

Fixes: #3119 

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
