### PR TITLE
Fix/tmdb collection and detail titles cjk fallback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -238,17 +238,37 @@ class TmdbMetadataService(
                 // If TMDB returned the original title because no translation
                 // exists for the user's language, treat as no localized title
                 // so the caller keeps the addon-provided title instead.
-                val localizedTitle = if (
-                    rawLocalizedTitle != null &&
+                val droppedUntranslatedTitle = rawLocalizedTitle != null &&
                     originalTitle != null &&
                     rawLocalizedTitle == originalTitle &&
                     !normalizedLanguage.startsWith("en") &&
                     language != null &&
                     !normalizedLanguage.startsWith(language)
+                var localizedTitle = if (droppedUntranslatedTitle) null else rawLocalizedTitle
+                val isCjkLanguage = normalizedLanguage.startsWith("ja") ||
+                    normalizedLanguage.startsWith("ko") ||
+                    normalizedLanguage.startsWith("zh")
+                if (
+                    normalizedLanguage != "en" &&
+                    !isCjkLanguage &&
+                    containsCjkOrHangul(localizedTitle ?: originalTitle ?: "")
                 ) {
-                    null
-                } else {
-                    rawLocalizedTitle
+                    val englishTitle = runCatching {
+                        when (tmdbType) {
+                            "tv" -> tmdbApi.getTvDetails(numericId, TMDB_API_KEY, "en").body()
+                            else -> tmdbApi.getMovieDetails(numericId, TMDB_API_KEY, "en").body()
+                        }?.let { englishDetails ->
+                            (englishDetails.title ?: englishDetails.name)
+                                ?.trim()
+                                ?.takeIf { it.isNotBlank() && !containsCjkOrHangul(it) }
+                        }
+                    }.getOrNull()
+                    localizedTitle = resolvePersonName(
+                        localizedName = rawLocalizedTitle,
+                        originalName = originalTitle,
+                        fallbackEnglishName = englishTitle,
+                        preferredLanguage = normalizedLanguage
+                    )
                 }
                 val productionCompanies = details?.productionCompanies
                     .orEmpty()

--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -5,6 +5,7 @@ import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.TmdbAggregateCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.TmdbCastMember
+import com.nuvio.tv.data.remote.api.TmdbCollectionPart
 import com.nuvio.tv.data.remote.api.TmdbCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbCrewMember
 import com.nuvio.tv.data.remote.api.TmdbDiscoverResult
@@ -755,12 +756,12 @@ class TmdbMetadataService(
         }
     }
 
-    private val collectionCache = ConcurrentHashMap<String, List<MetaPreview>>()
+    private val collectionCache = ConcurrentHashMap<String, TmdbMovieCollection>()
 
     suspend fun fetchMovieCollection(
         collectionId: Int,
         language: String = "en"
-    ): List<MetaPreview> = withContext(ioDispatcher) {
+    ): TmdbMovieCollection = withContext(ioDispatcher) {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$collectionId:$normalizedLanguage:collection"
         collectionCache[cacheKey]?.let { return@withContext it }
@@ -768,6 +769,30 @@ class TmdbMetadataService(
         try {
             val collectionResponse = tmdbApi.getCollectionDetails(collectionId, TMDB_API_KEY, normalizedLanguage).body()
             val rawParts = collectionResponse?.parts.orEmpty()
+            val isCjkLanguage = normalizedLanguage.startsWith("ja") ||
+                normalizedLanguage.startsWith("ko") ||
+                normalizedLanguage.startsWith("zh")
+            val englishCollection = if (
+                normalizedLanguage != "en" &&
+                !isCjkLanguage &&
+                (
+                    containsCjkOrHangul(collectionResponse?.name ?: "") ||
+                    collectionPartsContainCjkTitles(rawParts)
+                )
+            ) {
+                runCatching {
+                    tmdbApi.getCollectionDetails(collectionId, TMDB_API_KEY, "en").body()
+                }.getOrNull()
+            } else {
+                null
+            }
+            val englishTitlesById = englishCollectionTitlesById(englishCollection?.parts.orEmpty())
+            val resolvedCollectionName = resolvePersonName(
+                localizedName = collectionResponse?.name,
+                originalName = null,
+                fallbackEnglishName = englishCollection?.name,
+                preferredLanguage = normalizedLanguage
+            )
 
             // Show in release order
             val sortedParts = rawParts.sortedBy { it.releaseDate ?: "9999" }
@@ -782,7 +807,12 @@ class TmdbMetadataService(
             val items = coroutineScope {
                 sortedParts.map { part ->
                     async {
-                        val title = part.title ?: return@async null
+                        val title = resolvePersonName(
+                            localizedName = part.title,
+                            originalName = part.originalTitle,
+                            fallbackEnglishName = englishTitlesById[part.id],
+                            preferredLanguage = normalizedLanguage
+                        ) ?: return@async null
 
                         val localizedBackdropPath = runCatching {
                             tmdbApi.getMovieImages(part.id, TMDB_API_KEY, includeImageLanguage).body()
@@ -815,11 +845,15 @@ class TmdbMetadataService(
                     }
                 }.awaitAll().filterNotNull()
             }
-            collectionCache[cacheKey] = items
-            items
+            val collection = TmdbMovieCollection(
+                name = resolvedCollectionName,
+                items = items
+            )
+            collectionCache[cacheKey] = collection
+            collection
         } catch (e: Exception) {
             Log.w(TAG, "Failed to fetch collection for $collectionId: ${e.message}")
-            emptyList()
+            TmdbMovieCollection(name = null, items = emptyList())
         }
     }
 
@@ -1581,6 +1615,11 @@ private fun selectTvAgeRating(
         .firstOrNull { it.isNotBlank() }
 }
 
+data class TmdbMovieCollection(
+    val name: String?,
+    val items: List<MetaPreview>
+)
+
 data class TmdbEnrichment(
     val localizedTitle: String?,
     val description: String?,
@@ -1721,6 +1760,21 @@ private fun englishCreditTitlesById(credits: TmdbPersonCreditsResponse?): Map<In
     }
     credits.cast.orEmpty().forEach { putTitle(it.id, it.title, it.name) }
     credits.crew.orEmpty().forEach { putTitle(it.id, it.title, it.name) }
+    return titles
+}
+
+private fun collectionPartsContainCjkTitles(parts: List<TmdbCollectionPart>): Boolean {
+    return parts.any { containsCjkOrHangul(it.title ?: return@any false) }
+}
+
+private fun englishCollectionTitlesById(parts: List<TmdbCollectionPart>): Map<Int, String> {
+    val titles = LinkedHashMap<Int, String>()
+    parts.forEach { part ->
+        val text = part.title?.trim()?.takeIf { it.isNotBlank() } ?: return@forEach
+        if (!containsCjkOrHangul(text)) {
+            titles.putIfAbsent(part.id, text)
+        }
+    }
     return titles
 }
 

--- a/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tmdb/TmdbMetadataService.kt
@@ -263,10 +263,10 @@ class TmdbMetadataService(
                                 ?.takeIf { it.isNotBlank() && !containsCjkOrHangul(it) }
                         }
                     }.getOrNull()
-                    localizedTitle = resolvePersonName(
-                        localizedName = rawLocalizedTitle,
-                        originalName = originalTitle,
-                        fallbackEnglishName = englishTitle,
+                    localizedTitle = resolveDisplayLabel(
+                        localized = rawLocalizedTitle,
+                        original = originalTitle,
+                        fallbackEnglish = englishTitle,
                         preferredLanguage = normalizedLanguage
                     )
                 }
@@ -305,10 +305,10 @@ class TmdbMetadataService(
                 val castMembers = credits?.cast
                     .orEmpty()
                     .mapNotNull { member ->
-                        val name = resolvePersonName(
-                            localizedName = member.name,
-                            originalName = member.originalName,
-                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                        val name = resolveDisplayLabel(
+                            localized = member.name,
+                            original = member.originalName,
+                            fallbackEnglish = member.id?.let { englishFallbackNames[it] },
                             preferredLanguage = normalizedLanguage
                         )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
@@ -324,10 +324,10 @@ class TmdbMetadataService(
                         .orEmpty()
                         .mapNotNull { creatorItem ->
                             val tmdbPersonId = creatorItem.id ?: return@mapNotNull null
-                            val name = resolvePersonName(
-                                localizedName = creatorItem.name,
-                                originalName = creatorItem.originalName,
-                                fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                            val name = resolveDisplayLabel(
+                                localized = creatorItem.name,
+                                original = creatorItem.originalName,
+                                fallbackEnglish = englishFallbackNames[tmdbPersonId],
                                 preferredLanguage = normalizedLanguage
                             )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                             MetaCastMember(
@@ -346,10 +346,10 @@ class TmdbMetadataService(
                     details?.createdBy
                         .orEmpty()
                         .mapNotNull { creatorItem ->
-                            resolvePersonName(
-                                localizedName = creatorItem.name,
-                                originalName = creatorItem.originalName,
-                                fallbackEnglishName = creatorItem.id?.let { englishFallbackNames[it] },
+                            resolveDisplayLabel(
+                                localized = creatorItem.name,
+                                original = creatorItem.originalName,
+                                fallbackEnglish = creatorItem.id?.let { englishFallbackNames[it] },
                                 preferredLanguage = normalizedLanguage
                             )?.takeIf { it.isNotBlank() }
                         }
@@ -364,10 +364,10 @@ class TmdbMetadataService(
                 val directorMembers = directorCrew
                     .mapNotNull { member ->
                         val tmdbPersonId = member.id ?: return@mapNotNull null
-                        val name = resolvePersonName(
-                            localizedName = member.name,
-                            originalName = member.originalName,
-                            fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                        val name = resolveDisplayLabel(
+                            localized = member.name,
+                            original = member.originalName,
+                            fallbackEnglish = englishFallbackNames[tmdbPersonId],
                             preferredLanguage = normalizedLanguage
                         )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
@@ -381,10 +381,10 @@ class TmdbMetadataService(
 
                 val director = directorCrew
                     .mapNotNull { member ->
-                        resolvePersonName(
-                            localizedName = member.name,
-                            originalName = member.originalName,
-                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                        resolveDisplayLabel(
+                            localized = member.name,
+                            original = member.originalName,
+                            fallbackEnglish = member.id?.let { englishFallbackNames[it] },
                             preferredLanguage = normalizedLanguage
                         )?.takeIf { it.isNotBlank() }
                     }
@@ -399,10 +399,10 @@ class TmdbMetadataService(
                 val writerMembers = writerCrew
                     .mapNotNull { member ->
                         val tmdbPersonId = member.id ?: return@mapNotNull null
-                        val name = resolvePersonName(
-                            localizedName = member.name,
-                            originalName = member.originalName,
-                            fallbackEnglishName = englishFallbackNames[tmdbPersonId],
+                        val name = resolveDisplayLabel(
+                            localized = member.name,
+                            original = member.originalName,
+                            fallbackEnglish = englishFallbackNames[tmdbPersonId],
                             preferredLanguage = normalizedLanguage
                         )?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                         MetaCastMember(
@@ -416,10 +416,10 @@ class TmdbMetadataService(
 
                 val writer = writerCrew
                     .mapNotNull { member ->
-                        resolvePersonName(
-                            localizedName = member.name,
-                            originalName = member.originalName,
-                            fallbackEnglishName = member.id?.let { englishFallbackNames[it] },
+                        resolveDisplayLabel(
+                            localized = member.name,
+                            original = member.originalName,
+                            fallbackEnglish = member.id?.let { englishFallbackNames[it] },
                             preferredLanguage = normalizedLanguage
                         )?.takeIf { it.isNotBlank() }
                     }
@@ -807,10 +807,10 @@ class TmdbMetadataService(
                 null
             }
             val englishTitlesById = englishCollectionTitlesById(englishCollection?.parts.orEmpty())
-            val resolvedCollectionName = resolvePersonName(
-                localizedName = collectionResponse?.name,
-                originalName = null,
-                fallbackEnglishName = englishCollection?.name,
+            val resolvedCollectionName = resolveDisplayLabel(
+                localized = collectionResponse?.name,
+                original = null,
+                fallbackEnglish = englishCollection?.name,
                 preferredLanguage = normalizedLanguage
             )
 
@@ -827,10 +827,10 @@ class TmdbMetadataService(
             val items = coroutineScope {
                 sortedParts.map { part ->
                     async {
-                        val title = resolvePersonName(
-                            localizedName = part.title,
-                            originalName = part.originalTitle,
-                            fallbackEnglishName = englishTitlesById[part.id],
+                        val title = resolveDisplayLabel(
+                            localized = part.title,
+                            original = part.originalTitle,
+                            fallbackEnglish = englishTitlesById[part.id],
                             preferredLanguage = normalizedLanguage
                         ) ?: return@async null
 
@@ -1115,10 +1115,10 @@ class TmdbMetadataService(
         preferredLanguage: String,
         englishTitlesById: Map<Int, String>
     ): MetaPreview? {
-        val title = resolvePersonName(
-            localizedName = result.title ?: result.name,
-            originalName = result.originalTitle ?: result.originalName,
-            fallbackEnglishName = englishTitlesById[result.id],
+        val title = resolveDisplayLabel(
+            localized = result.title ?: result.name,
+            original = result.originalTitle ?: result.originalName,
+            fallbackEnglish = englishTitlesById[result.id],
             preferredLanguage = preferredLanguage
         ) ?: return null
 
@@ -1346,10 +1346,10 @@ class TmdbMetadataService(
                     person.biography
                 }?.takeIf { it.isNotBlank() }
 
-                val resolvedPersonName = resolvePersonName(
-                    localizedName = person.name,
-                    originalName = person.originalName,
-                    fallbackEnglishName = englishPerson?.name,
+                val resolvedPersonName = resolveDisplayLabel(
+                    localized = person.name,
+                    original = person.originalName,
+                    fallbackEnglish = englishPerson?.name,
                     preferredLanguage = normalizedLanguage
                 ) ?: "Unknown"
 
@@ -1424,10 +1424,10 @@ class TmdbMetadataService(
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenMovieIds.add(credit.id)) return@mapNotNull null
-                val title = resolvePersonName(
-                    localizedName = credit.title ?: credit.name,
-                    originalName = credit.originalTitle ?: credit.originalName,
-                    fallbackEnglishName = englishTitlesById[credit.id],
+                val title = resolveDisplayLabel(
+                    localized = credit.title ?: credit.name,
+                    original = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglish = englishTitlesById[credit.id],
                     preferredLanguage = preferredLanguage
                 ) ?: return@mapNotNull null
                 val year = credit.releaseDate?.take(4)
@@ -1458,10 +1458,10 @@ class TmdbMetadataService(
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenMovieIds.add(credit.id)) return@mapNotNull null
-                val title = resolvePersonName(
-                    localizedName = credit.title ?: credit.name,
-                    originalName = credit.originalTitle ?: credit.originalName,
-                    fallbackEnglishName = englishTitlesById[credit.id],
+                val title = resolveDisplayLabel(
+                    localized = credit.title ?: credit.name,
+                    original = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglish = englishTitlesById[credit.id],
                     preferredLanguage = preferredLanguage
                 ) ?: return@mapNotNull null
                 val year = credit.releaseDate?.take(4)
@@ -1492,10 +1492,10 @@ class TmdbMetadataService(
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenTvIds.add(credit.id)) return@mapNotNull null
-                val title = resolvePersonName(
-                    localizedName = credit.name ?: credit.title,
-                    originalName = credit.originalName ?: credit.originalTitle,
-                    fallbackEnglishName = englishTitlesById[credit.id],
+                val title = resolveDisplayLabel(
+                    localized = credit.name ?: credit.title,
+                    original = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglish = englishTitlesById[credit.id],
                     preferredLanguage = preferredLanguage
                 ) ?: return@mapNotNull null
                 val year = credit.firstAirDate?.take(4)
@@ -1526,10 +1526,10 @@ class TmdbMetadataService(
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seenTvIds.add(credit.id)) return@mapNotNull null
-                val title = resolvePersonName(
-                    localizedName = credit.name ?: credit.title,
-                    originalName = credit.originalName ?: credit.originalTitle,
-                    fallbackEnglishName = englishTitlesById[credit.id],
+                val title = resolveDisplayLabel(
+                    localized = credit.name ?: credit.title,
+                    original = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglish = englishTitlesById[credit.id],
                     preferredLanguage = preferredLanguage
                 ) ?: return@mapNotNull null
                 val year = credit.firstAirDate?.take(4)
@@ -1809,17 +1809,17 @@ internal fun containsCjkOrHangul(text: String): Boolean {
     }
 }
 
-internal fun resolvePersonName(
-    localizedName: String?,
-    originalName: String?,
-    fallbackEnglishName: String? = null,
+internal fun resolveDisplayLabel(
+    localized: String?,
+    original: String?,
+    fallbackEnglish: String? = null,
     preferredLanguage: String
 ): String? {
-    val name = localizedName?.trim()?.takeIf { it.isNotBlank() }
-    val original = originalName?.trim()?.takeIf { it.isNotBlank() }
-    val fallback = fallbackEnglishName?.trim()?.takeIf { it.isNotBlank() }
+    val name = localized?.trim()?.takeIf { it.isNotBlank() }
+    val originalLabel = original?.trim()?.takeIf { it.isNotBlank() }
+    val fallback = fallbackEnglish?.trim()?.takeIf { it.isNotBlank() }
 
-    if (name == null) return original ?: fallback
+    if (name == null) return originalLabel ?: fallback
     val lang = preferredLanguage.lowercase(Locale.US)
 
     // User explicitly prefers CJK / Hangul
@@ -1827,14 +1827,14 @@ internal fun resolvePersonName(
         return name
     }
 
-    // If already Latin or non-CJK script, keep localized name
+    // If already Latin or non-CJK script, keep localized label
     if (!containsCjkOrHangul(name)) {
         return name
     }
 
-    // Name is CJK/Hangul: if originalName is Latin (Romaji/stage name), use it
-    if (original != null && !containsCjkOrHangul(original)) {
-        return original
+    // Label is CJK/Hangul: if original is Latin (Romaji/stage name), use it
+    if (originalLabel != null && !containsCjkOrHangul(originalLabel)) {
+        return originalLabel
     }
 
     // If English fallback exists and is Latin / non-CJK, prefer it
@@ -1843,5 +1843,5 @@ internal fun resolvePersonName(
     }
 
     // Otherwise fallback to whatever non-null exists
-    return fallback ?: original ?: name
+    return fallback ?: originalLabel ?: name
 }

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/TmdbApi.kt
@@ -708,6 +708,7 @@ data class TmdbCollectionResponse(
 data class TmdbCollectionPart(
     @Json(name = "id") val id: Int,
     @Json(name = "title") val title: String? = null,
+    @Json(name = "original_title") val originalTitle: String? = null,
     @Json(name = "overview") val overview: String? = null,
     @Json(name = "release_date") val releaseDate: String? = null,
     @Json(name = "poster_path") val posterPath: String? = null,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsViewModel.kt
@@ -8,6 +8,7 @@ import com.nuvio.tv.core.player.StreamAutoPlayPolicy
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.core.tmdb.TmdbMovieCollection
 import com.nuvio.tv.core.tmdb.TmdbService
 import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.MDBListSettingsDataStore
@@ -1301,25 +1302,28 @@ class MetaDetailsViewModel @Inject constructor(
                 return@launch
             }
 
-            val items = runCatching {
+            val collection = runCatching {
                 tmdbMetadataService.fetchMovieCollection(
                     collectionId = collectionId,
                     language = settings.language
                 )
             }.getOrElse {
                 Log.w(TAG, "Failed to load collection $collectionId: ${it.message}")
-                emptyList()
+                TmdbMovieCollection(name = null, items = emptyList())
             }
 
             val filteredItems = if (hideUnreleasedContent) {
                 val today = LocalDate.now()
-                items.filterNot { it.isUnreleased(today) }
+                collection.items.filterNot { it.isUnreleased(today) }
             } else {
-                items
+                collection.items
             }
 
             _uiState.update { state ->
-                state.copy(collection = filteredItems, collectionName = collectionName)
+                state.copy(
+                    collection = filteredItems,
+                    collectionName = collection.name ?: collectionName
+                )
             }
         }
     }

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -643,6 +643,68 @@ class TmdbMetadataServiceTest {
     }
 
     @Test
+    fun `fetchEnrichment falls back CJK movie title to English`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getMovieDetails(10, any(), "tr-TR") } returns Response.success(
+            TmdbDetailsResponse(
+                id = 10,
+                title = "チェンソーマン総集篇 後篇",
+                originalTitle = "チェンソーマン総集篇 後篇",
+                originalLanguage = "ja"
+            )
+        )
+        coEvery { api.getMovieDetails(10, any(), "en") } returns Response.success(
+            TmdbDetailsResponse(
+                id = 10,
+                title = "Chainsaw Man - The Compilation Movie",
+                originalTitle = "チェンソーマン総集篇 後篇",
+                originalLanguage = "ja"
+            )
+        )
+        coEvery { api.getMovieCredits(any(), any(), any()) } returns Response.success(TmdbCreditsResponse())
+        coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+        coEvery { api.getMovieReleaseDates(any(), any()) } returns Response.success(TmdbMovieReleaseDatesResponse())
+        coEvery { api.getMovieVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 10))
+
+        val service = TmdbMetadataService(api)
+        val enrichment = service.fetchEnrichment(
+            tmdbId = "10",
+            contentType = ContentType.MOVIE,
+            language = "tr-TR"
+        )
+
+        assertEquals("Chainsaw Man - The Compilation Movie", enrichment?.localizedTitle)
+        coVerify(exactly = 1) { api.getMovieDetails(10, any(), "en") }
+    }
+
+    @Test
+    fun `fetchEnrichment keeps CJK movie title when language is Japanese`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getMovieDetails(10, any(), "ja-JP") } returns Response.success(
+            TmdbDetailsResponse(
+                id = 10,
+                title = "チェンソーマン総集篇 後篇",
+                originalTitle = "チェンソーマン総集篇 後篇",
+                originalLanguage = "ja"
+            )
+        )
+        coEvery { api.getMovieCredits(any(), any(), any()) } returns Response.success(TmdbCreditsResponse())
+        coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+        coEvery { api.getMovieReleaseDates(any(), any()) } returns Response.success(TmdbMovieReleaseDatesResponse())
+        coEvery { api.getMovieVideos(any(), any(), any()) } returns Response.success(TmdbVideosResponse(id = 10))
+
+        val service = TmdbMetadataService(api)
+        val enrichment = service.fetchEnrichment(
+            tmdbId = "10",
+            contentType = ContentType.MOVIE,
+            language = "ja-JP"
+        )
+
+        assertEquals("チェンソーマン総集篇 後篇", enrichment?.localizedTitle)
+        coVerify(exactly = 0) { api.getMovieDetails(10, any(), "en") }
+    }
+
+    @Test
     fun `fetchEnrichment falls back TV aggregate credits cast and creator names to English for Polish locale`() = runTest {
         val api = mockk<TmdbApi>()
         coEvery { api.getTvDetails(255358, any(), "pl-PL") } returns Response.success(

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -465,97 +465,97 @@ class TmdbMetadataServiceTest {
     }
 
     @Test
-    fun `resolvePersonName falls back JP kanji to romaji or english for non-CJK locales`() {
+    fun `resolveDisplayLabel falls back JP kanji to romaji or english for non-CJK locales`() {
         assertEquals(
             "Takuya Kimura",
-            resolvePersonName("木村拓哉", "Takuya Kimura", null, "tr-TR")
+            resolveDisplayLabel("木村拓哉", "Takuya Kimura", null, "tr-TR")
         )
         assertEquals(
             "Takuya Kimura",
-            resolvePersonName("木村拓哉", "木村拓哉", "Takuya Kimura", "tr-TR")
+            resolveDisplayLabel("木村拓哉", "木村拓哉", "Takuya Kimura", "tr-TR")
         )
         assertEquals(
             "Tsuyoshi Kusanagi",
-            resolvePersonName("草彅剛", "Tsuyoshi Kusanagi", null, "pl-PL")
+            resolveDisplayLabel("草彅剛", "Tsuyoshi Kusanagi", null, "pl-PL")
         )
         assertEquals(
             "Atsuko Tanaka",
-            resolvePersonName("田中敦子", "田中敦子", "Atsuko Tanaka", "de-DE")
+            resolveDisplayLabel("田中敦子", "田中敦子", "Atsuko Tanaka", "de-DE")
         )
     }
 
     @Test
-    fun `resolvePersonName keeps kanji when user language is Japanese`() {
+    fun `resolveDisplayLabel keeps kanji when user language is Japanese`() {
         assertEquals(
             "木村拓哉",
-            resolvePersonName("木村拓哉", "Takuya Kimura", "Takuya Kimura", "ja-JP")
+            resolveDisplayLabel("木村拓哉", "Takuya Kimura", "Takuya Kimura", "ja-JP")
         )
         assertEquals(
             "田中敦子",
-            resolvePersonName("田中敦子", "田中敦子", "Atsuko Tanaka", "ja")
+            resolveDisplayLabel("田中敦子", "田中敦子", "Atsuko Tanaka", "ja")
         )
     }
 
     @Test
-    fun `resolvePersonName falls back Hangul to Latin for non-Korean locales`() {
+    fun `resolveDisplayLabel falls back Hangul to Latin for non-Korean locales`() {
         assertEquals(
             "Kim Soo-hyun",
-            resolvePersonName("김수현", "Kim Soo-hyun", null, "de-DE")
+            resolveDisplayLabel("김수현", "Kim Soo-hyun", null, "de-DE")
         )
         assertEquals(
             "Kim Soo-hyun",
-            resolvePersonName("김수현", "김수현", "Kim Soo-hyun", "fr-FR")
+            resolveDisplayLabel("김수현", "김수현", "Kim Soo-hyun", "fr-FR")
         )
     }
 
     @Test
-    fun `resolvePersonName keeps Hangul when user language is Korean`() {
+    fun `resolveDisplayLabel keeps Hangul when user language is Korean`() {
         assertEquals(
             "김수현",
-            resolvePersonName("김수현", "Kim Soo-hyun", "Kim Soo-hyun", "ko-KR")
+            resolveDisplayLabel("김수현", "Kim Soo-hyun", "Kim Soo-hyun", "ko-KR")
         )
     }
 
     @Test
-    fun `resolvePersonName falls back Chinese hanzi to stage name for non-Chinese locales`() {
+    fun `resolveDisplayLabel falls back Chinese hanzi to stage name for non-Chinese locales`() {
         assertEquals(
             "Jackie Chan",
-            resolvePersonName("成龙", "Jackie Chan", null, "es-ES")
+            resolveDisplayLabel("成龙", "Jackie Chan", null, "es-ES")
         )
         assertEquals(
             "Jackie Chan",
-            resolvePersonName("成龙", "成龙", "Jackie Chan", "en-US")
+            resolveDisplayLabel("成龙", "成龙", "Jackie Chan", "en-US")
         )
     }
 
     @Test
-    fun `resolvePersonName keeps hanzi when user language is Chinese`() {
+    fun `resolveDisplayLabel keeps hanzi when user language is Chinese`() {
         assertEquals(
             "成龙",
-            resolvePersonName("成龙", "Jackie Chan", "Jackie Chan", "zh-CN")
+            resolveDisplayLabel("成龙", "Jackie Chan", "Jackie Chan", "zh-CN")
         )
     }
 
     @Test
-    fun `resolvePersonName leaves already-Latin names unchanged`() {
+    fun `resolveDisplayLabel leaves already-Latin names unchanged`() {
         assertEquals(
             "Scarlett Johansson",
-            resolvePersonName("Scarlett Johansson", "Scarlett Johansson", null, "tr-TR")
+            resolveDisplayLabel("Scarlett Johansson", "Scarlett Johansson", null, "tr-TR")
         )
         assertEquals(
             "Tom Hanks",
-            resolvePersonName("Tom Hanks", "Tom Hanks", null, "ja-JP")
+            resolveDisplayLabel("Tom Hanks", "Tom Hanks", null, "ja-JP")
         )
     }
 
     @Test
-    fun `resolvePersonName handles null and blank inputs`() {
-        assertEquals("Takuya Kimura", resolvePersonName(null, "Takuya Kimura", null, "tr-TR"))
-        assertEquals("Scarlett Johansson", resolvePersonName("Scarlett Johansson", null, null, "tr-TR"))
-        assertNull(resolvePersonName(null, null, null, "tr-TR"))
+    fun `resolveDisplayLabel handles null and blank inputs`() {
+        assertEquals("Takuya Kimura", resolveDisplayLabel(null, "Takuya Kimura", null, "tr-TR"))
+        assertEquals("Scarlett Johansson", resolveDisplayLabel("Scarlett Johansson", null, null, "tr-TR"))
+        assertNull(resolveDisplayLabel(null, null, null, "tr-TR"))
         assertEquals(
             "Takuya Kimura",
-            resolvePersonName("  木村拓哉  ", "Takuya Kimura", null, "fr-FR")
+            resolveDisplayLabel("  木村拓哉  ", "Takuya Kimura", null, "fr-FR")
         )
     }
 

--- a/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tmdb/TmdbMetadataServiceTest.kt
@@ -5,6 +5,8 @@ import com.nuvio.tv.data.remote.api.TmdbAggregateCreditsResponse
 import com.nuvio.tv.data.remote.api.TmdbAggregateRole
 import com.nuvio.tv.data.remote.api.TmdbApi
 import com.nuvio.tv.data.remote.api.TmdbCastMember
+import com.nuvio.tv.data.remote.api.TmdbCollectionPart
+import com.nuvio.tv.data.remote.api.TmdbCollectionResponse
 import com.nuvio.tv.data.remote.api.TmdbCompany
 import com.nuvio.tv.data.remote.api.TmdbCompanyDetailsResponse
 import com.nuvio.tv.data.remote.api.TmdbCreatedBy
@@ -26,6 +28,7 @@ import com.nuvio.tv.data.remote.api.TmdbTvContentRatingsResponse
 import com.nuvio.tv.data.remote.api.TmdbVideosResponse
 import com.nuvio.tv.domain.model.ContentType
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -788,6 +791,88 @@ class TmdbMetadataServiceTest {
         assertNotNull(detail)
         assertEquals("Ghost in the Shell: Stand Alone Complex", detail?.tvCredits?.single()?.name)
         assertEquals("Make My Day", detail?.movieCredits?.single()?.name)
+    }
+
+    @Test
+    fun `fetchMovieCollection falls back CJK titles to English`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getCollectionDetails(10, any(), "tr-TR") } returns Response.success(
+            TmdbCollectionResponse(
+                id = 10,
+                name = "チェンソーマン シリーズ",
+                parts = listOf(
+                    TmdbCollectionPart(
+                        id = 1,
+                        title = "Movie: Reze Arc",
+                        originalTitle = "チェンソーマン レゼ編",
+                        releaseDate = "2025-09-19",
+                        posterPath = "/reze.jpg"
+                    ),
+                    TmdbCollectionPart(
+                        id = 2,
+                        title = "チェンソーマン総集篇 前篇",
+                        originalTitle = "チェンソーマン総集篇 前篇",
+                        releaseDate = "2023-09-22",
+                        posterPath = "/part1.jpg"
+                    ),
+                    TmdbCollectionPart(
+                        id = 3,
+                        title = "チェンソーマン総集篇 後篇",
+                        originalTitle = "チェンソーマン総集篇 後篇",
+                        releaseDate = "2023-09-22",
+                        posterPath = "/part2.jpg"
+                    )
+                )
+            )
+        )
+        coEvery { api.getCollectionDetails(10, any(), "en") } returns Response.success(
+            TmdbCollectionResponse(
+                id = 10,
+                name = "Chainsaw Man Collection",
+                parts = listOf(
+                    TmdbCollectionPart(id = 1, title = "Chainsaw Man – The Movie: Reze Arc"),
+                    TmdbCollectionPart(id = 2, title = "Chainsaw Man Compilation Movie 1"),
+                    TmdbCollectionPart(id = 3, title = "Chainsaw Man Compilation Movie 2")
+                )
+            )
+        )
+        coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+
+        val service = TmdbMetadataService(api)
+        val collection = service.fetchMovieCollection(collectionId = 10, language = "tr-TR")
+
+        assertEquals("Chainsaw Man Collection", collection.name)
+        assertEquals("Movie: Reze Arc", collection.items.single { it.id == "tmdb:1" }.name)
+        assertEquals("Chainsaw Man Compilation Movie 1", collection.items.single { it.id == "tmdb:2" }.name)
+        assertEquals("Chainsaw Man Compilation Movie 2", collection.items.single { it.id == "tmdb:3" }.name)
+        coVerify(exactly = 1) { api.getCollectionDetails(10, any(), "en") }
+    }
+
+    @Test
+    fun `fetchMovieCollection keeps CJK titles when language is Japanese`() = runTest {
+        val api = mockk<TmdbApi>()
+        coEvery { api.getCollectionDetails(10, any(), "ja-JP") } returns Response.success(
+            TmdbCollectionResponse(
+                id = 10,
+                name = "チェンソーマン シリーズ",
+                parts = listOf(
+                    TmdbCollectionPart(
+                        id = 2,
+                        title = "チェンソーマン総集篇 前篇",
+                        originalTitle = "チェンソーマン総集篇 前篇",
+                        posterPath = "/part1.jpg"
+                    )
+                )
+            )
+        )
+        coEvery { api.getMovieImages(any(), any(), any()) } returns Response.success(TmdbImagesResponse())
+
+        val service = TmdbMetadataService(api)
+        val collection = service.fetchMovieCollection(collectionId = 10, language = "ja-JP")
+
+        assertEquals("チェンソーマン シリーズ", collection.name)
+        assertEquals("チェンソーマン総集篇 前篇", collection.items.single().name)
+        coVerify(exactly = 0) { api.getCollectionDetails(10, any(), "en") }
     }
 
     private data class MovieDiscoverCall(


### PR DESCRIPTION
## Summary

Continue the TMDB CJK display fallback from #3192 onto collection rows and detail-page titles.

#3192 reused `resolvePersonName` for person filmography labels and left detail-page enrichment titles out of scope. Collection names, collection part titles, and the hero title after opening a collection item still showed original CJK script when the selected metadata language (for example Turkish) had no TMDB translation. This PR applies the same fallback there: keep the localized title when it is already Latin (including Turkish), otherwise use the English TMDB title. `ja` / `ko` / `zh` locales still keep original-script titles.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

This is the remaining gap from #3192. Cast names and filmography rows already fall back CJK script to a Latin English title when the app language is not Japanese, Korean, or Chinese. Collection rails and TMDB-only detail pages did not: TMDB returns the original-script `title`/`name` when no translation exists, so Chainsaw Man collection cards and the opened movie hero stayed in Japanese. English TMDB titles (official international names) should be used in that case, not a language-specific extra rule. If TMDB does have a Turkish (or other non-CJK) translation, that localized title is kept.

## Issue or approval

Continuation of #3192. No new issue: localization-only update. Same CJK display fallback, now on collection names/parts and detail enrichment titles that #3192 explicitly left unchanged.

## Reproduction steps

No reproduction steps - localization-only update.

Manual check used while developing:

1. Set TMDB / app metadata language to a non-CJK locale (for example Turkish).
2. Open a Japanese collection item (example: Chainsaw Man collection, then a compilation movie).
3. Before: collection header and part labels are CJK (for example `チェンソーマン シリーズ`, `チェンソーマン総集篇 後篇`). Opening the part keeps the CJK hero title.
4. After: the collection uses English TMDB titles (`Chainsaw Man Collection`, `Chainsaw Man - The Compilation Part 2`). Latin/Turkish localized titles stay unchanged. `ja` / `ko` / `zh` locales still keep original-script titles.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to TMDB collection fetch (`fetchMovieCollection` name + parts), detail enrichment title fallback (`fetchEnrichment.localizedTitle`), the details ViewModel using the resolved collection name, `TmdbCollectionPart.originalTitle`, and unit tests. Does not change strings.xml, collection-editor TMDB source rows, person/cast filmography (already covered by #3192), or add romaji transliteration.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.tmdb.TmdbMetadataServiceTest` — passed, including `fetchMovieCollection falls back CJK titles to English`, `fetchMovieCollection keeps CJK titles when language is Japanese`, `fetchEnrichment falls back CJK movie title to English`, and `fetchEnrichment keeps CJK movie title when language is Japanese`.
- Existing CJK cast/filmography tests still pass.
- Manual: Android TV `192.168.2.13:5555` (Smart TV Pro), Chainsaw Man collection and compilation detail, non-CJK metadata language. Before screenshots had CJK collection and hero titles; after screenshots showed English TMDB titles.

## Screenshots / Video

| Before | After |
|:------:|:-----:|
| <img width="1920" height="1080" alt="fizik-tv-cjk" src="https://github.com/user-attachments/assets/62796319-30a2-450e-8f48-1697bd0438dc" /> | <img width="1920" height="1080" alt="fizik-tv-cjk-yeni" src="https://github.com/user-attachments/assets/0121d099-6ae4-46f5-875a-029f2a061132" /> |
| <img width="1920" height="1080" alt="fizik-tv-cjk-detail" src="https://github.com/user-attachments/assets/5088dc58-c451-49d7-91a2-4380161fee20" /> | <img width="1920" height="1080" alt="fizik-tv-cjk-detail-yeni" src="https://github.com/user-attachments/assets/a6b4f170-1df2-4ecf-afc4-510db4bee679" /> |
## Breaking changes


None

## Linked issues

Continuation of #3192 (`Reuse CJK name fallback for TMDB filmography titles.`). That PR fixed person filmography labels and called out detail-page enrichment titles as out of scope. This PR covers that remaining collection-row and detail-title CJK display gap
