### PR TITLE
fix(HUD): persist the stats overlay toggle from the info screen + polish from user feedback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerDebugStatsOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerDebugStatsOverlay.kt
@@ -105,7 +105,7 @@ internal fun PlayerDebugStatsOverlay(
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(8.dp))
-            .background(Color(0xCC000000))
+            .background(Color(0x99000000))
             .padding(horizontal = 14.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
@@ -113,7 +113,7 @@ internal fun PlayerDebugStatsOverlay(
             Row {
                 Text(
                     text = stat.label,
-                    modifier = Modifier.width(72.dp),
+                    modifier = Modifier.width(64.dp),
                     fontFamily = FontFamily.Monospace,
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
@@ -147,6 +147,8 @@ private class DebugStatsSampler(context: Context) {
     private var lastRxAtMs = 0L
     private var bufferTotal = 0.0
     private var bufferSamples = 0
+    private var networkTotal = 0.0
+    private var networkSamples = 0
     private var cpuTotal = 0.0
     private var cpuSamples = 0
     private var faultTotal = 0.0
@@ -171,10 +173,10 @@ private class DebugStatsSampler(context: Context) {
         add(networkStat())
         add(droppedStat(snapshot))
         addAll(thermalStats())
-    }
+    }.filterNot { it.value == UNAVAILABLE }
 
     private fun cpuStat(proc: ProcTimes?, elapsedSeconds: Double): DebugStat {
-        if (proc == null) return DebugStat("cpu", "n/a")
+        if (proc == null) return DebugStat("cpu", UNAVAILABLE)
         if (lastCpuTicks < 0L || elapsedSeconds <= 0.0) return DebugStat("cpu", "...")
         val cpuSeconds = (proc.cpuTicks - lastCpuTicks).toDouble() / clockTicks
         val percent = cpuSeconds / elapsedSeconds / cores * 100.0
@@ -189,7 +191,7 @@ private class DebugStatsSampler(context: Context) {
 
     // Faults that had to hit storage, so a high rate means the device is paging rather than playing.
     private fun majorFaultStat(proc: ProcTimes?, elapsedSeconds: Double): DebugStat {
-        if (proc == null) return DebugStat("paging", "n/a")
+        if (proc == null) return DebugStat("paging", UNAVAILABLE)
         if (lastMajorFaults < 0L || elapsedSeconds <= 0.0) return DebugStat("paging", "...")
         val perSecond = (proc.majorFaults - lastMajorFaults).toDouble() / elapsedSeconds
         faultTotal += perSecond
@@ -227,7 +229,7 @@ private class DebugStatsSampler(context: Context) {
     }
 
     private fun bufferStat(snapshot: PlayerSnapshot?): DebugStat {
-        if (snapshot == null) return DebugStat("buffer", "n/a")
+        if (snapshot == null) return DebugStat("buffer", UNAVAILABLE)
         val ahead = snapshot.aheadMs / 1000.0
         bufferTotal += ahead
         bufferSamples++
@@ -254,14 +256,14 @@ private class DebugStatsSampler(context: Context) {
         }
         val video = snapshot?.videoBitrate ?: -1
         val audio = snapshot?.audioBitrate ?: -1
-        if (video <= 0 && audio <= 0) return DebugStat("bitrate", "n/a")
+        if (video <= 0 && audio <= 0) return DebugStat("bitrate", UNAVAILABLE)
         val totalMbps = (video.coerceAtLeast(0) + audio.coerceAtLeast(0)) / 1_000_000.0
         return DebugStat("bitrate", String.format(Locale.US, "%.1f Mbps tracks", totalMbps))
     }
 
     private fun networkStat(): DebugStat {
         val rx = runCatching { TrafficStats.getUidRxBytes(Process.myUid()) }.getOrDefault(-1L)
-        if (rx < 0L) return DebugStat("network", "n/a")
+        if (rx < 0L) return DebugStat("network", UNAVAILABLE)
         val now = System.currentTimeMillis()
         val previousRx = lastRxBytes
         val previousAt = lastRxAtMs
@@ -269,7 +271,17 @@ private class DebugStatsSampler(context: Context) {
         lastRxAtMs = now
         if (previousRx < 0L || now <= previousAt) return DebugStat("network", "...")
         val mbps = (rx - previousRx).toDouble() / ((now - previousAt) / 1000.0) * 8.0 / 1_000_000.0
-        return DebugStat("network", String.format(Locale.US, "%.1f Mbps", mbps))
+        networkTotal += mbps
+        networkSamples++
+        return DebugStat(
+            label = "network",
+            value = String.format(
+                Locale.US,
+                "%.1f Mbps   avg %.1f",
+                mbps,
+                networkTotal / networkSamples
+            )
+        )
     }
 
     private fun droppedStat(snapshot: PlayerSnapshot?): DebugStat {
@@ -279,19 +291,19 @@ private class DebugStatsSampler(context: Context) {
 
     // Headroom is normalised so 1.00 is the throttling point; the status line only matters once it trips.
     private fun thermalStats(): List<DebugStat> {
-        val pm = powerManager ?: return listOf(DebugStat("thermal", "n/a"))
+        val pm = powerManager ?: return listOf(DebugStat("thermal", UNAVAILABLE))
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            return listOf(DebugStat("thermal", "needs api 30"))
+            return listOf(DebugStat("thermal", UNAVAILABLE))
         }
         val headroom = runCatching { pm.getThermalHeadroom(0) }.getOrDefault(Float.NaN)
         val status = runCatching { pm.currentThermalStatus }.getOrDefault(PowerManager.THERMAL_STATUS_NONE)
         val headroomStat = DebugStat(
             label = "thermal",
-            value = if (headroom.isNaN()) "n/a" else String.format(Locale.US, "%.2f / 1.00", headroom),
+            value = if (headroom.isNaN()) UNAVAILABLE else String.format(Locale.US, "%.2f / 1.00", headroom),
             warn = !headroom.isNaN() && headroom >= 0.9f
         )
         val throttleName = throttleName(status) ?: return listOf(headroomStat)
-        return listOf(headroomStat, DebugStat("throttling", throttleName, warn = true))
+        return listOf(headroomStat, DebugStat("throttle", throttleName, warn = true))
     }
 
     private fun throttleName(status: Int): String? = when (status) {
@@ -308,5 +320,9 @@ private class DebugStatsSampler(context: Context) {
 
     private companion object {
         const val MB = 1024L * 1024L
+
+        // A row carrying this is one the device will never fill in, so it is dropped rather than
+        // taking a line; the warmup placeholder is left alone so no row appears a second later.
+        const val UNAVAILABLE = "n/a"
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -196,6 +196,7 @@ internal fun PlayerRuntimeController.initializePlayer(
             effectiveBackBufferDurationMs = 0
             currentBitrateAwareLoadControl = null
             configuredBackBufferMs = 0
+            _uiState.update { it.copy(playerStatsHudButtonAvailable = it.playerStatsHudEnabled) }
 
             val playerSettings = playerSettingsDataStore.playerSettings.first()
             currentPlayerSettingsForReport = playerSettings

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -889,12 +889,12 @@ internal fun PlayerRuntimeController.observePlayerStatsHud() {
         deviceLocalPlayerPreferences.playerStatsHudEnabled
             .distinctUntilChanged()
             .collect { enabled ->
-                // Turning the setting on is a request to see the overlay, even if the button hid
-                // it during an earlier playback.
+                // The button outlives the setting for the rest of the playback, so turning the
+                // overlay off from it leaves a way to turn it back on without visiting settings.
                 _uiState.update {
                     it.copy(
                         playerStatsHudEnabled = enabled,
-                        playerStatsHudVisible = if (enabled) true else it.playerStatsHudVisible
+                        playerStatsHudButtonAvailable = it.playerStatsHudButtonAvailable || enabled
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -1746,9 +1746,10 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
             _uiState.update { it.copy(showStreamInfoOverlay = false) }
         }
         PlayerEvent.OnTogglePlayerStatsHud -> {
-            // Writing the setting here would hide the button along with the overlay and leave no way
-            // back without going to settings mid playback.
-            _uiState.update { it.copy(playerStatsHudVisible = !it.playerStatsHudVisible) }
+            // This is the only way to turn the overlay off from the player, so it writes the setting
+            // rather than a session flag the next playback would start from scratch.
+            val enable = !_uiState.value.playerStatsHudEnabled
+            scope.launch { deviceLocalPlayerPreferences.setPlayerStatsHudEnabled(enable) }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1019,7 +1019,7 @@ fun PlayerScreen(
                 viewModel = viewModel,
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .padding(start = 28.dp, top = NuvioTheme.spacing.xl)
+                    .padding(start = NuvioTheme.spacing.xl, top = NuvioTheme.spacing.xl)
                     .zIndex(2.75f)
             )
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1006,15 +1006,15 @@ fun PlayerScreen(
                 !uiState.showLoadingOverlay && !postPlayRecommendationState.isVisible,
             onClose = dismissStreamInfoOverlay,
             data = uiState.streamInfoData,
-            hudAvailable = uiState.playerStatsHudEnabled,
-            hudVisible = uiState.playerStatsHudVisible,
+            hudEnabled = uiState.playerStatsHudEnabled,
+            hudButtonShown = uiState.playerStatsHudButtonAvailable,
             onToggleHud = { viewModel.onEvent(PlayerEvent.OnTogglePlayerStatsHud) },
             modifier = Modifier
                 .fillMaxSize()
                 .zIndex(2.6f)
         )
 
-        if (uiState.playerStatsHudEnabled && uiState.playerStatsHudVisible && uiState.error == null) {
+        if (uiState.playerStatsHudEnabled && uiState.error == null) {
             PlayerDebugStatsOverlay(
                 viewModel = viewModel,
                 modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerUiState.kt
@@ -90,7 +90,7 @@ data class PlayerUiState(
     val pauseOverlayEnabled: Boolean = true,
     val osdClockEnabled: Boolean = true,
     val playerStatsHudEnabled: Boolean = false,
-    val playerStatsHudVisible: Boolean = true,
+    val playerStatsHudButtonAvailable: Boolean = false,
     val showPauseOverlay: Boolean = false,
     val audioTracks: List<TrackInfo> = emptyList(),
     val subtitleTracks: List<TrackInfo> = emptyList(),

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamInfoOverlay.kt
@@ -51,8 +51,8 @@ fun StreamInfoOverlay(
     visible: Boolean,
     onClose: () -> Unit,
     data: StreamInfoData?,
-    hudAvailable: Boolean,
-    hudVisible: Boolean,
+    hudEnabled: Boolean,
+    hudButtonShown: Boolean,
     onToggleHud: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -74,16 +74,16 @@ fun StreamInfoOverlay(
                 KeyEvent.KEYCODE_DPAD_RIGHT -> true
                 else -> false
             }
-            if (!isDirection || hudFocused || !hudAvailable) return@onPreviewKeyEvent false
+            if (!isDirection || hudFocused || !hudButtonShown) return@onPreviewKeyEvent false
             runCatching { hudFocusRequester.requestFocus() }.isSuccess
         },
-        dismissOnCenter = true,
+        dismissOnCenter = !hudButtonShown,
         contentPadding = PaddingValues(start = NuvioTheme.spacing.xxxl, end = NuvioTheme.spacing.xxxl, top = 36.dp, bottom = 36.dp)
     ) {
         // Someone who never turned the overlay on has no use for a control they cannot interpret.
-        if (hudAvailable) {
+        if (hudButtonShown) {
             StreamInfoHudButton(
-                enabled = hudVisible,
+                enabled = hudEnabled,
                 onClick = onToggleHud,
                 focusRequester = hudFocusRequester,
                 onFocusChanged = { hudFocused = it },
@@ -329,10 +329,10 @@ private fun StreamInfoHudButton(
             },
         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
         colors = ButtonDefaults.colors(
-            containerColor = Color.White.copy(alpha = 0.14f),
-            contentColor = Color.White,
-            focusedContainerColor = Color.White,
-            focusedContentColor = Color.Black
+            containerColor = Color.White.copy(alpha = if (enabled) 0.14f else 0.06f),
+            contentColor = Color.White.copy(alpha = if (enabled) 1f else 0.5f),
+            focusedContainerColor = Color.White.copy(alpha = if (enabled) 1f else 0.4f),
+            focusedContentColor = if (enabled) Color.Black else Color.White
         )
     ) {
         // The label stays fixed, so the dot is the only thing carrying the on or off state.


### PR DESCRIPTION
## Summary

Fixes to the playback stats overlay button added in #3229, plus overlay changes from user feedback.

Fixes:

- The button only turned the overlay off for the current session, so the next playback started with it on again and there was no way to disable the overlay from the player. It now writes the same device-local setting the Advanced settings toggle writes.
- Pressing the button also closed the info screen. The overlay scaffold dismisses on `DPAD_CENTER` key-down, and a TV button clicks on key-up, so the down event reached the scaffold first. Centre no longer dismisses while the button is on screen; Back still closes it.
- The button stays available for the rest of the playback after being pressed off, so it can be turned back on without visiting settings. The next playback starts from the persisted setting, and shows no button when that is off.
- The off state is now dimmer in every state including focused, so a selected button no longer looks the same on as off.

From user feedback:

- `network` now carries a running average, matching `cpu`, `paging` and `buffer`. This is the app's download rate from `TrafficStats`, so it includes subtitle and metadata fetches and reads higher than the file's own bitrate.
- Rows the device can never fill in are dropped instead of showing `n/a`, which reclaims a line or two on hardware without thermal reporting. The `...` shown before the first sample is kept, so no row appears a second after the overlay opens.
- The panel is less opaque, its label column is narrower, and it sits slightly closer to the corner. It stays clear of the TV safe area so it is not clipped on sets that overscan.
- The `throttling` row is now labelled `throttle`; it was the widest label and set the column width.

## PR type
- [x] Critical bug fix

The first four items are the bug fix. The feedback items are an addition to the feature merged in #3229, included here with maintainer approval rather than opened separately.

## Why

Reported by users after #3229. The button reads as a normal on/off control, but its off did not survive the session, and pressing it closed the screen it lives on. The remaining items are user requests against the same overlay.

## Issue or approval

Follow up to #3229.

## Reproduction steps

1. Enable the playback stats overlay in Advanced settings.
2. Start playback and open the player info screen.
3. Press the HUD button. The info screen closes.
4. Reopen it, exit playback, start another. The overlay is on again.

## UI / behavior impact
- [x] Behavior changed only to fix a documented bug/regression
- [x] UI changed only to fix a documented glitch/bug
- [x] UI change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No change to what the overlay measures or how often it samples, and no change to the Advanced settings toggle. The setting stays in `DeviceLocalPlayerPreferences` and is still never synced. Centre still dismisses the info screen when the overlay setting is off, which is every user who has not enabled it. The overlay's position stays inside the TV safe area rather than moving fully into the corner.

## Testing

Fire TV Stick 4K Max 2nd gen. Pressed the button off and confirmed the info screen stays open with the overlay gone; closed and reopened the info screen in the same playback and the button was still there; pressed it back on; exited and started a new playback with the setting off and confirmed no overlay and no button. Confirmed centre still closes the info screen when the setting is off. Confirmed the overlay renders without the thermal row on hardware that does not report it, and that the network average tracks alongside the instantaneous reading.

## Screenshots / Video

N/A

## Breaking changes

None.

## Linked issues

Follow up to #3229.