### PR TITLE
chore(i18n): complete Greek locale parity (post-play, stats HUD, episode overlay)

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -501,6 +501,9 @@
   <string name="advanced_clear_cw_cache_done">Η προσωρινή μνήμη καθαρίστηκε</string>
   <string name="advanced_remember_last_profile">Απομνημόνευση τελευταίου προφίλ</string>
   <string name="advanced_remember_last_profile_subtitle">Απομνημόνευση του τελευταίου επιλεγμένου προφίλ κατά την εκκίνηση</string>
+  <string name="advanced_confirm_exit">Πλήρης έξοδος κατά το κλείσιμο</string>
+  <string name="advanced_confirm_exit_subtitle">Πλήρης τερματισμός της εφαρμογής και απελευθέρωση μνήμης κατά την έξοδο. Απαιτείται διπλό πάτημα του πλήκτρου πίσω για επιβεβαίωση.</string>
+  <string name="confirm_exit_toast">Πατήστε ξανά πίσω για έξοδο</string>
   <string name="settings_debug">Αποσφαλμάτωση</string>
   <string name="settings_debug_subtitle">Εργαλεία προγραμματιστή και σημαίες χαρακτηριστικών</string>
   <string name="settings_plugins_section_subtitle">Διαχείριση αποθετηρίων, παρόχων και καταστάσεων πρόσθετων</string>
@@ -743,6 +746,10 @@
   <string name="autoplay_mode_first">Αυτόματη αναπαραγωγή πρώτης πηγής</string>
   <string name="autoplay_mode_regex">Αυτόματη αναπαραγωγή με αντιστοίχιση κανονικής έκφρασης</string>
   <string name="autoplay_stream_selection">Αυτόματη επιλογή ροής</string>
+  <string name="autoplay_post_play_recommendations">Προτάσεις μετά την αναπαραγωγή</string>
+  <string name="autoplay_post_play_recommendations_sub">Εμφάνιση προτάσεων κοντά στο τέλος ταινιών και σειρών.</string>
+  <string name="autoplay_post_play_movie_threshold">Χρονισμός προτάσεων ταινιών</string>
+  <string name="autoplay_post_play_movie_threshold_sub">Επιλέξτε πότε εμφανίζονται οι προτάσεις ταινιών. Τα επεισόδια ακολουθούν τη ρύθμιση κατωφλίου επόμενου επεισοδίου.</string>
   <string name="autoplay_next_episode">Αυτόματη αναπαραγωγή επόμενου επεισοδίου</string>
   <string name="autoplay_next_episode_sub">Αυτόματη έναρξη επόμενου επεισοδίου όταν εμφανιστεί η προτροπή.</string>
   <string name="autoplay_next_episode_fallback">Εναλλακτική όταν αποτυγχάνει η ομάδα binge</string>
@@ -849,6 +856,14 @@
   <string name="layout_use_episode_thumbnails_cw_sub">Χρήση μικρογραφιών επεισοδίων ως προεπιλεγμένη εικόνα. Όταν είναι ανενεργό, χρησιμοποιείται backdrop.</string>
   <string name="layout_blur_unwatched">Θόλωμα μη προβληθέντων επεισοδίων</string>
   <string name="layout_blur_unwatched_sub">Θόλωμα μικρογραφιών επεισοδίων μέχρι να προβληθούν για αποφυγή spoilers.</string>
+  <string name="layout_episode_options_overlay">Επικάλυψη επιλογών επεισοδίου</string>
+  <string name="layout_episode_options_overlay_sub">Επιλέξτε την εμφάνιση που εμφανίζεται όταν κρατάτε πατημένο ένα επεισόδιο.</string>
+  <string name="layout_episode_options_overlay_none">Κανένα</string>
+  <string name="layout_episode_options_overlay_none_desc">Χρήση διαβάθμισης πλήρους οθόνης χωρίς εικόνα επεισοδίου.</string>
+  <string name="layout_episode_options_overlay_artwork">Εικόνα</string>
+  <string name="layout_episode_options_overlay_artwork_desc">Χρήση διάταξης πλήρους οθόνης με εικόνα επεισοδίου.</string>
+  <string name="layout_episode_options_overlay_blur">Θόλωμα</string>
+  <string name="layout_episode_options_overlay_blur_desc">Χρήση διάταξης πλήρους οθόνης με θολωμένη εικόνα επεισοδίου.</string>
   <string name="layout_blur_cw_next_up">Θόλωμα μη προβληθέντων στο Συνέχεια παρακολούθησης</string>
   <string name="layout_blur_cw_next_up_sub">Θόλωμα μικρογραφιών επόμενου επεισοδίου στο Συνέχεια παρακολούθησης για αποφυγή spoilers.</string>
   <string name="layout_next_up_furthest_episode">Επόμενο από το πιο προχωρημένο επεισόδιο</string>
@@ -1497,6 +1512,7 @@
   <string name="parental_severity_moderate">Μέτριο</string>
   <string name="parental_severity_mild">Ήπιο</string>
   <string name="player_ends_at">Τελειώνει στις %1$s</string>
+  <string name="player_live_watched">ΖΩΝΤΑΝΑ  %1$s</string>
   <string name="player_via">μέσω %1$s</string>
   <!-- Season/episode code shown in player UI (e.g. S01E02). %1$d = season, %2$d = episode. -->
   <string name="season_episode_format">S%1$d E%2$d</string>
@@ -1520,6 +1536,8 @@
   <string name="stream_info_resolution">Ανάλυση</string>
   <string name="stream_info_frame_rate">Ρυθμός καρέ</string>
   <string name="stream_info_bitrate">Ρυθμός μετάδοσης</string>
+  <string name="stream_info_bitrate_file">Ρυθμός μετάδοσης (αρχείο)</string>
+  <string name="stream_info_hud">HUD</string>
   <string name="stream_info_channels">Κανάλια</string>
   <string name="stream_info_sample_rate">Ρυθμός δειγματοληψίας</string>
   <string name="stream_info_language">Γλώσσα</string>
@@ -1624,6 +1642,15 @@
   <string name="player_next_episode_prompt_message">Θέλετε να αναπαραχθεί το επόμενο επεισόδιο;</string>
   <string name="player_next_episode_prompt_yes">Ναι</string>
   <string name="player_next_episode_prompt_no">Όχι, επιστροφή στις λεπτομέρειες</string>
+  <string name="player_post_play_because">Επειδή παρακολουθήσατε %1$s</string>
+  <string name="player_post_play_recommended">Προτάσεις για εσάς</string>
+  <string name="player_post_play_play">Αναπαραγωγή</string>
+  <string name="player_post_play_previous_recommendation">Προηγούμενη πρόταση</string>
+  <string name="player_post_play_next_recommendation">Επόμενη πρόταση</string>
+  <string name="player_post_play_return_to_player">Επιστροφή στην αναπαραγωγή</string>
+  <string name="player_post_play_trailer_countdown">Τρέιλερ σε %1$d δευτ.</string>
+  <string name="player_post_play_trailer_playing">Αναπαραγωγή τρέιλερ</string>
+  <string name="player_post_play_trailer">Τρέιλερ</string>
   <string name="next_episode_unaired">Δεν έχει προβληθεί</string>
   <string name="next_episode_not_aired_yet">Το επόμενο επεισόδιο δεν έχει προβληθεί ακόμα</string>
   <string name="still_watching_title">Παρακολουθείτε ακόμα;</string>
@@ -1851,6 +1878,7 @@
   <string name="auth_qr_expires">Λήγει σε %1$s</string>
   <string name="auth_qr_scan_instruction">Σαρώστε QR, εγκρίνετε στον browser και επιστρέψτε εδώ.</string>
   <string name="auth_qr_code_display">Κωδικός: %1$s</string>
+  <string name="auth_qr_manual_instruction">Ή μεταβείτε στο %1$s και εισάγετε τον κωδικό</string>
   <string name="auth_qr_refresh">Ανανέωση QR</string>
   <string name="auth_qr_continue_without_account">Συνέχεια χωρίς λογαριασμό</string>
   <string name="auth_qr_connected">Ο λογαριασμός σας είναι συνδεδεμένος σε αυτή την TV.</string>
@@ -2838,6 +2866,8 @@
     <item quantity="other">Ακόμα φορτώνει μετά από %1$d δευτερόλεπτα</item>
   </plurals>
   <string name="advanced_playback_issue_reports_subtitle">Εμφάνιση κουμπιών αναφοράς κατά την αναπαραγωγή, σε παρατεταμένη φόρτωση και σε σφάλματα αναπαραγωγής</string>
+  <string name="advanced_player_stats_hud">Οθόνη στατιστικών αναπαραγωγής</string>
+  <string name="advanced_player_stats_hud_subtitle">Εμφάνιση ζωντανών ενδείξεων CPU, μνήμης, buffer, ρυθμού μετάδοσης και θερμοκρασίας κατά την αναπαραγωγή</string>
   <string name="settings_stream_badge_position_top">Πάνω</string>
   <string name="stream_test_btn_measuring_parallel8">Μέτρηση παράλληλης (8MB)...</string>
   <string name="diag_value_not_ready">Μη έτοιμο</string>


### PR DESCRIPTION
## Summary

Completes Greek (el) locale parity with the English source file. Adds the 30 missing translations introduced by recent features (post-play recommendations overlay, playback stats HUD, full-exit confirmation, episode options overlay styles, live watched indicator, stream info bitrate/HUD labels, QR manual sign-in instruction).

Scope: only `app/src/main/res/values-el/strings.xml` (+30 lines, no deletions). No other files changed.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix

## Why

The Greek locale was missing 30 strings that were added upstream after the last Greek parity update. This PR restores exact 1:1 key parity (2897 = 2897 keys) so Greek users see translated UI instead of falling back to English.

## Issue or approval

No linked issue: localization-only update.

## Reproduction steps

No reproduction steps - localization-only update.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only `app/src/main/res/values-el/strings.xml` is modified.
- No English strings, code, resources, or build files were touched.
- Existing Greek translations were left untouched; terminology follows established Greek conventions already present in the file (e.g. «Ρυθμός μετάδοσης» for bitrate, «Θόλωμα» for blur, «Κανένα» for none, «Αναπαραγωγή» for play, «Τρέιλερ» for trailer, «κατώφλι επόμενου επεισοδίου» for next episode threshold).
- Technical terms and brands (HUD, CPU, buffer, QR) intentionally kept as-is, consistent with the rest of the Greek locale.

## Testing

- XML validity verified for both `values/strings.xml` and `values-el/strings.xml` (fast-xml-parser).
- Key parity verified: 2897 = 2897 keys, 0 missing, 0 extra, 0 duplicates.
- Placeholder token parity verified: 0 mismatches (all `%1$s` / `%1$d` / `%2$d` tokens preserved).
- Plurals verified: 4/4 present, none missing.
- No build impact: string resources only.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - localization-only update.