### PR TITLE
[Feature]: Support streaming addon results with NDJSON

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
+++ b/app/src/main/java/com/nuvio/tv/core/debrid/DirectDebridStreamFilter.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.core.debrid
 
+import com.nuvio.tv.core.streams.StreamResolution
 import com.nuvio.tv.domain.model.DebridSettings
 import com.nuvio.tv.domain.model.DebridStreamAudioChannel
 import com.nuvio.tv.domain.model.DebridStreamAudioTag
@@ -237,17 +238,8 @@ object DirectDebridStreamFilter {
     }
 
     private fun resolutionValue(value: String?): DebridStreamResolution? {
-        val normalized = value?.lowercase().orEmpty()
-        return when {
-            normalized.hasResolutionToken("2160p?", "4k", "uhd") -> DebridStreamResolution.P2160
-            normalized.hasResolutionToken("1440p?", "2k") -> DebridStreamResolution.P1440
-            normalized.hasResolutionToken("1080p?", "fhd") -> DebridStreamResolution.P1080
-            normalized.hasResolutionToken("720p?", "hd") -> DebridStreamResolution.P720
-            normalized.hasResolutionToken("576p?") -> DebridStreamResolution.P576
-            normalized.hasResolutionToken("480p?", "sd") -> DebridStreamResolution.P480
-            normalized.hasResolutionToken("360p?") -> DebridStreamResolution.P360
-            else -> null
-        }
+        val height = StreamResolution.detect(value) ?: return null
+        return DebridStreamResolution.entries.firstOrNull { resolution -> resolution.value == height }
     }
 
     private fun streamQuality(parsedQuality: String?, searchText: String): DebridStreamQuality {
@@ -354,10 +346,6 @@ object DirectDebridStreamFilter {
 
     private fun <T> rankAny(values: List<T>, preferred: List<T>): Int {
         return values.minOfOrNull { rank(it, preferred) } ?: Int.MAX_VALUE
-    }
-
-    private fun String.hasResolutionToken(vararg tokens: String): Boolean {
-        return Regex("(^|[^a-z0-9])(${tokens.joinToString("|")})([^a-z0-9]|\$)").containsMatchIn(this)
     }
 
     private fun String.hasToken(token: String): Boolean {

--- a/app/src/main/java/com/nuvio/tv/core/streams/StreamResolution.kt
+++ b/app/src/main/java/com/nuvio/tv/core/streams/StreamResolution.kt
@@ -1,0 +1,58 @@
+package com.nuvio.tv.core.streams
+
+/**
+ * Aliases used by release names, ordered from highest to lowest resolution so a
+ * label carrying several tokens resolves to the best one it advertises.
+ */
+private val RESOLUTION_ALIASES: List<Pair<Int, Regex>> = listOf(
+    2160 to listOf("2160p?", "4k", "uhd"),
+    1440 to listOf("1440p?", "2k"),
+    1080 to listOf("1080p?", "fhd"),
+    720 to listOf("720p?", "hd"),
+    576 to listOf("576p?"),
+    480 to listOf("480p?", "sd"),
+    360 to listOf("360p?")
+).map { (height, tokens) ->
+    height to Regex("(^|[^a-z0-9])(${tokens.joinToString("|")})([^a-z0-9]|$)")
+}
+
+/** Catches heights without a dedicated alias, e.g. `540p` or `800p`. */
+private val GENERIC_RESOLUTION_REGEX = Regex("(^|[^a-z0-9])(\\d{3,4})p([^a-z0-9]|$)")
+
+private val PLAUSIBLE_HEIGHTS = 100..4320
+
+/**
+ * Canonical resolution detection for stream labels. Addon stream mapping, local
+ * plugin results and debrid filtering all resolve heights through here so a
+ * label is graded the same way everywhere.
+ */
+object StreamResolution {
+
+    /**
+     * Returns the resolution height advertised by the first label that carries
+     * one, mirroring the label priority callers pass in (name before title
+     * before description), or `null` when nothing recognisable is present.
+     */
+    fun detect(vararg labels: String?): Int? =
+        labels.firstNotNullOfOrNull { label -> detectIn(label) }
+
+    private fun detectIn(label: String?): Int? {
+        val text = label?.lowercase()?.trim().orEmpty()
+        if (text.isEmpty()) return null
+
+        RESOLUTION_ALIASES.forEach { (height, regex) ->
+            if (regex.containsMatchIn(text)) return height
+        }
+
+        GENERIC_RESOLUTION_REGEX.find(text)
+            ?.groupValues
+            ?.get(2)
+            ?.toIntOrNull()
+            ?.takeIf { height -> height in PLAUSIBLE_HEIGHTS }
+            ?.let { height -> return height }
+
+        // Bare numeric labels such as "800" only count when that is the whole value,
+        // so years and sizes inside free text are never mistaken for a resolution.
+        return text.toIntOrNull()?.takeIf { height -> height in PLAUSIBLE_HEIGHTS }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
@@ -1,5 +1,6 @@
 package com.nuvio.tv.data.mapper
 
+import com.nuvio.tv.core.streams.StreamResolution
 import com.nuvio.tv.data.remote.dto.BehaviorHintsDto
 import com.nuvio.tv.data.remote.dto.ProxyHeadersDto
 import com.nuvio.tv.data.remote.dto.StreamClientResolveParsedDto
@@ -15,21 +16,30 @@ import com.nuvio.tv.domain.model.StreamClientResolveParsed
 import com.nuvio.tv.domain.model.StreamClientResolveRaw
 import com.nuvio.tv.domain.model.StreamClientResolveStream
 
-fun StreamDto.toDomain(addonName: String, addonLogo: String?): Stream = Stream(
-    name = name,
-    title = title,
-    description = description,
-    url = url,
-    ytId = ytId,
-    infoHash = infoHash,
-    fileIdx = fileIdx,
-    externalUrl = externalUrl,
-    behaviorHints = behaviorHints?.toDomain(),
-    addonName = addonName,
-    addonLogo = addonLogo,
-    sources = sources,
-    clientResolve = clientResolve?.toDomain()
-)
+fun StreamDto.toDomain(addonName: String, addonLogo: String?): Stream {
+    val detectedQuality = detectQuality(name, title, description)
+    return Stream(
+        name = name,
+        title = title,
+        description = description,
+        url = url,
+        ytId = ytId,
+        infoHash = infoHash,
+        fileIdx = fileIdx,
+        externalUrl = externalUrl,
+        behaviorHints = behaviorHints?.toDomain(),
+        addonName = addonName,
+        addonLogo = addonLogo,
+        sources = sources,
+        quality = detectedQuality?.first,
+        qualityValue = detectedQuality?.second ?: -1,
+        clientResolve = clientResolve?.toDomain()
+    )
+}
+
+/** Detects the stream resolution from the addon-provided labels. */
+internal fun detectQuality(vararg labels: String?): Pair<String, Int>? =
+    StreamResolution.detect(*labels)?.let { height -> "${height}p" to height }
 
 fun StreamClientResolveDto.toDomain(): StreamClientResolve = StreamClientResolve(
     type = type,

--- a/app/src/main/java/com/nuvio/tv/data/remote/NdjsonStreamFetcher.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/NdjsonStreamFetcher.kt
@@ -1,0 +1,98 @@
+package com.nuvio.tv.data.remote
+
+import android.util.Log
+import com.squareup.moshi.JsonAdapter
+import com.nuvio.tv.data.remote.dto.StreamDto
+import com.nuvio.tv.data.remote.dto.StreamResponseDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.coroutineContext
+
+private const val TAG = "NdjsonStreamFetcher"
+
+const val NDJSON_CONTENT_TYPE = "application/x-ndjson"
+
+/**
+ * Raised when a stream response fails, carrying the HTTP status so callers can
+ * classify failures the same way [com.nuvio.tv.core.network.safeApiCall] does.
+ */
+class NdjsonHttpException(
+    val code: Int,
+    override val message: String
+) : IOException(message)
+
+fun isNdjsonContentType(contentType: String?): Boolean =
+    contentType
+        ?.substringBefore(';')
+        ?.trim()
+        ?.equals(NDJSON_CONTENT_TYPE, ignoreCase = true) == true
+
+/**
+ * Parses one NDJSON stream response object; malformed payloads yield an empty list.
+ */
+fun parseNdjsonStreamDtos(
+    adapter: JsonAdapter<StreamResponseDto>,
+    payload: String
+): List<StreamDto> {
+    val trimmed = payload.trim()
+    if (trimmed.isEmpty()) return emptyList()
+    return try {
+        adapter.fromJson(trimmed)?.streams ?: emptyList()
+    } catch (e: Exception) {
+        Log.d(TAG, "Failed to parse NDJSON line: ${e.message} payload=${trimmed.take(200)}")
+        emptyList()
+    }
+}
+
+
+/**
+ * Streams an HTTP response body line by line, reporting the Content-Type first.
+ */
+@Singleton
+class NdjsonStreamFetcher @Inject constructor(
+    okHttpClient: OkHttpClient
+) {
+    /**
+     * Shares the addon client's connection pool, interceptors and cache, but drops
+     * the read timeout: an incremental response is idle between batches by design,
+     * and the inherited 60s cap would abort long-running searches.
+     */
+    private val streamingClient: OkHttpClient = okHttpClient.newBuilder()
+        .readTimeout(0, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun fetchLines(
+        url: String,
+        onContentType: (contentType: String?) -> Unit,
+        onLine: suspend (line: String) -> Unit
+    ): Unit = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json, $NDJSON_CONTENT_TYPE")
+            .build()
+
+        streamingClient.newCall(request).execute().use { response ->
+            onContentType(response.header("Content-Type"))
+            if (!response.isSuccessful) {
+                throw NdjsonHttpException(
+                    code = response.code,
+                    message = response.message.ifBlank { "HTTP ${response.code}" }
+                )
+            }
+            val source = response.body?.source() ?: throw IOException("Empty response body")
+            val context = coroutineContext
+            while (true) {
+                context.ensureActive()
+                val line = source.readUtf8Line() ?: break
+                onLine(line)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -210,7 +210,6 @@ class StreamRepositoryImpl @Inject constructor(
                 // Launch addon jobs
                 streamAddons.forEach { addon ->
                     launch {
-                        var delivered = false
                         try {
                             val streamsResult = fetchAddonStreams(
                                 baseUrl = addon.baseUrl,
@@ -220,12 +219,12 @@ class StreamRepositoryImpl @Inject constructor(
                                 addonLogo = addon.logo,
                                 onBatch = { partialStreams ->
                                     if (partialStreams.isNotEmpty()) {
-                                        delivered = true
                                         resultChannel.send(
                                             AddonStreams(
                                                 addonName = addon.displayName,
                                                 addonLogo = addon.logo,
-                                                streams = partialStreams
+                                                streams = partialStreams,
+                                                isFinal = false
                                             )
                                         )
                                     }
@@ -234,16 +233,14 @@ class StreamRepositoryImpl @Inject constructor(
                             when (streamsResult) {
                                 is NetworkResult.Success -> {
                                     if (streamsResult.data.isNotEmpty()) {
-                                        // Batches already covered this addon's streams.
-                                        if (!delivered) {
-                                            resultChannel.send(
-                                                AddonStreams(
-                                                    addonName = addon.displayName,
-                                                    addonLogo = addon.logo,
-                                                    streams = streamsResult.data
-                                                )
+                                        resultChannel.send(
+                                            AddonStreams(
+                                                addonName = addon.displayName,
+                                                addonLogo = addon.logo,
+                                                streams = streamsResult.data,
+                                                isFinal = true
                                             )
-                                        }
+                                        )
                                     } else {
                                         // Stream endpoint returned empty - try inline
                                         // streams from meta response as fallback.
@@ -255,7 +252,8 @@ class StreamRepositoryImpl @Inject constructor(
                                                 AddonStreams(
                                                     addonName = addon.displayName,
                                                     addonLogo = addon.logo,
-                                                    streams = inlineStreams
+                                                    streams = inlineStreams,
+                                                    isFinal = true
                                                 )
                                             )
                                         } else {
@@ -441,7 +439,8 @@ class StreamRepositoryImpl @Inject constructor(
         if (existingIndex >= 0) {
             val existing = accumulatedResults[existingIndex]
             val merged = existing.copy(
-                streams = mergeStreams(existing.streams, result.streams)
+                streams = mergeStreams(existing.streams, result.streams),
+                isFinal = result.isFinal
             )
             accumulatedResults[existingIndex] = presentStreams(merged, debridSettings)
         } else {

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.repository
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.nuvio.tv.R
 import com.nuvio.tv.core.network.NetworkResult
@@ -10,10 +11,17 @@ import com.nuvio.tv.core.debrid.LocalDebridAvailabilityService
 import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.plugin.resolvePluginSeasonEpisode
 import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.streams.StreamResolution
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.DebridSettingsDataStore
+import com.nuvio.tv.data.local.StreamBadgeSettingsDataStore
 import com.nuvio.tv.data.mapper.toDomain
+import com.nuvio.tv.data.remote.NdjsonStreamFetcher
+import com.nuvio.tv.data.remote.NdjsonHttpException
+import com.nuvio.tv.data.remote.isNdjsonContentType
+import com.nuvio.tv.data.remote.parseNdjsonStreamDtos
 import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.StreamResponseDto
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.DebridSettings
@@ -26,6 +34,8 @@ import com.nuvio.tv.domain.model.StreamBehaviorHints
 import com.nuvio.tv.domain.model.enabledAddons
 import com.nuvio.tv.domain.repository.AddonRepository
 import com.nuvio.tv.domain.repository.StreamRepository
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -44,6 +54,10 @@ import javax.inject.Inject
 
 private const val TAG = "StreamRepositoryImpl"
 
+/** Minimum delay between NDJSON partial renders. */
+private const val NDJSON_EMIT_INTERVAL_MS = 300L
+
+
 class StreamRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val api: AddonApi,
@@ -53,7 +67,9 @@ class StreamRepositoryImpl @Inject constructor(
     private val debridSettingsDataStore: DebridSettingsDataStore,
     private val tmdbService: TmdbService,
     private val debridStreamPresentation: DebridStreamPresentation,
-    private val localDebridAvailabilityService: LocalDebridAvailabilityService
+    private val localDebridAvailabilityService: LocalDebridAvailabilityService,
+    private val ndjsonStreamFetcher: NdjsonStreamFetcher,
+    private val moshi: Moshi
 ) : StreamRepository {
     private val streamSearchSessions = StreamSearchSessionCache()
     private val localPluginSearchPaused = MutableStateFlow(false)
@@ -181,29 +197,53 @@ class StreamRepositoryImpl @Inject constructor(
             coroutineScope {
                 // Channel to receive results as they complete
                 val resultChannel = Channel<AddonStreams>(Channel.UNLIMITED)
-                
-                // Track number of pending jobs
-                val totalJobs = streamAddons.size + 1
+
+                // Only count plugin job if it will actually run
+                val totalJobs = streamAddons.size + if (hasCompatiblePlugins) 1 else 0
                 val completedJobs = java.util.concurrent.atomic.AtomicInteger(0)
+                fun tryCloseChannel() {
+                    if (completedJobs.incrementAndGet() == totalJobs) {
+                        resultChannel.close()
+                    }
+                }
 
                 // Launch addon jobs
                 streamAddons.forEach { addon ->
                     launch {
+                        var delivered = false
                         try {
-                            val streamsResult = getStreamsFromAddon(addon.baseUrl, type, videoId)
-                            when (streamsResult) {
-                                is NetworkResult.Success -> {
-                                    if (streamsResult.data.isNotEmpty()) {
-                                        val namedStreams = streamsResult.data.map {
-                                            it.copy(addonName = addon.displayName, addonLogo = addon.logo)
-                                        }
+                            val streamsResult = fetchAddonStreams(
+                                baseUrl = addon.baseUrl,
+                                type = type,
+                                videoId = videoId,
+                                addonName = addon.displayName,
+                                addonLogo = addon.logo,
+                                onBatch = { partialStreams ->
+                                    if (partialStreams.isNotEmpty()) {
+                                        delivered = true
                                         resultChannel.send(
                                             AddonStreams(
                                                 addonName = addon.displayName,
                                                 addonLogo = addon.logo,
-                                                streams = namedStreams
+                                                streams = partialStreams
                                             )
                                         )
+                                    }
+                                }
+                            )
+                            when (streamsResult) {
+                                is NetworkResult.Success -> {
+                                    if (streamsResult.data.isNotEmpty()) {
+                                        // Batches already covered this addon's streams.
+                                        if (!delivered) {
+                                            resultChannel.send(
+                                                AddonStreams(
+                                                    addonName = addon.displayName,
+                                                    addonLogo = addon.logo,
+                                                    streams = streamsResult.data
+                                                )
+                                            )
+                                        }
                                     } else {
                                         // Stream endpoint returned empty - try inline
                                         // streams from meta response as fallback.
@@ -237,49 +277,48 @@ class StreamRepositoryImpl @Inject constructor(
                                 detail = e.message ?: context.getString(com.nuvio.tv.R.string.stream_error_detail_addon_request_failed)
                             )
                         } finally {
-                            if (completedJobs.incrementAndGet() >= totalJobs) {
-                                resultChannel.close()
-                            }
+                            tryCloseChannel()
                         }
                     }
                 }
 
-                launch {
-                    try {
-                        if (!hasCompatiblePlugins) return@launch
-
-                        val tmdbId = tmdbService.ensureTmdbId(videoId, type)
-                        Log.d(TAG, "Video ID: $videoId -> TMDB ID: $tmdbId (type: $type)")
-                        val pluginRequest = buildPluginRequest(tmdbId, type, videoId)
-                            ?: return@launch
-                        val (pluginSeason, pluginEpisode) = resolvePluginSeasonEpisode(
-                            videoId = videoId,
-                            season = season,
-                            episode = episode
-                        )
-                        localPluginSearchPaused
-                            .transformLatest { paused ->
-                                if (!paused) {
-                                    streamLocalPlugins(
-                                        pluginId = pluginRequest.id,
-                                        mediaType = pluginRequest.mediaType,
-                                        pluginSource = pluginRequest.source,
-                                        season = pluginSeason,
-                                        episode = pluginEpisode,
-                                        resultChannel = resultChannel
-                                    )
-                                    emit(Unit)
+                if (hasCompatiblePlugins) {
+                    launch {
+                        try {
+                            val tmdbId = tmdbService.ensureTmdbId(videoId, type)
+                            Log.d(TAG, "Video ID: $videoId -> TMDB ID: $tmdbId (type: $type)")
+                            val pluginRequest = buildPluginRequest(tmdbId, type, videoId)
+                                ?: return@launch
+                            val (pluginSeason, pluginEpisode) = resolvePluginSeasonEpisode(
+                                videoId = videoId,
+                                season = season,
+                                episode = episode
+                            )
+                            localPluginSearchPaused
+                                .transformLatest { paused ->
+                                    if (!paused) {
+                                        streamLocalPlugins(
+                                            pluginId = pluginRequest.id,
+                                            mediaType = pluginRequest.mediaType,
+                                            pluginSource = pluginRequest.source,
+                                            season = pluginSeason,
+                                            episode = pluginEpisode,
+                                            resultChannel = resultChannel
+                                        )
+                                        emit(Unit)
+                                    }
                                 }
-                            }
-                            .first()
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
-                        Log.e(TAG, "Plugin execution failed: ${e.message}")
-                    } finally {
-                        if (completedJobs.incrementAndGet() >= totalJobs) {
-                            resultChannel.close()
+                                .first()
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            Log.e(TAG, "Plugin execution failed: ${e.message}")
+                        } finally {
+                            tryCloseChannel()
                         }
                     }
+                }
+                if (totalJobs == 0) {
+                    resultChannel.close()
                 }
 
                 // Emit results as they arrive
@@ -418,12 +457,24 @@ class StreamRepositoryImpl @Inject constructor(
         ).firstOrNull() ?: result
     }
 
+    /**
+     * A later NDJSON snapshot carries every stream the group already had, so its
+     * ordering wins outright. Partial results - plugin scrapers, inline meta
+     * streams - are appended in arrival order instead.
+     */
     private fun mergeStreams(existing: List<Stream>, incoming: List<Stream>): List<Stream> {
+        val incomingKeys = incoming.mapTo(HashSet(incoming.size)) { stream -> stream.dedupKey() }
+        if (existing.all { stream -> stream.dedupKey() in incomingKeys }) return incoming
+
         val streamsByKey = LinkedHashMap<String, Stream>()
         existing.forEach { stream -> streamsByKey[stream.dedupKey()] = stream }
         incoming.forEach { stream -> streamsByKey[stream.dedupKey()] = stream }
         return streamsByKey.values.toList()
     }
+
+    /** Best resolution first; addon order is kept within a resolution. */
+    private fun Collection<Stream>.byResolution(): List<Stream> =
+        sortedByDescending { stream -> stream.qualityValue }
 
     /**
      * Stream local plugin results - each scraper sends results individually
@@ -546,24 +597,32 @@ class StreamRepositoryImpl @Inject constructor(
         return if (parts.isNotEmpty()) parts.joinToString(" • ") else null
     }
 
-    private fun parseQualityValue(quality: String?): Int {
-        if (quality == null) return -1
-        val lower = quality.lowercase()
-        return when {
-            lower.contains("4k") || lower.contains("2160") -> 2160
-            lower.contains("1080") -> 1080
-            lower.contains("800") -> 800
-            lower.contains("720") -> 720
-            lower.contains("480") -> 480
-            lower.contains("360") -> 360
-            else -> -1
-        }
-    }
+    private fun parseQualityValue(quality: String?): Int =
+        StreamResolution.detect(quality) ?: -1
 
     override suspend fun getStreamsFromAddon(
         baseUrl: String,
         type: String,
         videoId: String
+    ): NetworkResult<List<Stream>> = fetchAddonStreams(
+        baseUrl = baseUrl,
+        type = type,
+        videoId = videoId,
+        onBatch = {}
+    )
+
+    /**
+     * Fetches one addon's streams, reporting NDJSON batches through [onBatch] as
+     * they arrive. [addonName]/[addonLogo] come from the installed addon record
+     * when the caller has one; otherwise the manifest is fetched to label them.
+     */
+    private suspend fun fetchAddonStreams(
+        baseUrl: String,
+        type: String,
+        videoId: String,
+        addonName: String? = null,
+        addonLogo: String? = null,
+        onBatch: suspend (List<Stream>) -> Unit
     ): NetworkResult<List<Stream>> {
         val cleanBaseUrl = baseUrl.trimEnd('/')
         val queryStart = cleanBaseUrl.indexOf('?')
@@ -574,35 +633,107 @@ class StreamRepositoryImpl @Inject constructor(
         val streamUrl = "$basePath/stream/$encodedType/$encodedVideoId.json$baseQuery"
         Log.d(TAG, "Fetching streams type=$type videoId=$videoId url=$streamUrl")
 
-        // First, get addon info for name and logo
-        val addonResult = addonRepository.fetchAddon(baseUrl)
-        val addonName = when (addonResult) {
-            is NetworkResult.Success -> addonResult.data.displayName
-            else -> context.getString(com.nuvio.tv.R.string.stream_addon_unknown)
-        }
-        val addonLogo = when (addonResult) {
-            is NetworkResult.Success -> addonResult.data.logo
-            else -> null
+        val resolvedName: String
+        val resolvedLogo: String?
+        if (addonName != null) {
+            resolvedName = addonName
+            resolvedLogo = addonLogo
+        } else {
+            val addonResult = addonRepository.fetchAddon(baseUrl)
+            resolvedName = when (addonResult) {
+                is NetworkResult.Success -> addonResult.data.displayName
+                else -> context.getString(com.nuvio.tv.R.string.stream_addon_unknown)
+            }
+            resolvedLogo = when (addonResult) {
+                is NetworkResult.Success -> addonResult.data.logo
+                else -> null
+            }
         }
 
-        return when (val result = safeApiCall(context) { api.getStreams(streamUrl) }) {
-            is NetworkResult.Success -> {
-                val streams = result.data.streams?.map { 
-                    it.toDomain(addonName, addonLogo) 
-                } ?: emptyList()
+        return fetchStreams(
+            streamUrl = streamUrl,
+            addonName = resolvedName,
+            addonLogo = resolvedLogo,
+            onBatch = onBatch
+        )
+    }
+
+    /**
+     * Reads a `/stream` response. NDJSON responses report each batch through
+     * [onBatch] as it arrives, ordered by resolution because batches land in
+     * whatever order the addon's sources finish. A plain JSON document is parsed
+     * once complete and keeps the order the addon sent.
+     */
+    private suspend fun fetchStreams(
+        streamUrl: String,
+        addonName: String,
+        addonLogo: String?,
+        onBatch: suspend (List<Stream>) -> Unit
+    ): NetworkResult<List<Stream>> {
+        val streamAdapter = moshi.adapter(StreamResponseDto::class.java)
+        var isNdjson = false
+        var sawBatch = false
+        var pendingBatch = false
+        var lastEmitMs = 0L
+        val buffered = StringBuilder()
+        val streamsByKey = LinkedHashMap<String, Stream>()
+
+        return try {
+            ndjsonStreamFetcher.fetchLines(
+                url = streamUrl,
+                onContentType = { contentType -> isNdjson = isNdjsonContentType(contentType) },
+                onLine = { line ->
+                    if (isNdjson) {
+                        if (line.isBlank()) return@fetchLines
+                        val batch = parseStreamBatch(streamAdapter, line, addonName, addonLogo)
+                        if (batch.isEmpty()) return@fetchLines
+                        // Every line is additive - update known keys in place.
+                        batch.forEach { stream -> streamsByKey[stream.dedupKey()] = stream }
+                        val isFirstBatch = !sawBatch
+                        sawBatch = true
+                        pendingBatch = true
+                        // Throttle renders - first batch immediately, then one update per interval.
+                        val nowMs = SystemClock.elapsedRealtime()
+                        if (isFirstBatch || nowMs - lastEmitMs >= NDJSON_EMIT_INTERVAL_MS) {
+                            lastEmitMs = nowMs
+                            pendingBatch = false
+                            onBatch(streamsByKey.values.byResolution())
+                        }
+                    } else {
+                        buffered.append(line)
+                    }
+                }
+            )
+            if (sawBatch) {
+                val streams = streamsByKey.values.byResolution()
+                // Flush whatever the throttle held back.
+                if (pendingBatch) onBatch(streams)
+                Log.d(TAG, "NDJSON streams success addon=$addonName count=${streams.size} url=$streamUrl")
+                NetworkResult.Success(streams)
+            } else {
+                val streams = parseStreamBatch(streamAdapter, buffered.toString(), addonName, addonLogo)
                 Log.d(TAG, "Streams success addon=$addonName count=${streams.size} url=$streamUrl")
                 NetworkResult.Success(streams)
             }
-            is NetworkResult.Error -> {
-                Log.w(
-                    TAG,
-                    "Streams failed addon=$addonName code=${result.code} message=${result.message} url=$streamUrl"
-                )
-                result
-            }
-            NetworkResult.Loading -> NetworkResult.Loading
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: NdjsonHttpException) {
+            // Keep the status code so buildAddonFailure can still classify 404 as "no streams".
+            Log.w(TAG, "Streams failed addon=$addonName code=${e.code} message=${e.message} url=$streamUrl")
+            NetworkResult.Error(e.message, e.code)
+        } catch (e: Exception) {
+            Log.w(TAG, "Streams failed addon=$addonName error=${e.message} url=$streamUrl")
+            NetworkResult.Error(e.message ?: context.getString(com.nuvio.tv.R.string.stream_error_fetch_failed))
         }
     }
+
+    private fun parseStreamBatch(
+        streamAdapter: JsonAdapter<StreamResponseDto>,
+        payload: String,
+        addonName: String,
+        addonLogo: String?
+    ): List<Stream> =
+        parseNdjsonStreamDtos(streamAdapter, payload).map { it.toDomain(addonName, addonLogo) }
 
     /**
      * Check if addon supports stream resource for the given type and video id.

--- a/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Stream.kt
@@ -266,7 +266,8 @@ data class ProxyHeaders(
 data class AddonStreams(
     val addonName: String,
     val addonLogo: String?,
-    val streams: List<Stream>
+    val streams: List<Stream>,
+    val isFinal: Boolean = true
 )
 
 private fun String?.isMagnetLink(): Boolean =

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -264,7 +264,7 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
                             sourceAvailableAddons = mergedAvailableAddons,
                             sourceChips = mergeSourceChipStatuses(
                                 existing = it.sourceChips,
-                                succeededNames = addonStreams.map { group -> group.addonName }
+                                succeededNames = addonStreams.filter { it.isFinal }.map { it.addonName }
                             ),
                             sourceStreamsError = null
                         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -300,12 +300,15 @@ internal fun PlayerRuntimeController.loadSourceStreams(forceRefresh: Boolean) {
 
 /**
  * Merge fresh stream results with previously cached streams.
- * Newer entries for the same stream (matched by addon + url/infoHash) replace older ones.
+ * Fresh ordering wins; cached-only streams are appended at the end.
  */
 private fun mergeSourceStreams(cached: List<Stream>, fresh: List<Stream>): List<Stream> {
     val merged = LinkedHashMap<String, Stream>()
-    cached.forEach { stream -> merged[stream.mergeKey()] = stream }
     fresh.forEach { stream -> merged[stream.mergeKey()] = stream }
+    cached.forEach { stream ->
+        val key = stream.mergeKey()
+        if (!merged.containsKey(key)) merged[key] = stream
+    }
     return merged.values.toList()
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -1021,6 +1021,8 @@ private fun StreamsList(
         streamFocusRequesters.getOrPut(key) { FocusRequester() }
     }
     var firstCardHasFocus by remember(firstStreamKey) { mutableStateOf(false) }
+    var anchoredIndex by remember { mutableStateOf(-1) }
+    var listFocused by remember { mutableStateOf(false) }
     // Reset scroll position to the top when the addon filter changes (#2538).
     LaunchedEffect(selectedAddonFilter) {
         streamListState.scrollToItem(0)
@@ -1054,12 +1056,29 @@ private fun StreamsList(
         onRestoreFocusedStreamHandled()
     }
 
+    // Keep cursor at the same visual position when new NDJSON batches resort the list.
+    LaunchedEffect(streamKeys) {
+        if (shouldRestoreFocusedStream) return@LaunchedEffect
+        if (!listFocused) return@LaunchedEffect
+        if (anchoredIndex !in streamKeys.indices) return@LaunchedEffect
+        repeat(2) { withFrameNanos { } }
+        try {
+            streamListState.scrollToItem(anchoredIndex)
+            withFrameNanos { }
+            streamFocusRequesters.getValue(streamKeys[anchoredIndex]).requestFocus()
+        } catch (_: Exception) {
+        }
+    }
+
     LazyColumn(
         state = streamListState,
         modifier = Modifier
             .fillMaxSize()
             .padding(NuvioTheme.spacing.lg)
-            .onFocusChanged { onFocusChanged(it.hasFocus) }
+            .onFocusChanged {
+                listFocused = it.hasFocus
+                onFocusChanged(it.hasFocus)
+            }
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
 
@@ -1117,6 +1136,7 @@ private fun StreamsList(
                         if (index == 0) {
                             firstCardHasFocus = focused
                         }
+                        if (focused) anchoredIndex = index
                     },
                     onUpKey = if (index == 0) {{
                         val idx = if (selectedAddonFilter == null) 1

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreenViewModel.kt
@@ -527,10 +527,9 @@ class StreamScreenViewModel @Inject constructor(
                         addonStreams = mergedAddonStreams,
                         allStreams = allStreams,
                         filteredStreams = filteredStreams,
-                        availableAddons = availableAddons,
                         sourceChips = mergeSourceChipStatuses(
                             existing = _uiState.value.sourceChips,
-                            succeededNames = mergedAddonStreams.map { it.addonName }
+                            succeededNames = mergedAddonStreams.filter { it.isFinal }.map { it.addonName }
                         ),
                         // Preserve an already-resolved stream: the post-collect
                         // "isAllLoaded=true" pass re-runs the selector with

--- a/app/src/test/java/com/nuvio/tv/core/streams/StreamResolutionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/streams/StreamResolutionTest.kt
@@ -1,0 +1,68 @@
+package com.nuvio.tv.core.streams
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StreamResolutionTest {
+
+    @Test
+    fun `detects explicit heights`() {
+        assertEquals(2160, StreamResolution.detect("TestAddon 2160p"))
+        assertEquals(1440, StreamResolution.detect("TestAddon 1440p"))
+        assertEquals(1080, StreamResolution.detect("TestAddon 1080p"))
+        assertEquals(720, StreamResolution.detect("TestAddon 720p"))
+        assertEquals(360, StreamResolution.detect("TestAddon 360p"))
+    }
+
+    @Test
+    fun `detects release name aliases`() {
+        assertEquals(2160, StreamResolution.detect("TestAddon 4K"))
+        assertEquals(2160, StreamResolution.detect("TestAddon UHD"))
+        assertEquals(1440, StreamResolution.detect("TestAddon 2K"))
+        assertEquals(1080, StreamResolution.detect("TestAddon FHD"))
+        assertEquals(720, StreamResolution.detect("TestAddon HD"))
+        assertEquals(480, StreamResolution.detect("TestAddon SD"))
+    }
+
+    @Test
+    fun `requires token boundaries so encodes are not resolutions`() {
+        assertNull(StreamResolution.detect("TestAddon HDTV"))
+        assertNull(StreamResolution.detect("TestAddon HDRip"))
+        assertNull(StreamResolution.detect("TestAddon x264"))
+    }
+
+    @Test
+    fun `detects heights without a dedicated alias`() {
+        assertEquals(800, StreamResolution.detect("TestAddon 800p"))
+        assertEquals(540, StreamResolution.detect("TestAddon 540p"))
+    }
+
+    @Test
+    fun `accepts bare numeric labels only when they are the whole value`() {
+        assertEquals(800, StreamResolution.detect("800"))
+        assertNull(StreamResolution.detect("Obsession 2026"))
+    }
+
+    @Test
+    fun `earlier labels win over later ones`() {
+        assertEquals(720, StreamResolution.detect("TestAddon 720p", "Also available in 1080p"))
+    }
+
+    @Test
+    fun `falls through to the next label when one carries no resolution`() {
+        assertEquals(1080, StreamResolution.detect("TestAddon", "TestAddon 1080p"))
+    }
+
+    @Test
+    fun `highest advertised token wins inside a single label`() {
+        assertEquals(2160, StreamResolution.detect("TestAddon 4K HDR 1080p downscale"))
+    }
+
+    @Test
+    fun `returns null without a resolution`() {
+        assertNull(StreamResolution.detect("TestAddon"))
+        assertNull(StreamResolution.detect(null))
+        assertNull(StreamResolution.detect("   "))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperQualityTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mapper/StreamMapperQualityTest.kt
@@ -1,0 +1,31 @@
+package com.nuvio.tv.data.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StreamMapperQualityTest {
+
+    @Test
+    fun `detects 4k from addon stream name`() {
+        val result = detectQuality("TestAddon 4K")
+        assertEquals(2160, result?.second)
+    }
+
+    @Test
+    fun `detects 1080p from addon stream name`() {
+        val result = detectQuality("TestAddon 1080p")
+        assertEquals(1080, result?.second)
+    }
+
+    @Test
+    fun `detects 360p from addon stream name`() {
+        val result = detectQuality("TestAddon 360p")
+        assertEquals(360, result?.second)
+    }
+
+    @Test
+    fun `returns null when no resolution mentioned`() {
+        assertNull(detectQuality("TestAddon"))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/remote/NdjsonStreamParserTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/remote/NdjsonStreamParserTest.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.data.remote
+
+import com.nuvio.tv.data.remote.dto.StreamDto
+import com.nuvio.tv.data.remote.dto.StreamResponseDto
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NdjsonStreamParserTest {
+
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(StreamResponseDto::class.java)
+
+    @Test
+    fun `isNdjsonContentType matches x-ndjson with and without charset`() {
+        assertTrue(isNdjsonContentType("application/x-ndjson"))
+        assertTrue(isNdjsonContentType("application/x-ndjson; charset=utf-8"))
+        assertTrue(isNdjsonContentType("APPLICATION/X-NDJSON"))
+    }
+
+    @Test
+    fun `isNdjsonContentType rejects other content types`() {
+        assertFalse(isNdjsonContentType("application/json"))
+        assertFalse(isNdjsonContentType("text/event-stream"))
+        assertFalse(isNdjsonContentType("application/x-ndjsonx"))
+        assertFalse(isNdjsonContentType(null))
+    }
+
+    @Test
+    fun `parseNdjsonStreamDtos decodes each line independently`() {
+        val line1 = """{"streams":[{"name":"A","url":"https://a.example/1"}]}"""
+        val line2 = """{"streams":[{"name":"B","url":"https://b.example/2"}]}"""
+
+        val batch1 = parseNdjsonStreamDtos(adapter, line1)
+        val batch2 = parseNdjsonStreamDtos(adapter, line2)
+
+        assertEquals(listOf("A"), batch1.map { it.name })
+        assertEquals(listOf("B"), batch2.map { it.name })
+    }
+
+    @Test
+    fun `parseNdjsonStreamDtos tolerates blank and malformed lines`() {
+        assertEquals(emptyList<StreamDto>(), parseNdjsonStreamDtos(adapter, ""))
+        assertEquals(emptyList<StreamDto>(), parseNdjsonStreamDtos(adapter, "   "))
+        assertEquals(emptyList<StreamDto>(), parseNdjsonStreamDtos(adapter, "not json"))
+        assertEquals(emptyList<StreamDto>(), parseNdjsonStreamDtos(adapter, """{"streams":[]}"""))
+        assertEquals(emptyList<StreamDto>(), parseNdjsonStreamDtos(adapter, """{"other":1}"""))
+    }
+
+    @Test
+    fun `parseNdjsonStreamDtos keeps stream fields`() {
+        val batch = parseNdjsonStreamDtos(
+            adapter,
+            """{"streams":[{"name":"A","url":"https://a.example/1","infoHash":"abc"}]}"""
+        )
+
+        assertEquals(1, batch.size)
+        assertEquals("A", batch[0].name)
+        assertEquals("https://a.example/1", batch[0].url)
+        assertEquals("abc", batch[0].infoHash)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryNdjsonTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryNdjsonTest.kt
@@ -68,12 +68,16 @@ class StreamRepositoryNdjsonTest {
             .filterIsInstance<NetworkResult.Success<List<AddonStreams>>>()
 
         // First batch renders before the response completes, then the accumulated set.
-        assertEquals(listOf(1, 2), successes.map { it.data.single().streams.size })
+        // The final emission (isFinal=true) is a duplicate of the last batch and flips the chip.
+        val sizes = successes.map { it.data.single().streams.size }
+        assertEquals(listOf(1, 2), sizes.distinct())
+        assertTrue(sizes.size >= 2)
         // The slower 2160p source arrived last but still sorts above the 1080p one.
         assertEquals(
             listOf("B 2160p", "A 1080p"),
             successes.last().data.single().streams.map { it.name }
         )
+        assertTrue(successes.last().data.single().isFinal)
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryNdjsonTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryNdjsonTest.kt
@@ -1,0 +1,228 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.R
+import com.nuvio.tv.core.debrid.DebridStreamPresentation
+import com.nuvio.tv.core.debrid.LocalDebridAvailabilityService
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.core.plugin.PluginManager
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.DebridSettingsDataStore
+import com.nuvio.tv.data.remote.NdjsonHttpException
+import com.nuvio.tv.data.remote.NdjsonStreamFetcher
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.AddonStreams
+import com.nuvio.tv.domain.model.DebridSettings
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Covers the `/stream` line reader: NDJSON batches and plain JSON documents. */
+class StreamRepositoryNdjsonTest {
+
+    private val addon = Addon(
+        id = "ndjson-addon",
+        name = "NDJSON Addon",
+        version = "1.0.0",
+        description = null,
+        logo = null,
+        baseUrl = "https://addon.example",
+        catalogs = emptyList(),
+        types = emptyList(),
+        resources = listOf(
+            AddonResource(
+                name = "stream",
+                types = listOf("movie"),
+                idPrefixes = listOf("tt")
+            )
+        )
+    )
+
+    @Test
+    fun `each ndjson batch is rendered as it arrives, best resolution first`() = runBlocking {
+        val repository = newRepository(
+            NdjsonResponse(
+                contentType = "application/x-ndjson",
+                lines = listOf(
+                    """{"streams":[{"name":"A 1080p","url":"https://a.example/1"}]}""",
+                    """{"streams":[{"name":"B 2160p","url":"https://b.example/2"}]}"""
+                )
+            )
+        )
+
+        val successes = repository.getStreamsFromAllAddons(type = "movie", videoId = "tt1")
+            .toList()
+            .filterIsInstance<NetworkResult.Success<List<AddonStreams>>>()
+
+        // First batch renders before the response completes, then the accumulated set.
+        assertEquals(listOf(1, 2), successes.map { it.data.single().streams.size })
+        // The slower 2160p source arrived last but still sorts above the 1080p one.
+        assertEquals(
+            listOf("B 2160p", "A 1080p"),
+            successes.last().data.single().streams.map { it.name }
+        )
+    }
+
+    @Test
+    fun `repeated stream keys update in place instead of duplicating`() = runBlocking {
+        val repository = newRepository(
+            NdjsonResponse(
+                contentType = "application/x-ndjson",
+                lines = listOf(
+                    """{"streams":[{"name":"A","url":"https://a.example/1"}]}""",
+                    """{"streams":[{"name":"A refreshed","url":"https://a.example/1"}]}"""
+                )
+            )
+        )
+
+        val streams = repository.getStreamsFromAllAddons(type = "movie", videoId = "tt1")
+            .toList()
+            .filterIsInstance<NetworkResult.Success<List<AddonStreams>>>()
+            .last()
+            .data
+            .single()
+            .streams
+
+        assertEquals(listOf("A refreshed"), streams.map { it.name })
+    }
+
+    @Test
+    fun `a plain json response keeps the order the addon sent`() = runBlocking {
+        val repository = newRepository(
+            NdjsonResponse(
+                contentType = "application/json",
+                lines = listOf(
+                    """{"streams":[{"name":"A 1080p","url":"https://a.example/1"},{"name":"B 2160p","url":"https://b.example/2"}]}"""
+                )
+            )
+        )
+
+        val streams = repository.getStreamsFromAllAddons(type = "movie", videoId = "tt1")
+            .toList()
+            .filterIsInstance<NetworkResult.Success<List<AddonStreams>>>()
+            .last()
+            .data
+            .single()
+            .streams
+
+        // No reordering: buffered JSON is left exactly as the addon ranked it.
+        assertEquals(listOf("A 1080p", "B 2160p"), streams.map { it.name })
+    }
+
+    @Test
+    fun `a 404 is reported as missing streams rather than a request failure`() = runBlocking {
+        // "HTTP 404" is what the fetcher reports; only the status code can classify it,
+        // since the message no longer spells out "Not Found".
+        val repository = newRepository(NdjsonResponse(failure = NdjsonHttpException(404, "HTTP 404")))
+
+        val error = repository.getStreamsFromAllAddons(type = "movie", videoId = "tt1")
+            .toList()
+            .filterIsInstance<NetworkResult.Error>()
+            .last()
+
+        assertEquals(MISSING_STREAMS_MESSAGE, error.message)
+    }
+
+    @Test
+    fun `a 500 is still reported as a request failure`() = runBlocking {
+        val repository = newRepository(NdjsonResponse(failure = NdjsonHttpException(500, "Server Error")))
+
+        val error = repository.getStreamsFromAllAddons(type = "movie", videoId = "tt1")
+            .toList()
+            .filterIsInstance<NetworkResult.Error>()
+            .last()
+
+        assertEquals(ADDON_ISSUES_MESSAGE, error.message)
+    }
+
+    private class NdjsonResponse(
+        val contentType: String? = null,
+        val lines: List<String> = emptyList(),
+        val failure: Exception? = null
+    )
+
+    private fun newRepository(response: NdjsonResponse): StreamRepositoryImpl {
+        val fetcher = mockk<NdjsonStreamFetcher>()
+        coEvery { fetcher.fetchLines(any(), any(), any()) } coAnswers {
+            val onContentType = arg<(String?) -> Unit>(1)
+            val onLine = arg<suspend (String) -> Unit>(2)
+            response.failure?.let { failure ->
+                onContentType(response.contentType)
+                throw failure
+            }
+            onContentType(response.contentType)
+            response.lines.forEach { line -> onLine(line) }
+        }
+
+        val addonRepository = mockk<AddonRepository>()
+        every { addonRepository.getInstalledAddons() } returns flowOf(listOf(addon))
+        coEvery { addonRepository.fetchAddon(addon.baseUrl) } returns NetworkResult.Success(addon)
+
+        val pluginManager = mockk<PluginManager>(relaxed = true)
+        every { pluginManager.enabledScrapers } returns flowOf(emptyList())
+        every { pluginManager.pluginsEnabled } returns flowOf(false)
+        every { pluginManager.groupStreamsByRepository } returns flowOf(false)
+        every { pluginManager.repositories } returns flowOf(emptyList())
+
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        every { profileManager.activeProfileId } returns MutableStateFlow(1)
+
+        val debridSettingsDataStore = mockk<DebridSettingsDataStore>()
+        every { debridSettingsDataStore.settings } returns flowOf(DebridSettings())
+
+        val presentation = mockk<DebridStreamPresentation>()
+        every { presentation.apply(any(), any<DebridSettings>(), any(), any()) } answers {
+            firstArg<List<AddonStreams>>()
+        }
+
+        val availability = mockk<LocalDebridAvailabilityService>()
+        coEvery { availability.markChecking(any()) } coAnswers { firstArg<List<AddonStreams>>() }
+        coEvery { availability.annotateCachedAvailability(any()) } coAnswers {
+            firstArg<List<AddonStreams>>()
+        }
+
+        val context = mockk<Context>(relaxed = true)
+        every {
+            context.getString(eq(R.string.error_stream_tried_none), *anyVararg())
+        } returns MISSING_STREAMS_MESSAGE
+        every {
+            context.getString(eq(R.string.error_stream_tried_issues), *anyVararg())
+        } returns ADDON_ISSUES_MESSAGE
+        every {
+            context.getString(eq(R.string.error_stream_tried_generic), *anyVararg())
+        } returns ADDON_GENERIC_MESSAGE
+
+        return StreamRepositoryImpl(
+            context = context,
+            api = mockk(relaxed = true),
+            addonRepository = addonRepository,
+            pluginManager = pluginManager,
+            profileManager = profileManager,
+            debridSettingsDataStore = debridSettingsDataStore,
+            tmdbService = mockk<TmdbService>(relaxed = true),
+            debridStreamPresentation = presentation,
+            localDebridAvailabilityService = availability,
+            ndjsonStreamFetcher = fetcher,
+            moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        )
+    }
+
+    private companion object {
+        const val MISSING_STREAMS_MESSAGE = "no-streams-for-id"
+        const val ADDON_ISSUES_MESSAGE = "addon-issues"
+        const val ADDON_GENERIC_MESSAGE = "addon-generic"
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
@@ -8,9 +8,9 @@ import com.nuvio.tv.core.plugin.PluginManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.DebridSettingsDataStore
-import com.nuvio.tv.data.remote.api.AddonApi
-import com.nuvio.tv.data.remote.dto.StreamDto
-import com.nuvio.tv.data.remote.dto.StreamResponseDto
+import com.nuvio.tv.data.remote.NdjsonStreamFetcher
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonResource
 import com.nuvio.tv.domain.model.AddonStreams
@@ -33,7 +33,6 @@ import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import retrofit2.Response
 
 class StreamRepositoryPluginIsolationTest {
     @Test
@@ -57,7 +56,7 @@ class StreamRepositoryPluginIsolationTest {
         assertEquals(listOf("Fast Addon"), groups.map { it.addonName })
         assertEquals(1, groups.single().streams.size)
         assertTrue(tmdbResult.isActive)
-        coVerify(exactly = 1) { harness.api.getStreams(any()) }
+        coVerify(exactly = 1) { harness.fetcher.fetchLines(any(), any(), any()) }
         tmdbResult.complete(null)
         Unit
     }
@@ -75,22 +74,18 @@ class StreamRepositoryPluginIsolationTest {
 
         assertTrue(results.last() is NetworkResult.Success)
         coVerify(exactly = 0) { harness.tmdbService.ensureTmdbId(any(), any()) }
-        coVerify(exactly = 1) { harness.api.getStreams(any()) }
+        coVerify(exactly = 1) { harness.fetcher.fetchLines(any(), any(), any()) }
     }
 
     private fun newHarness(enabledScrapers: List<ScraperInfo>): Harness {
         val addon = compatibleAddon()
-        val api = mockk<AddonApi>()
-        coEvery { api.getStreams(any()) } returns Response.success(
-            StreamResponseDto(
-                streams = listOf(
-                    StreamDto(
-                        name = "Fast Stream",
-                        url = "https://stream.example/video.m3u8"
-                    )
-                )
+        val fetcher = mockk<NdjsonStreamFetcher>()
+        coEvery { fetcher.fetchLines(any(), any(), any()) } coAnswers {
+            arg<(String?) -> Unit>(1)("application/json")
+            arg<suspend (String) -> Unit>(2)(
+                """{"streams":[{"name":"Fast Stream","url":"https://stream.example/video.m3u8"}]}"""
             )
-        )
+        }
 
         val addonRepository = mockk<AddonRepository>()
         every { addonRepository.getInstalledAddons() } returns flowOf(listOf(addon))
@@ -123,16 +118,18 @@ class StreamRepositoryPluginIsolationTest {
         return Harness(
             repository = StreamRepositoryImpl(
                 context = mockk<Context>(relaxed = true),
-                api = api,
+                api = mockk(relaxed = true),
                 addonRepository = addonRepository,
                 pluginManager = pluginManager,
                 profileManager = profileManager,
                 debridSettingsDataStore = debridSettingsDataStore,
                 tmdbService = tmdbService,
                 debridStreamPresentation = presentation,
-                localDebridAvailabilityService = availability
+                localDebridAvailabilityService = availability,
+                ndjsonStreamFetcher = fetcher,
+                moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
             ),
-            api = api,
+            fetcher = fetcher,
             tmdbService = tmdbService
         )
     }
@@ -173,7 +170,7 @@ class StreamRepositoryPluginIsolationTest {
 
     private data class Harness(
         val repository: StreamRepositoryImpl,
-        val api: AddonApi,
+        val fetcher: NdjsonStreamFetcher,
         val tmdbService: TmdbService
     )
 }


### PR DESCRIPTION
## Summary

Add incremental NDJSON support for `/stream` so addons can send `{"streams":[...]}` batches as each source finishes. NDJSON batches are sorted by resolution via shared `StreamResolution` helper, shown incrementally with throttling, while plain JSON keeps addon order. Chip spinner stays loading until the addon actually finishes, and focus stays at the same visual index when sorting occurs.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix

> This is a feature with maintainer approval, not a bug fix or translation. See Issue or approval.

## Why

Addons that scrape several sources sequentially force users to wait for the slowest source. #3046 proposes NDJSON so results appear as they arrive. Approved for draft PR by @tapframe on 2026-08-26.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioTV/issues/3046
Approval: https://github.com/NuvioMedia/NuvioTV/issues/3046#issuecomment-326... (@tapframe: "I like the approach, you can create a draft PR")

## Reproduction steps

1. Install an addon that serves `Content-Type: application/x-ndjson` for `/stream` (or use `PenguPlay` test addon with staggered sources).
2. Open a detail page and go to stream selection.
3. Observe: first batch appears quickly, later batches appear and resort by resolution, chip stays loading, cursor stays at index.
4. Control: same addon with `application/json` keeps original order and shows once.

No reproduction steps for plain JSON path beyond normal stream loading.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Notes: Stream list ordering for NDJSON and loading spinner plus focus anchoring are behavior changes covered by #3046 approval. Plain JSON UI unchanged.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix. This is a feature with explicit maintainer approval for a draft PR as above.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes beyond the approved scope.
- [x] This PR is small, focused, and limited to one issue (#3046).
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes as a feature with approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed or out of scope for this NDJSON branch:

- Plain JSON (`application/json`) addon order is preserved exactly as the addon sent it, no re sorting.
- `DebridStreamPresentation` reverted to `upstream/dev` verbatim. Debrid presentation sorting only applies inside the NDJSON read path (`StreamRepositoryImpl.fetchStreams` `byResolution()`), not globally.
- No new user facing setting or toggle added. Incremental path is content type opt in per #3046.
- No unrelated refactors beyond `StreamResolution` unification (`StreamMapper`, `DirectDebridStreamFilter`, `parseQualityValue` to one parser).
- No UI polish beyond required behavior: chip spinner persistence and index anchored cursor.
- No DataStore, config, or schema migration.

## Testing

- **Unit (fullDebug):** `BUILD SUCCESSFUL`
  - `StreamResolutionTest` (9 cases: explicit heights, aliases `4K`, `UHD`, `2K`, `FHD`, `HD`, `SD`, token boundaries `HDTV` not `HD`, generic `800p`, bare `800`, label priority, intra label highest wins)
  - `NdjsonStreamParserTest` (5 cases: content type with charset and case, blank and malformed tolerance, field preservation)
  - `StreamRepositoryNdjsonTest` (5 cases: batches render as they arrive `byResolution` `["B 2160p","A 1080p"]`, plain JSON keeps order `["A 1080p","B 2160p"]`, dedup update, 404 to `MISSING` vs 500 to `REQUEST_FAILED`)
  - `StreamRepositoryPluginIsolationTest` (2 cases: addon results arrive while TMDB lookup pending)
- **Compile per commit:** `:app:compileFullDebugKotlin` and `:app:compileFullDebugUnitTestKotlin` `BUILD SUCCESSFUL` on `tv_ndjson` worktrees for each commit in the series.
- **Manual (emulator):** `tv_ndjson` AVD `android-tv` API 36 `x86_64` 1920x1080 (`-gpu host -feature -Vulkan` with `QT_QPA_PLATFORM=xcb` under Wayland). Installed `app-full-x86_64-debug.apk` (92 MB) and `universal` (228 MB) via `adb install -r -t` from `5cdc4b1` rebased on `upstream/dev eca648a86`.
  - NDJSON `application/x-ndjson` addon `PenguPlay` batches appear incrementally, sorted `4K` > `1080p` as they arrive.
  - Plain JSON addon order untouched.
  - Chip stays `LOADING` until `isFinal=true` (spinner visible while streams already shown).
  - Cursor stays at same visual index (for example 2nd) when resort happens.

Prebuilt APKs (no build needed): https://github.com/pengu-play/NuvioTV/releases/tag/feat-ndjson-streams-5cdc4b197
- `NuvioTV-universal-feat-ndjson-streams-5cdc4b197.apk` (228 MB)
- `NuvioTV-x86_64-feat-ndjson-streams-5cdc4b197.apk` (92 MB)
Install via `adb install -r -t <apk>` on `tv_ndjson` AVD, or build from source:

```
NUVIO_RELEASE_STORE_FILE=~/.android/debug.keystore NUVIO_RELEASE_KEY_ALIAS=androiddebugkey \
  NUVIO_RELEASE_KEY_PASSWORD=android NUVIO_RELEASE_STORE_PASSWORD=android \
  ./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.data.repository.StreamRepository*"
```

## Screenshots / Video


https://github.com/user-attachments/assets/df5fa410-78b4-4ff6-8a5b-b429bb559728


https://github.com/pengu-play/NuvioTV/releases/download/feat-ndjson-streams-5cdc4b197/recording_20260828_203813.mp4

UI change is limited to stream list ordering, loading spinner, and focus behavior. Screenshot from `tv_ndjson` (`com.nuviodebug.com/com.nuvio.tv.MainActivity`, `OBSESSION` detail):

- `NuvioTV-universal` stream list shows `PenguPlay 4K` on top, `PenguPlay 1080p` second. NDJSON sorted, addon chip `PenguPlay` still shows loading spinner while contents are visible (see release asset).
- Plain JSON control: same addon with `application/json` keeps sent order (verified via `StreamRepositoryNdjsonTest`).
- Video: screen recording of NDJSON incremental batches on `tv_ndjson` (link above), showing batches arriving and resorting, spinner persisting, and cursor staying at index.

## Breaking changes

None.

- `AddonStreams.isFinal: Boolean = true` added with default. Existing construction sites unchanged, no wire format change for `Stream`, no DataStore or config migration, no addon API contract change. Opt in by `Content-Type: application/x-ndjson`.

## Linked issues

Implements https://github.com/NuvioMedia/NuvioTV/issues/3046



