### PR TITLE
fix: let the focus marquee stop instead of scrolling forever

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/FocusMarqueeText.kt
@@ -20,6 +20,16 @@ import androidx.tv.material3.Text
 // noticeably faster while keeping a comfortable margin below that rate.
 private val MarqueeVelocity = 45.dp
 
+// A marquee is an animation: it wakes the Compose frame clock ~50 times a second for as long as it
+// runs, and on a TV the focus can rest on the same row or card for hours. Unbounded
+// (Int.MAX_VALUE) that cost never ends -- a Settings sidebar left on "Content & Discovery" measured
+// 1460 frames and 271 CPU ticks over 30s on a Fire TV Cube, and would have gone on doing that all
+// night. Three passes is enough to read a long label, and matches what the platform has always
+// defaulted to for TextView (android:marqueeRepeatLimit="3"); after that the text rests and the
+// screen goes quiet. Moving focus away and back replays it, because the modifier only exists while
+// the item is focused.
+internal const val MarqueeIterations = 3
+
 /**
  * Returns true if the first strongly-directional character in this string is RTL (Hebrew, Arabic,
  * etc.), false if it's LTR. Digits, punctuation, and spaces are skipped since they have no
@@ -60,7 +70,7 @@ fun FocusMarqueeText(
         Text(
             text = text,
             modifier = if (focused) {
-                modifier.basicMarquee(iterations = Int.MAX_VALUE, velocity = MarqueeVelocity)
+                modifier.basicMarquee(iterations = MarqueeIterations, velocity = MarqueeVelocity)
             } else {
                 modifier
             },

--- a/app/src/test/java/com/nuvio/tv/ui/components/FocusMarqueeTextTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/components/FocusMarqueeTextTest.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.ui.components
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FocusMarqueeTextTest {
+
+    /**
+     * Guards against the marquee going unbounded again: on a TV the focus can rest on the same item
+     * indefinitely, and an unbounded marquee keeps the frame clock running for exactly as long. The
+     * count has to stay small and finite -- enough passes to read a long label, few enough that the
+     * screen falls silent on its own.
+     */
+    @Test
+    fun `the focus marquee stops on its own`() {
+        assertTrue("marquee must be bounded", MarqueeIterations in 1..5)
+    }
+}


### PR DESCRIPTION
## Summary

`FocusMarqueeText` scrolled a focused overflowing label with `basicMarquee(iterations = Int.MAX_VALUE)`. This bounds it to 3 passes, so the app can go idle again.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A marquee is an animation: it wakes the Compose frame clock ~50 times a second for as long as it runs. On a TV the focus rests on the same row or card for as long as the remote is left alone, so an unbounded marquee means the app never goes idle.

Measured on a Fire TV Cube (AFTGAZL, Fire OS 7.7.1.5 / Android 9, `assembleFullRelease` armeabi-v7a), no remote input, focus on the Settings sidebar item "Content & Discovery":

| state | frames | main-thread CPU |
|---|---|---|
| before | **1460 / 30 s (~49 fps)** | **271 ticks / 30 s (~9%)**, indefinitely |
| after | 630 / 15 s while the 3 passes run, then **0 / 25 s** | **0 ticks / 25 s** |
| control: focus on a label that fits (before and after) | 0 | 0 |

Same on Home with a Continue Watching card whose title overflows: 601 frames / 12 s; move focus one card sideways to a title that fits, 0 frames / 12 s; move back, 601 again. It tracks exactly whether the focused label overflows.

## Issue or approval

Fixes #3264

## Reproduction steps

1. Install a release build on an Android TV device.
2. Open Settings, put focus on a sidebar item whose label overflows ("Content & Discovery" in English).
3. Put the remote down.
4. `adb shell dumpsys gfxinfo com.nuvio.tv | grep "Total frames rendered"` twice, 30 s apart -> ~1460 frames, and it never stops.
5. `PID=$(adb shell pidof com.nuvio.tv); adb shell cat /proc/$PID/task/$PID/stat | awk '{print $14+$15}'` twice, 30 s apart -> ~270 ticks.
6. Move focus to a label that fits and repeat -> 0 and 0.

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

The label still scrolls when it takes focus and still reveals its full text; it now stops after 3 passes and rests instead of looping forever. Moving focus away and back replays it, because the modifier only exists while the item is focused. 3 is what the platform has always defaulted to for `TextView` (`android:marqueeRepeatLimit="3"`).

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `FocusMarqueeText` changes. `StreamBadgeChips` has the same unbounded `basicMarquee` on focused chips; I left it alone to keep this to one problem, and can send it separately if you want it fixed the same way.
- Velocity, direction, RTL handling, the ellipsize-when-unfocused behaviour and every call site are untouched.

## Testing

- Device: Fire TV Cube (AFTGAZL), Fire OS 7.7.1.5 / Android 9 (API 28), armeabi-v7a release build.
- Before/after frame and CPU measurements as in the table above, on both repro paths (Settings sidebar, Home Continue Watching card).
- Verified the marquee still runs and reveals the full label, and that moving focus away and back replays it.
- Unit test added (`FocusMarqueeTextTest`) guarding that the iteration count stays small and finite; it passes.

## Screenshots / Video

Static screenshots cannot show a scroll loop, so the evidence is the frame counter: `dumpsys gfxinfo` "Total frames rendered" climbs ~49 fps forever before the change and stops climbing after the passes complete. Visually nothing changes except that the label eventually comes to rest.

## Breaking changes

None.

## Linked issues

Fixes #3264
