### PR TITLE
fix: stop the home placeholder shimmer once the rows have loaded

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePlaceholderShimmer.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePlaceholderShimmer.kt
@@ -1,0 +1,13 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.isPlaceholder
+
+/**
+ * A catalog row draws the sweeping placeholder shimmer only while it is still loading and its
+ * cards are placeholders. Once the real posters arrive nothing reads the shimmer offset any more.
+ */
+internal fun showsPlaceholderShimmer(isLoading: Boolean, firstItemImageUrl: String?): Boolean =
+    isLoading && firstItemImageUrl.isPlaceholder()
+
+internal fun HeroCarouselRow.showsPlaceholderShimmer(): Boolean =
+    showsPlaceholderShimmer(isLoading, items.list.firstOrNull()?.imageUrl)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -470,7 +470,7 @@ internal fun ModernRowSection(
     onLoadMoreCatalog: (String, String, String) -> Unit,
     onBackdropInteraction: () -> Unit,
     onExpandedCatalogFocusKeyChange: (String?) -> Unit,
-    sharedPlaceholderShimmerOffsetState: State<Float>,
+    sharedPlaceholderShimmerOffsetState: State<Float>?,
     itemFocusRequesters: StableRef<MutableMap<Int, FocusRequester>> = StableRef(mutableMapOf())
 ) {
     // Unwrap StableRef wrappers
@@ -853,8 +853,7 @@ internal fun ModernRowSection(
         }
 
         CompositionLocalProvider(LocalBringIntoViewSpec provides horizontalBringIntoViewSpec) {
-            val usesPlaceholderShimmer = row.isLoading &&
-                row.items.list.firstOrNull()?.imageUrl.isPlaceholder()
+            val usesPlaceholderShimmer = row.showsPlaceholderShimmer()
             val placeholderShimmerOffsetState = if (usesPlaceholderShimmer) {
                 sharedPlaceholderShimmerOffsetState
             } else {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -247,7 +248,22 @@ internal fun ModernHomeRowsList(
 
     val defaultBringIntoViewSpec = LocalBringIntoViewSpec.current
 
-    val sharedPlaceholderShimmerOffsetState = rememberPlaceholderShimmerOffsetState(label = "sharedRowShimmer")
+    // Only run the shared shimmer while a row on screen actually draws it: rememberInfiniteTransition
+    // keeps waking the Compose frame clock on every frame for as long as it is composed, even when
+    // nothing reads its value. Rows below the fold stay placeholders until they are scrolled to, so
+    // the check has to be on the visible rows, not on the whole list.
+    val needsPlaceholderShimmer by remember(carouselRows) {
+        derivedStateOf {
+            verticalRowListState.layoutInfo.visibleItemsInfo.any { visibleRow ->
+                carouselRows.list.getOrNull(visibleRow.index)?.showsPlaceholderShimmer() == true
+            }
+        }
+    }
+    val sharedPlaceholderShimmerOffsetState = if (needsPlaceholderShimmer) {
+        rememberPlaceholderShimmerOffsetState(label = "sharedRowShimmer")
+    } else {
+        null
+    }
 
     CompositionLocalProvider(
         LocalBringIntoViewSpec provides verticalRowBringIntoViewSpec,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRowsList.kt
@@ -251,11 +251,15 @@ internal fun ModernHomeRowsList(
     // Only run the shared shimmer while a row on screen actually draws it: rememberInfiniteTransition
     // keeps waking the Compose frame clock on every frame for as long as it is composed, even when
     // nothing reads its value. Rows below the fold stay placeholders until they are scrolled to, so
-    // the check has to be on the visible rows, not on the whole list.
-    val needsPlaceholderShimmer by remember(carouselRows) {
+    // the check has to be on the visible rows, not on the whole list. Keyed on the list state for
+    // the same reason isVerticalRowsScrollingState is in ModernHomeContent: rememberLazyListState
+    // is saveable-backed and can hand back a new instance, and a derived state still holding the
+    // old one would read a layout that has stopped updating.
+    val needsPlaceholderShimmer by remember(verticalRowListState) {
         derivedStateOf {
+            val rows = latestCarouselRowsForLazy.value.list
             verticalRowListState.layoutInfo.visibleItemsInfo.any { visibleRow ->
-                carouselRows.list.getOrNull(visibleRow.index)?.showsPlaceholderShimmer() == true
+                rows.getOrNull(visibleRow.index)?.showsPlaceholderShimmer() == true
             }
         }
     }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomePlaceholderShimmerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ModernHomePlaceholderShimmerTest.kt
@@ -1,0 +1,92 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.PLACEHOLDER_IMAGE_URL
+import com.nuvio.tv.ui.util.StableList
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModernHomePlaceholderShimmerTest {
+
+    @Test
+    fun `a loading row of placeholder cards draws the shimmer`() {
+        assertTrue(showsPlaceholderShimmer(isLoading = true, firstItemImageUrl = PLACEHOLDER_IMAGE_URL))
+    }
+
+    @Test
+    fun `a loaded row draws no shimmer even while its cards are still placeholders`() {
+        assertFalse(showsPlaceholderShimmer(isLoading = false, firstItemImageUrl = PLACEHOLDER_IMAGE_URL))
+    }
+
+    @Test
+    fun `a loading row with real posters draws no shimmer`() {
+        assertFalse(showsPlaceholderShimmer(isLoading = true, firstItemImageUrl = "https://example.test/poster.jpg"))
+    }
+
+    @Test
+    fun `an empty row draws no shimmer`() {
+        assertFalse(showsPlaceholderShimmer(isLoading = true, firstItemImageUrl = null))
+    }
+
+    @Test
+    fun `a row still loading placeholders drives the shared shimmer`() {
+        assertTrue(row(key = "loading", isLoading = true, imageUrl = PLACEHOLDER_IMAGE_URL).showsPlaceholderShimmer())
+    }
+
+    @Test
+    fun `a loaded row does not drive the shared shimmer`() {
+        assertFalse(row(key = "movies", isLoading = false, imageUrl = "https://example.test/a.jpg").showsPlaceholderShimmer())
+    }
+
+    @Test
+    fun `a row with no items does not drive the shared shimmer`() {
+        assertFalse(emptyRow(key = "empty", isLoading = true).showsPlaceholderShimmer())
+    }
+
+    private fun emptyRow(key: String, isLoading: Boolean): HeroCarouselRow =
+        HeroCarouselRow(
+            key = key,
+            title = key,
+            globalRowIndex = 0,
+            items = StableList(emptyList()),
+            isLoading = isLoading
+        )
+
+    private fun row(key: String, isLoading: Boolean, imageUrl: String?): HeroCarouselRow =
+        HeroCarouselRow(
+            key = key,
+            title = key,
+            globalRowIndex = 0,
+            items = StableList(listOf(item(key = key, imageUrl = imageUrl))),
+            isLoading = isLoading
+        )
+
+    private fun item(key: String, imageUrl: String?): ModernCarouselItem =
+        ModernCarouselItem(
+            key = key,
+            title = key,
+            subtitle = null,
+            imageUrl = imageUrl,
+            heroPreview = HeroPreview(
+                title = key,
+                logo = null,
+                description = null,
+                contentTypeText = null,
+                yearText = null,
+                imdbText = null,
+                genres = StableList(emptyList()),
+                poster = imageUrl,
+                backdrop = null,
+                imageUrl = imageUrl
+            ),
+            payload = ModernPayload.Catalog(
+                focusKey = key,
+                itemId = key,
+                itemType = "movie",
+                addonBaseUrl = "https://example.test/manifest.json",
+                trailerTitle = key,
+                trailerReleaseInfo = null,
+                trailerApiType = "movie"
+            )
+        )
+}


### PR DESCRIPTION
## Summary

`ModernHomeRowsList` created the shared placeholder-shimmer `InfiniteTransition` unconditionally, so it kept animating for the whole life of the Home screen. This makes it exist only while a row that is currently on screen actually draws the shimmer.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`rememberInfiniteTransition` requests a frame for as long as it is composed. The shared shimmer offset was created once at the top of `ModernHomeRowsList`, so after every row had real posters — and every consumer was already passing `null` — the animation still wrote a `Float` state on every frame forever.

Measured on a Fire TV Cube (AFTGAZL, Fire OS 7.7.1.5 / Android 9, `assembleFullRelease` armeabi-v7a), Home idle with no remote input:

| screen | main-thread CPU (utime+stime delta from `/proc/<pid>/task/<tid>/stat`) |
|---|---|
| Home (Modern), before | **139-150 ticks / 30 s -> 4.6-7.5%** |
| Home (Modern), after | **0 ticks / 40 s** |
| Settings (control), before and after | 0 ticks / 30 s |

`dumpsys gfxinfo` showed "Total frames rendered" frozen the whole time, i.e. that CPU produced nothing visible. A `Snapshot.registerApplyObserver` in a temporary local build named the culprit: one `MutableState<Float>` written every frame from `AndroidUiFrameClock$withFrameNanos$2$callback$1`, values sweeping `-1f..2f`, which is `rememberPlaceholderShimmerOffsetState`'s `initialValue`/`targetValue`.

On a low-power TV box this is continuous wasted power and lost frame headroom on the most-used screen.

## Issue or approval

Fixes #3262

## Reproduction steps

1. Install a release build on an Android TV device and open the **Modern** home layout.
2. Let the rows finish loading, then do not touch the remote.
3. `adb shell dumpsys gfxinfo com.nuvio.tv | grep "Total frames rendered"` twice, 15 s apart -> the count does not move.
4. Sample main-thread CPU over the same idle window:
   ```sh
   PID=$(adb shell pidof com.nuvio.tv)
   adb shell cat /proc/$PID/task/$PID/stat | awk '{print $14+$15}'   # wait 30s, run again
   ```
   Before: delta ~140 ticks. After: 0.
5. Repeat on Settings for a control -> 0 both before and after.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

Nothing about what is drawn changes. `ModernRowSection` still passes `null` for rows that are not loading placeholders, and a placeholder card that gets no shared state still falls back to its own transition (`ModernHomeRows.kt` / `ContentCard.kt`), so a loading row shimmers exactly as before. The check is on the *visible* rows because rows below the fold stay placeholders until they are scrolled to; scrolling one into view starts the shared transition again.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- `PlaceholderShimmer.kt` (the animation itself, its timing, colours and draw modifier) is untouched.
- `CatalogRowSection` (classic home) already gated its transition correctly and is untouched.
- The only extraction is the row-level condition `row.isLoading && first item is a placeholder`, moved into `showsPlaceholderShimmer()` so the new list-level check and the existing row-level check cannot drift apart. No other refactoring, formatting or polish.
- Other findings from the same profiling session (install footprint of the extracted native libs, image cache high-water mark) are deliberately not in this PR.

## Testing

- Device: Fire TV Cube (AFTGAZL), Fire OS 7.7.1.5 / Android 9 (API 28), armeabi-v7a, release build (`CI_USE_DEBUG_SIGNING=true ./gradlew :app:assembleFullRelease`).
- Idle CPU on Home measured before/after as in the table above (0 ticks / 40 s after).
- Verified with a `Snapshot.registerApplyObserver` build that snapshot applies while idle on Home drop from continuous per-frame writes to `--- window: 0 applies ---`.
- Verified the shimmer still runs while rows are loading (per-frame `-1f..2f` writes during the initial catalog load) and stops once they are loaded.
- Cold start unchanged: `am start -W` TotalTime 1543 / 1742 / 1507 ms after, 1440 / 1572 ms before.
- Manual pass: cold start, Home rows load, vertical + horizontal navigation across rows, scrolling back to the top, Settings and back.
- Unit tests: new `ModernHomePlaceholderShimmerTest` (7 tests) passes. Full `:app:testFullReleaseUnitTest` shows the same failures on this branch as on a clean `dev` checkout of the same commit (14 vs 15, the extra one on `dev` being a date-dependent `ContinueWatchingAiringRulesTest` case) — no new failures.

## Screenshots / Video

Not a UI change — the shimmer is drawn exactly as before while a placeholder row is on screen, and it was invisible in the state this fixes (no frames were being rendered at all).

## Breaking changes

None.

## Linked issues

Fixes #3262
