### PR TITLE
Fix intermittent CI OOM during packaging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8
+# Limits concurrent Gradle worker actions (e.g. APK packaging splitters) to avoid
+# multiple workers spiking memory at the same time and hitting "Java heap space" on CI.
+org.gradle.workers.max=2
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8
-# Limits concurrent Gradle worker actions (e.g. APK packaging splitters) to avoid
-# multiple workers spiking memory at the same time and hitting "Java heap space" on CI.
-org.gradle.workers.max=2
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Summary

Bumps org.gradle.jvmargs heap from -Xmx4096m to -Xmx6144m, adds -XX:MaxMetaspaceSize=1024m. No app code changes.


## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

The pr-full-debug-build workflow intermittently failed at :app:packageFullDebug with Java heap space, while a re-run of the exact same commit succeeded. The build log showed two PackageAndroidArtifact$IncrementalSplitterRunnable worker failures reported at once, indicating multiple packaging workers ran in parallel and together exceeded the available heap — a resource race rather than a deterministic code bug, which is why re-running fixed it.

ubuntu-latest GitHub-hosted runners provide 16GB RAM / 4 cores, so the previous 4GB heap ceiling left little headroom for concurrent worker spikes during packaging. This change:

* Raises the heap ceiling so a single worker spike doesn't exhaust available memory.
* Caps concurrent Gradle workers to 2, reducing the chance of multiple packaging workers competing for memory at the same instant (the root cause seen in the failing log).

## Issue or approval

<!-- Required for critical bug fixes. Link the bug issue. For localization-only PRs with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / No linked issue: localization-only update. -->

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is localization-only. -->

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for critical bug fixes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->
