### PR TITLE
feat(plugins): add 7-day per-provider latency cache

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginManager.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.plugin
 
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.core.plugin.cloudstream.toNuvioType
 import com.nuvio.tv.core.plugin.cloudstream.tvTypeFromString
@@ -7,6 +8,7 @@ import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionLoader
 import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionRunner
 import com.nuvio.tv.core.plugin.cloudstream.ExternalRepoParser
 import com.nuvio.tv.data.local.PluginDataStore
+import com.nuvio.tv.data.local.ScraperLatencyDataStore
 import com.nuvio.tv.domain.model.ExternalPluginEntry
 import com.nuvio.tv.domain.model.LocalScraperResult
 import com.nuvio.tv.domain.model.PluginManifest
@@ -56,7 +58,7 @@ private const val MAX_RESPONSE_SIZE = 5 * 1024 * 1024L
 // at 60s and returns partial links. This outer cap only fires if the runner hangs
 // outside of loadLinks (e.g. slow TMDB enrichment, slow search). Generous to avoid
 // cancelling the runner's coroutine before it can return accumulated links.
-private const val SCRAPER_TIMEOUT_MS = 120_000L
+private const val SCRAPER_TIMEOUT_MS = ScraperLatencyPolicy.TIMEOUT_MS
 private const val MANIFEST_SUFFIX = "/manifest.json"
 
 @Singleton
@@ -67,7 +69,8 @@ class PluginManager @Inject constructor(
     private val authManager: com.nuvio.tv.core.auth.AuthManager,
     private val externalRepoParser: ExternalRepoParser,
     private val externalExtensionLoader: ExternalExtensionLoader,
-    private val externalExtensionRunner: ExternalExtensionRunner
+    private val externalExtensionRunner: ExternalExtensionRunner,
+    private val scraperLatencyDataStore: ScraperLatencyDataStore
 ) {
     private val moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
@@ -639,6 +642,11 @@ class PluginManager @Inject constructor(
     suspend fun setGroupStreamsByRepository(enabled: Boolean) {
         dataStore.setGroupStreamsByRepository(enabled)
     }
+
+    private suspend fun rankScrapersByLatency(scrapers: List<ScraperInfo>): List<ScraperInfo> {
+        val snapshot = runCatching { scraperLatencyDataStore.snapshot() }.getOrElse { emptyMap() }
+        return ScraperLatencyPolicy.rankByCachedLatency(scrapers, ScraperInfo::id, snapshot)
+    }
     
     /**
      * Execute all enabled scrapers for a given media
@@ -653,8 +661,9 @@ class PluginManager @Inject constructor(
             return@coroutineScope emptyList()
         }
         
-        val enabledScraperList = enabledScrapers.first()
-            .filter { it.supportsType(mediaType) }
+        val enabledScraperList = rankScrapersByLatency(
+            enabledScrapers.first().filter { it.supportsType(mediaType) }
+        )
         
         if (enabledScraperList.isEmpty()) {
             return@coroutineScope emptyList()
@@ -701,8 +710,9 @@ class PluginManager @Inject constructor(
         season: Int? = null,
         episode: Int? = null
     ): Flow<Pair<ScraperInfo, List<LocalScraperResult>>> = channelFlow {
-        val enabledList = enabledScrapers.first()
-            .filter { it.supportsType(mediaType) }
+        val enabledList = rankScrapersByLatency(
+            enabledScrapers.first().filter { it.supportsType(mediaType) }
+        )
         
         if (enabledList.isEmpty() || !dataStore.pluginsEnabled.first()) {
             return@channelFlow
@@ -731,6 +741,8 @@ class PluginManager @Inject constructor(
                     if (results.isNotEmpty()) {
                         send(scraper to results)
                     }
+                } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                    throw cancelled
                 } catch (e: Exception) {
                     Log.e(TAG, "Scraper ${scraper.name} failed in streaming: ${e.message}")
                 }
@@ -763,8 +775,26 @@ class PluginManager @Inject constructor(
         // Create new deferred
         return coroutineScope {
             val deferred = async {
-                scraperSemaphore.withPermit {
-                    executeScraper(scraper, tmdbId, mediaType, season, episode)
+                val startedAt = SystemClock.elapsedRealtime()
+                try {
+                    scraperSemaphore.withPermit {
+                        executeScraper(scraper, tmdbId, mediaType, season, episode)
+                    }.also { results ->
+                        scraperLatencyDataStore.record(
+                            scraper.id,
+                            SystemClock.elapsedRealtime() - startedAt,
+                            success = true
+                        )
+                    }
+                } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                    throw cancelled
+                } catch (e: Exception) {
+                    scraperLatencyDataStore.record(
+                        scraper.id,
+                        SystemClock.elapsedRealtime() - startedAt,
+                        success = false
+                    )
+                    throw e
                 }
             }
             
@@ -772,6 +802,8 @@ class PluginManager @Inject constructor(
             
             try {
                 deferred.await()
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                throw cancelled
             } catch (e: Exception) {
                 Log.e(TAG, "Scraper ${scraper.name} failed: ${e.message}")
                 emptyList()
@@ -808,7 +840,7 @@ class PluginManager @Inject constructor(
             val code = dataStore.getScraperCode(scraper.id)
             if (code.isNullOrBlank()) {
                 Log.w(TAG, "No code found for scraper: ${scraper.name}")
-                return emptyList()
+                error("No code found for scraper: ${scraper.name}")
             }
 
             // Debug: confirm which exact JS code is running on-device.
@@ -846,15 +878,17 @@ class PluginManager @Inject constructor(
 
             if (results == null) {
                 Log.w(TAG, "Scraper ${scraper.name} timed out after ${SCRAPER_TIMEOUT_MS}ms")
-                return emptyList()
+                error("Scraper ${scraper.name} timed out")
             }
 
             Log.d(TAG, "Scraper ${scraper.name} returned ${results.size} results")
             results.map { it.copy(provider = scraper.name) }
 
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            throw cancelled
         } catch (e: Exception) {
             Log.e(TAG, "Failed to execute scraper ${scraper.name}: ${e.message}", e)
-            emptyList()
+            throw e
         }
     }
 
@@ -877,13 +911,15 @@ class PluginManager @Inject constructor(
             }
             if (results == null) {
                 Log.w(TAG, "DEX scraper ${scraper.name} timed out after ${SCRAPER_TIMEOUT_MS}ms")
-                return emptyList()
+                error("DEX scraper ${scraper.name} timed out")
             }
             Log.d(TAG, "DEX scraper ${scraper.name} returned ${results.size} results")
             results.map { it.copy(provider = scraper.name) }
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            throw cancelled
         } catch (e: Exception) {
             Log.e(TAG, "Failed to execute DEX scraper ${scraper.name}: ${e.message}", e)
-            emptyList()
+            throw e
         }
     }
     

--- a/app/src/full/java/com/nuvio/tv/di/PluginModule.kt
+++ b/app/src/full/java/com/nuvio/tv/di/PluginModule.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.core.plugin.cloudstream.ExternalExtensionRunner
 import com.nuvio.tv.core.plugin.cloudstream.ExternalRepoParser
 import com.nuvio.tv.core.sync.PluginSyncService
 import com.nuvio.tv.data.local.PluginDataStore
+import com.nuvio.tv.data.local.ScraperLatencyDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -33,11 +34,13 @@ object PluginModule {
         authManager: AuthManager,
         externalRepoParser: ExternalRepoParser,
         externalExtensionLoader: ExternalExtensionLoader,
-        externalExtensionRunner: ExternalExtensionRunner
+        externalExtensionRunner: ExternalExtensionRunner,
+        scraperLatencyDataStore: ScraperLatencyDataStore
     ): PluginManager {
         return PluginManager(
             dataStore, runtime, pluginSyncService, authManager,
-            externalRepoParser, externalExtensionLoader, externalExtensionRunner
+            externalRepoParser, externalExtensionLoader, externalExtensionRunner,
+            scraperLatencyDataStore
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/plugin/ScraperLatencyPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/core/plugin/ScraperLatencyPolicy.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.core.plugin
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlin.math.roundToLong
+
+/**
+ * Ranking and TTL rules for per-provider scraper latency.
+ * Keys are scraper/plugin ids already used elsewhere in the app ([com.nuvio.tv.domain.model.ScraperInfo.id]).
+ */
+object ScraperLatencyPolicy {
+    const val TTL_MS = 7L * 24L * 60L * 60L * 1000L
+    const val EMA_ALPHA = 0.3
+    const val TIMEOUT_MS = 120_000L
+    const val FAILURE_PENALTY_MS = TIMEOUT_MS
+    const val UNKNOWN_DEFAULT_MS = 10_000L
+
+    fun recordedDurationMs(durationMs: Long, success: Boolean): Long {
+        val safe = durationMs.coerceAtLeast(0L)
+        return if (success) safe else maxOf(safe, FAILURE_PENALTY_MS)
+    }
+
+    fun nextEmaMs(previousEmaMs: Long?, previousSamples: Int, recordedMs: Long): Long {
+        if (previousSamples <= 0 || previousEmaMs == null) return recordedMs
+        return (EMA_ALPHA * recordedMs + (1.0 - EMA_ALPHA) * previousEmaMs).roundToLong()
+    }
+
+    fun isFresh(updatedAtMs: Long, nowMs: Long, ttlMs: Long = TTL_MS): Boolean {
+        return updatedAtMs > 0L && nowMs - updatedAtMs in 0L..ttlMs
+    }
+
+    fun unknownSentinelMs(knownLatenciesMs: Collection<Long>): Long {
+        if (knownLatenciesMs.isEmpty()) return UNKNOWN_DEFAULT_MS
+        val sorted = knownLatenciesMs.sorted()
+        val mid = sorted.size / 2
+        return if (sorted.size % 2 == 0) {
+            (sorted[mid - 1] + sorted[mid]) / 2
+        } else {
+            sorted[mid]
+        }
+    }
+
+    fun <T> rankByCachedLatency(
+        items: List<T>,
+        idOf: (T) -> String,
+        snapshot: Map<String, Long>
+    ): List<T> {
+        val sentinel = unknownSentinelMs(snapshot.values)
+        return items.sortedWith(compareBy { snapshot[idOf(it)] ?: sentinel })
+    }
+
+    /**
+     * Run [execute] for every item concurrently and emit as each finishes.
+     * Does not join all work before the first emission.
+     */
+    fun <T, R> streamAsEachCompletes(
+        items: List<T>,
+        execute: suspend (T) -> R
+    ): Flow<Pair<T, R>> = channelFlow {
+        items.forEach { item ->
+            launch {
+                send(item to execute(item))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/ScraperLatencyDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/ScraperLatencyDataStore.kt
@@ -1,0 +1,88 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.nuvio.tv.core.plugin.ScraperLatencyPolicy
+import com.nuvio.tv.core.profile.ProfileManager
+import kotlinx.coroutines.flow.first
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * On-device per-provider scraper latency cache.
+ * Entries expire after [ScraperLatencyPolicy.TTL_MS] (7 days) and are keyed by scraper id.
+ */
+@Singleton
+class ScraperLatencyDataStore(
+    private val factory: ProfileDataStoreFactory,
+    private val profileManager: ProfileManager,
+    private val currentTimeMs: () -> Long
+) {
+    @Inject
+    constructor(
+        factory: ProfileDataStoreFactory,
+        profileManager: ProfileManager
+    ) : this(factory, profileManager, { System.currentTimeMillis() })
+
+    companion object {
+        private const val FEATURE = "scraper_latency"
+        private val LATENCY_KEY = stringPreferencesKey("scraper_latency")
+    }
+
+    private fun store(profileId: Int = profileManager.activeProfileId.value) =
+        factory.get(profileId, FEATURE)
+
+    suspend fun record(scraperId: String, durationMs: Long, success: Boolean = true) {
+        val now = currentTimeMs()
+        val recordedMs = ScraperLatencyPolicy.recordedDurationMs(durationMs, success)
+        store().edit { prefs ->
+            val root = prefs[LATENCY_KEY]?.let { raw ->
+                runCatching { JSONObject(raw) }.getOrNull()
+            } ?: JSONObject()
+
+            val existing = root.optJSONObject(scraperId)
+            val previousSamples = existing?.optInt("samples", 0) ?: 0
+            val previousEma = existing?.optLong("emaMs", recordedMs) ?: recordedMs
+            val emaMs = ScraperLatencyPolicy.nextEmaMs(
+                previousEmaMs = if (previousSamples <= 0) null else previousEma,
+                previousSamples = previousSamples,
+                recordedMs = recordedMs
+            )
+
+            val expired = mutableListOf<String>()
+            root.keys().forEach { key ->
+                if (key == scraperId) return@forEach
+                val entry = root.optJSONObject(key) ?: return@forEach
+                val updatedAt = entry.optLong("updatedAtMs", 0L)
+                if (!ScraperLatencyPolicy.isFresh(updatedAt, now)) {
+                    expired += key
+                }
+            }
+            expired.forEach { root.remove(it) }
+
+            root.put(scraperId, JSONObject().apply {
+                put("emaMs", emaMs)
+                put("lastMs", recordedMs)
+                put("updatedAtMs", now)
+                put("samples", previousSamples + 1)
+            })
+            prefs[LATENCY_KEY] = root.toString()
+        }
+    }
+
+    suspend fun snapshot(): Map<String, Long> {
+        val now = currentTimeMs()
+        val raw = store().data.first()[LATENCY_KEY] ?: return emptyMap()
+        val root = runCatching { JSONObject(raw) }.getOrNull() ?: return emptyMap()
+        val result = mutableMapOf<String, Long>()
+        root.keys().forEach { key ->
+            val entry = root.optJSONObject(key) ?: return@forEach
+            val updatedAt = entry.optLong("updatedAtMs", 0L)
+            if (ScraperLatencyPolicy.isFresh(updatedAt, now)) {
+                result[key] = entry.optLong("emaMs", 0L)
+            }
+        }
+        return result
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/core/plugin/ScraperLatencyPolicyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/plugin/ScraperLatencyPolicyTest.kt
@@ -1,0 +1,127 @@
+package com.nuvio.tv.core.plugin
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.delay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScraperLatencyPolicyTest {
+
+    @Test
+    fun `faster completions rank ahead of slower ones`() {
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("slow", "medium", "fast"),
+            idOf = { it },
+            snapshot = mapOf(
+                "fast" to 120L,
+                "medium" to 800L,
+                "slow" to 4_000L
+            )
+        )
+        assertEquals(listOf("fast", "medium", "slow"), ranked)
+    }
+
+    @Test
+    fun `failed instant-error providers do not outrank real successes`() {
+        val failedMs = ScraperLatencyPolicy.recordedDurationMs(durationMs = 4L, success = false)
+        val successMs = ScraperLatencyPolicy.recordedDurationMs(durationMs = 850L, success = true)
+        assertEquals(ScraperLatencyPolicy.FAILURE_PENALTY_MS, failedMs)
+        assertEquals(850L, successMs)
+
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("instant-404", "real-success"),
+            idOf = { it },
+            snapshot = mapOf(
+                "instant-404" to failedMs,
+                "real-success" to successMs
+            )
+        )
+        assertEquals(listOf("real-success", "instant-404"), ranked)
+    }
+
+    @Test
+    fun `failure penalty matches scraper timeout so slow successes still rank first`() {
+        assertEquals(120_000L, ScraperLatencyPolicy.FAILURE_PENALTY_MS)
+        assertEquals(ScraperLatencyPolicy.TIMEOUT_MS, ScraperLatencyPolicy.FAILURE_PENALTY_MS)
+        val failedMs = ScraperLatencyPolicy.recordedDurationMs(durationMs = 4L, success = false)
+        val slowSuccessMs = ScraperLatencyPolicy.recordedDurationMs(durationMs = 90_000L, success = true)
+        assertTrue(slowSuccessMs < failedMs)
+    }
+
+
+    @Test
+    fun `missing unknown provider uses sentinel and does not wait behind slow ones`() {
+        val snapshot = mapOf("fast" to 100L, "slow" to 9_000L)
+        val sentinel = ScraperLatencyPolicy.unknownSentinelMs(snapshot.values)
+        assertEquals(4_550L, sentinel)
+
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("slow", "unknown", "fast"),
+            idOf = { it },
+            snapshot = snapshot
+        )
+        assertEquals(listOf("fast", "unknown", "slow"), ranked)
+    }
+
+    @Test
+    fun `unknown default is used when cache is empty`() {
+        assertEquals(
+            ScraperLatencyPolicy.UNKNOWN_DEFAULT_MS,
+            ScraperLatencyPolicy.unknownSentinelMs(emptyList())
+        )
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("b", "a"),
+            idOf = { it },
+            snapshot = emptyMap()
+        )
+        assertEquals(listOf("b", "a"), ranked)
+    }
+
+    @Test
+    fun `seven day ttl marks stale versus fresh`() {
+        val now = 1_700_000_000_000L
+        val ttl = ScraperLatencyPolicy.TTL_MS
+        assertEquals(7L * 24L * 60L * 60L * 1000L, ttl)
+        assertTrue(ScraperLatencyPolicy.isFresh(updatedAtMs = now, nowMs = now, ttlMs = ttl))
+        assertTrue(ScraperLatencyPolicy.isFresh(updatedAtMs = now - ttl, nowMs = now, ttlMs = ttl))
+        assertFalse(ScraperLatencyPolicy.isFresh(updatedAtMs = now - ttl - 1L, nowMs = now, ttlMs = ttl))
+        assertFalse(ScraperLatencyPolicy.isFresh(updatedAtMs = 0L, nowMs = now, ttlMs = ttl))
+    }
+
+    @Test
+    fun `fast providers emit without waiting for slow ones`() = runTest {
+        val slowHold = CompletableDeferred<Unit>()
+        val seen = mutableListOf<String>()
+        val job = launch {
+            ScraperLatencyPolicy.streamAsEachCompletes(listOf("slow", "fast")) { id ->
+                if (id == "slow") slowHold.await() else id
+                id
+            }.collect { seen += it.first }
+        }
+
+        testScheduler.runCurrent()
+        assertEquals(listOf("fast"), seen)
+        assertTrue(job.isActive)
+
+        slowHold.complete(Unit)
+        job.join()
+        assertEquals(listOf("fast", "slow"), seen)
+    }
+
+    @Test
+    fun `stream emits fast completion before slow without join-all`() = runTest {
+        val order = ScraperLatencyPolicy.streamAsEachCompletes(
+            items = listOf("slow", "fast")
+        ) { id ->
+            if (id == "slow") delay(1_000) else delay(10)
+            id
+        }.toList().map { it.first }
+
+        assertEquals(listOf("fast", "slow"), order)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/local/ScraperLatencyDataStoreTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/local/ScraperLatencyDataStoreTest.kt
@@ -1,0 +1,140 @@
+package com.nuvio.tv.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import com.nuvio.tv.core.plugin.ScraperLatencyPolicy
+import com.nuvio.tv.core.profile.ProfileManager
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScraperLatencyDataStoreTest {
+
+    @Test
+    fun `per provider cache write then read`() = runTest {
+        val harness = harness(nowMs = 1_000L)
+        harness.store.record("provider-a", durationMs = 250L, success = true)
+        harness.store.record("provider-b", durationMs = 1_200L, success = true)
+
+        val snapshot = harness.store.snapshot()
+        assertEquals(250L, snapshot["provider-a"])
+        assertEquals(1_200L, snapshot["provider-b"])
+        assertEquals(2, snapshot.size)
+    }
+
+    @Test
+    fun `seven day ttl expiry stale versus fresh`() = runTest {
+        val now = MutableStateFlow(10_000L)
+        val harness = harness { now.value }
+
+        harness.store.record("fresh", durationMs = 300L, success = true)
+        now.value = 10_000L + ScraperLatencyPolicy.TTL_MS
+        harness.store.record("still-fresh-edge", durationMs = 400L, success = true)
+
+        var snapshot = harness.store.snapshot()
+        assertTrue(snapshot.containsKey("fresh"))
+        assertTrue(snapshot.containsKey("still-fresh-edge"))
+
+        now.value = 10_000L + ScraperLatencyPolicy.TTL_MS + 1L
+        snapshot = harness.store.snapshot()
+        assertFalse(snapshot.containsKey("fresh"))
+        assertTrue(snapshot.containsKey("still-fresh-edge"))
+        assertEquals(400L, snapshot["still-fresh-edge"])
+    }
+
+    @Test
+    fun `failed providers are penalized so they do not rank first`() = runTest {
+        val harness = harness(nowMs = 50L)
+        harness.store.record("npe-provider", durationMs = 2L, success = false)
+        harness.store.record("ok-provider", durationMs = 900L, success = true)
+
+        val snapshot = harness.store.snapshot()
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("npe-provider", "ok-provider"),
+            idOf = { it },
+            snapshot = snapshot
+        )
+        assertEquals(ScraperLatencyPolicy.FAILURE_PENALTY_MS, snapshot["npe-provider"])
+        assertEquals(900L, snapshot["ok-provider"])
+        assertEquals(listOf("ok-provider", "npe-provider"), ranked)
+    }
+
+    @Test
+    fun `empty successful scrape is not penalized`() = runTest {
+        val harness = harness(nowMs = 50L)
+        harness.store.record("empty-ok", durationMs = 400L, success = true)
+        harness.store.record("crash", durationMs = 2L, success = false)
+
+        val snapshot = harness.store.snapshot()
+        assertEquals(400L, snapshot["empty-ok"])
+        assertEquals(ScraperLatencyPolicy.FAILURE_PENALTY_MS, snapshot["crash"])
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("crash", "empty-ok"),
+            idOf = { it },
+            snapshot = snapshot
+        )
+        assertEquals(listOf("empty-ok", "crash"), ranked)
+    }
+
+    @Test
+    fun `unknown provider is absent from snapshot and ranks by default sentinel`() = runTest {
+        val harness = harness(nowMs = 50L)
+        harness.store.record("known-fast", durationMs = 100L, success = true)
+        harness.store.record("known-slow", durationMs = 8_000L, success = true)
+
+        val snapshot = harness.store.snapshot()
+        assertFalse(snapshot.containsKey("brand-new"))
+
+        val ranked = ScraperLatencyPolicy.rankByCachedLatency(
+            items = listOf("known-slow", "brand-new", "known-fast"),
+            idOf = { it },
+            snapshot = snapshot
+        )
+        assertEquals(listOf("known-fast", "brand-new", "known-slow"), ranked)
+    }
+
+    private fun harness(nowMs: Long): Harness = harness { nowMs }
+
+    private fun harness(clock: () -> Long): Harness {
+        val prefs = TestPreferencesDataStore()
+        val factory = mockk<ProfileDataStoreFactory>()
+        every { factory.get(any(), any()) } returns prefs
+        val profileManager = mockk<ProfileManager>()
+        every { profileManager.activeProfileId } returns MutableStateFlow(1)
+        return Harness(
+            store = ScraperLatencyDataStore(factory, profileManager, clock),
+            prefs = prefs
+        )
+    }
+
+    private data class Harness(
+        val store: ScraperLatencyDataStore,
+        val prefs: TestPreferencesDataStore
+    )
+
+    private class TestPreferencesDataStore(
+        initial: Preferences = emptyPreferences()
+    ) : DataStore<Preferences> {
+        private val mutex = Mutex()
+        private val state = MutableStateFlow(initial)
+
+        override val data: Flow<Preferences> = state
+
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+            return mutex.withLock {
+                transform(state.value).also { updated ->
+                    state.value = updated
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a 7-day on-device per-provider scraper latency cache. Enabled scrapers are ranked by cached EMA completion time so previously fast providers start first, and streaming still emits as each scraper finishes instead of waiting on slow ones. Instant failures and timeouts are recorded with a 120s penalty matching `SCRAPER_TIMEOUT_MS`. An empty stream list is a successful completion, not a failure. The Play Store stub `PluginManager` is unchanged.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Scrapers were launched in list order with no memory of which providers actually finish first. Slow or instantly-failing plugins competed equally with fast ones, so the first usable streams were delayed and a one-off 404/parse/timeout could look "fast" on the next title. There was no device-side TTL ranking keyed by provider id.

## Issue or approval

No GitHub issue number. Problem: plugin/scraper execution did not persist per-provider completion time, so ranking could not prefer fast providers, fast results waited on slow ones in practice, and empty "no streams for this title" was treated the same as a crash.

## Reproduction steps

1. Enable many scrapers (50+ providers) and open a title that several of them support.
2. Note first-stream wait: slow or dead plugins occupy early slots, and a plugin that 404s in milliseconds can rank ahead of a provider that returns real links in 1-2s.
3. Open a second title on the same device within 7 days.
4. Before: order is unchanged, fast providers are not preferred, empty results can be penalized like failures. After: providers are ordered by cached EMA, streaming emits as each finishes, timeouts/crashes get a 120s penalty, empty successful scrapes keep measured duration.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Full flavor only: `PluginManager` streaming/batch ranking, `ScraperLatencyDataStore`, and `ScraperLatencyPolicy`. Does not change Play Store stub plugins, concurrency limiter / CW prewarm from `feat/plugin-latency-scheduler`, extractor loading, or UI screens.

## Testing

- `.\gradlew.bat :app:testFullDebugUnitTest --tests com.nuvio.tv.core.plugin.ScraperLatencyPolicyTest --tests com.nuvio.tv.data.local.ScraperLatencyDataStoreTest --offline`
- Policy tests: rank order, 7-day TTL fresh vs stale, 120s failure penalty vs slow success, unknown provider sentinel, non-blocking fast-before-slow emit, empty successful scrape not penalized.
- DataStore tests: per-provider write/read, 7-day expiry, failure ranking, unknown absent from snapshot, empty success vs crash.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Plugin/scraper runs had no per-provider on-device latency cache, so completion order was not reused, fast providers were not started first, slow plugins delayed useful streams, instant failures could outrank real successes, and an empty result for a title was treated like a crash. This PR stores EMA latency per scraper id for 7 days, ranks by that snapshot, uses a 120s timeout penalty for failures only, and leaves the Play Store build behavior unchanged.
