### PR TITLE
Fix Back and focus navigation in Settings

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
@@ -90,6 +90,18 @@ fun DebridSettingsContent(
     initialFocusRequester: FocusRequester? = null
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // The first two rows are gated on a connected provider and cannot take focus without one,
+    // so the entry requester goes to the first row that can accept it. Left on a gated row the
+    // request is declined, focus stays on the category rail, and the next press walks the rail
+    // instead of entering these options.
+    //
+    // The last of the three is the first account row, which is ungated and so always takes the
+    // request. That rests on DebridProviders.visible() having something in it: it filters a fixed
+    // list on a compile time flag, so it is empty only if every provider is hidden at once, and
+    // this screen has nothing to show at all in that case.
+    val entryOnCloudLibrary = uiState.hasCloudLibraryProvider
+    val entryOnDebridToggle = !entryOnCloudLibrary && uiState.hasResolverProvider
+    val entryOnFirstAccount = !entryOnCloudLibrary && !entryOnDebridToggle
     var activeApiKeyDialog by remember { mutableStateOf<String?>(null) }
     var activeDeviceAuthDialog by remember { mutableStateOf<String?>(null) }
     var activeStreamPicker by remember { mutableStateOf<DebridStreamPicker?>(null) }
@@ -137,7 +149,7 @@ fun DebridSettingsContent(
                             modifier = Modifier
                                 .padding(top = NuvioTheme.spacing.xxs)
                                 .then(
-                                    if (initialFocusRequester != null) {
+                                    if (initialFocusRequester != null && entryOnCloudLibrary) {
                                         Modifier.focusRequester(initialFocusRequester)
                                     } else {
                                         Modifier
@@ -153,6 +165,11 @@ fun DebridSettingsContent(
                             subtitle = stringResource(R.string.debrid_enable_subtitle),
                             checked = uiState.canResolvePlayableLinks,
                             onToggle = { viewModel.onEvent(DebridSettingsEvent.ToggleEnabled(!uiState.enabled)) },
+                            modifier = if (initialFocusRequester != null && entryOnDebridToggle) {
+                                Modifier.focusRequester(initialFocusRequester)
+                            } else {
+                                Modifier
+                            },
                             enabled = uiState.hasResolverProvider
                         )
                     }
@@ -179,7 +196,7 @@ fun DebridSettingsContent(
                         DebridSectionLabel(text = stringResource(R.string.debrid_section_account))
                     }
 
-                    DebridProviders.visible().forEach { provider ->
+                    DebridProviders.visible().forEachIndexed { providerIndex, provider ->
                         item(key = "debrid_${provider.id}_api_key") {
                             SettingsActionRow(
                                 title = provider.displayName,
@@ -199,6 +216,15 @@ fun DebridSettingsContent(
                                         DebridProviderAuthMethod.DeviceCode -> activeDeviceAuthDialog = provider.id
                                         DebridProviderAuthMethod.ApiKey -> activeApiKeyDialog = provider.id
                                     }
+                                },
+                                modifier = if (
+                                    initialFocusRequester != null &&
+                                    entryOnFirstAccount &&
+                                    providerIndex == 0
+                                ) {
+                                    Modifier.focusRequester(initialFocusRequester)
+                                } else {
+                                    Modifier
                                 },
                                 enabled = true
                             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/DebridSettingsScreen.kt
@@ -101,6 +101,8 @@ fun DebridSettingsContent(
     // this screen has nothing to show at all in that case.
     val entryOnCloudLibrary = uiState.hasCloudLibraryProvider
     val entryOnDebridToggle = !entryOnCloudLibrary && uiState.hasResolverProvider
+    // The first visible account row, which is always enabled whatever is connected, so it is the
+    // one row that can always take the entry requester.
     val entryOnFirstAccount = !entryOnCloudLibrary && !entryOnDebridToggle
     var activeApiKeyDialog by remember { mutableStateOf<String?>(null) }
     var activeDeviceAuthDialog by remember { mutableStateOf<String?>(null) }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/LayoutSettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -224,8 +225,11 @@ fun LayoutSettingsContent(
                     focusRequester = homeLayoutHeaderFocus,
                     onFocused = { focusedSection = LayoutSettingsSection.HOME_LAYOUT }
                 ) {
+                    val firstHomeLayoutFocusRequester = remember { FocusRequester() }
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .settingsOptionRow(firstHomeLayoutFocusRequester),
                         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)
                     ) {
                         LayoutCard(
@@ -237,7 +241,9 @@ fun LayoutSettingsContent(
                             onFocused = {
                                 focusedSection = LayoutSettingsSection.HOME_LAYOUT
                             },
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier
+                                .weight(1f)
+                                .focusRequester(firstHomeLayoutFocusRequester)
                         )
                         LayoutCard(
                             layout = HomeLayout.GRID,
@@ -318,21 +324,28 @@ fun LayoutSettingsContent(
                             style = MaterialTheme.typography.bodySmall,
                             color = NuvioTheme.colors.TextTertiary
                         )
+                        val firstHeroCatalogFocusRequester = remember { FocusRequester() }
                         LazyRow(
+                            modifier = Modifier.settingsOptionRow(firstHeroCatalogFocusRequester),
                             contentPadding = PaddingValues(end = NuvioTheme.spacing.sm),
                             horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
                         ) {
-                            items(
+                            itemsIndexed(
                                 items = uiState.availableCatalogs,
-                                key = { it.key }
-                            ) { catalog ->
+                                key = { _, catalog -> catalog.key }
+                            ) { catalogIndex, catalog ->
                                 CatalogChip(
                                     catalogInfo = catalog,
                                     isSelected = catalog.key in uiState.heroCatalogKeys,
                                     onClick = {
                                         viewModel.onEvent(LayoutSettingsEvent.ToggleHeroCatalog(catalog.key))
                                     },
-                                    onFocused = { focusedSection = LayoutSettingsSection.HOME_LAYOUT }
+                                    onFocused = { focusedSection = LayoutSettingsSection.HOME_LAYOUT },
+                                    modifier = if (catalogIndex == 0) {
+                                        Modifier.focusRequester(firstHeroCatalogFocusRequester)
+                                    } else {
+                                        Modifier
+                                    }
                                 )
                             }
                         }
@@ -1273,12 +1286,15 @@ private fun ModernTrailerPlaybackTargetRow(
         style = MaterialTheme.typography.bodySmall,
         color = NuvioTheme.colors.TextTertiary
     )
+    val firstTrailerTargetFocusRequester = remember { FocusRequester() }
     LazyRow(
+        modifier = Modifier.settingsOptionRow(firstTrailerTargetFocusRequester),
         contentPadding = PaddingValues(end = NuvioTheme.spacing.sm),
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
     ) {
         item(key = "trailer_target_expanded_card") {
             SettingsChoiceChip(
+                modifier = Modifier.focusRequester(firstTrailerTargetFocusRequester),
                 label = stringResource(R.string.layout_trailer_expanded_card),
                 selected = selectedTarget == FocusedPosterTrailerPlaybackTarget.EXPANDED_CARD,
                 onClick = {
@@ -1572,9 +1588,11 @@ private fun CatalogChip(
     catalogInfo: CatalogInfo,
     isSelected: Boolean,
     onClick: () -> Unit,
-    onFocused: () -> Unit
+    onFocused: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     SettingsChoiceChip(
+        modifier = modifier,
         label = catalogInfo.name,
         selected = isSelected,
         onClick = onClick,
@@ -1926,19 +1944,26 @@ private fun OptionRow(
         color = NuvioTheme.colors.TextSecondary
     )
 
+    val firstOptionFocusRequester = remember { FocusRequester() }
     LazyRow(
+        modifier = Modifier.settingsOptionRow(firstOptionFocusRequester),
         contentPadding = PaddingValues(end = NuvioTheme.spacing.sm),
         horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
     ) {
-        items(
+        itemsIndexed(
             items = options,
-            key = { it.value }
-        ) { option ->
+            key = { _, option -> option.value }
+        ) { optionIndex, option ->
             ValueChip(
                 label = option.label,
                 isSelected = option.value == selectedValue,
                 onClick = { onSelected(option.value) },
-                onFocused = onFocused
+                onFocused = onFocused,
+                modifier = if (optionIndex == 0) {
+                    Modifier.focusRequester(firstOptionFocusRequester)
+                } else {
+                    Modifier
+                }
             )
         }
     }
@@ -1949,9 +1974,11 @@ private fun ValueChip(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit,
-    onFocused: () -> Unit
+    onFocused: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     SettingsChoiceChip(
+        modifier = modifier,
         label = label,
         selected = isSelected,
         onClick = onClick,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAutoPlaySettings.kt
@@ -856,18 +856,30 @@ private fun StreamRegexDialog(
                     color = NuvioTheme.colors.TextSecondary
                 )
 
-                LazyRow(horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)) {
-                    items(
+                val firstPresetFocusRequester = remember { FocusRequester() }
+                LazyRow(
+                    modifier = Modifier.settingsOptionRow(firstPresetFocusRequester),
+                    horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
+                ) {
+                    itemsIndexed(
                         items = presets,
-                        key = { it.first }
-                    ) { (label, pattern) ->
+                        key = { _, preset -> preset.first }
+                    ) { presetIndex, (label, pattern) ->
                         var isFocused by remember { mutableStateOf(false) }
                         Card(
                             onClick = {
                                 regex = pattern
                                 regexError = null
                             },
-                            modifier = Modifier.onFocusChanged { isFocused = it.isFocused },
+                            modifier = Modifier
+                                .onFocusChanged { isFocused = it.isFocused }
+                                .then(
+                                    if (presetIndex == 0) {
+                                        Modifier.focusRequester(firstPresetFocusRequester)
+                                    } else {
+                                        Modifier
+                                    }
+                                ),
                             colors = CardDefaults.colors(
                                 containerColor = NuvioTheme.colors.BackgroundElevated,
                                 focusedContainerColor = NuvioTheme.colors.FocusBackground

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -1306,11 +1306,14 @@ internal fun ColorSelectionDialog(
                 .heightIn(max = 360.dp)
         ) {
             // Color grid using LazyRow for proper TV focus
+            val firstColorFocusRequester = remember { FocusRequester() }
             LazyRow(
                 state = colorListState,
                 horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md),
                 contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.sm),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .settingsOptionRow(firstColorFocusRequester)
             ) {
                 items(
                     count = colors.size,
@@ -1331,7 +1334,13 @@ internal fun ColorSelectionDialog(
                             Modifier.focusRequester(focusRequester)
                         } else {
                             Modifier
-                        }
+                        }.then(
+                            if (index == 0) {
+                                Modifier.focusRequester(firstColorFocusRequester)
+                            } else {
+                                Modifier
+                            }
+                        )
                     )
                 }
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsDesignSystem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -51,6 +52,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -98,6 +100,19 @@ internal val SettingsRailItemHeight = NuvioComponents.tokens.settings.railItemHe
 internal val SettingsZenRowShape = RoundedCornerShape(12.dp)
 internal val SettingsHorizonRowShape = RoundedCornerShape(10.dp)
 internal val SettingsHorizonGroupShape = RoundedCornerShape(16.dp)
+
+/**
+ * Marks a row that holds several options side by side. Without it, moving into the row uses a
+ * geometric search and lands on whichever option sits nearest the full width row above, which is
+ * the middle one. With it, coming back to the row takes the option last used, and anything else
+ * takes [fallbackOption], which callers point at the first option.
+ *
+ * The fallback has to be named. Left at the default it hands the choice back to the same geometric
+ * search, which puts focus in the middle again.
+ */
+internal fun Modifier.settingsOptionRow(fallbackOption: FocusRequester): Modifier = this
+    .focusRestorer(fallbackOption)
+    .focusGroup()
 
 @Composable
 @androidx.compose.runtime.ReadOnlyComposable

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -317,7 +317,10 @@ fun SettingsScreen(
     var integrationSection by remember { mutableStateOf(IntegrationSettingsSection.Hub) }
     var pendingContentFocusCategory by remember { mutableStateOf<SettingsCategory?>(null) }
     var pendingContentFocusRequestId by remember { mutableLongStateOf(0L) }
-    var allowDetailAutofocus by remember { mutableStateOf(false) }
+    // Saveable so it survives a trip out to one of the screens a category opens. The pane bounces
+    // focus back to the rail whenever it gains focus while this is false, so a plain remember made
+    // every return from those screens land on the rail rather than where the user had been.
+    var allowDetailAutofocus by rememberSaveable { mutableStateOf(false) }
     var detailHasFocus by remember { mutableStateOf(false) }
 
     // Back inside the options pane returns to the category rail before it leaves settings, the
@@ -342,7 +345,17 @@ fun SettingsScreen(
     }
 
     LaunchedEffect(Unit) {
-        runCatching { railContainerFocusRequester.requestFocus() }
+        // Categories such as plugins and addons open a destination of their own, so Settings leaves
+        // composition and comes back with nothing asking for the options pane: the rail is simply
+        // the first thing able to take focus. Landing there loses the user's place for a trip they
+        // did not take through the rail. The saved flag says the pane was where they were, so aim
+        // for it and leave the rail to the case where it really was the last thing focused.
+        if (allowDetailAutofocus) {
+            pendingContentFocusCategory = selectedCategory
+            pendingContentFocusRequestId += 1L
+        } else {
+            runCatching { railContainerFocusRequester.requestFocus() }
+        }
     }
 
     LaunchedEffect(pendingContentFocusRequestId) {
@@ -384,6 +397,11 @@ fun SettingsScreen(
 
             val onSectionClick: (SettingsSectionSpec) -> Unit = { section ->
                 if (section.destination == SettingsSectionDestination.External) {
+                    // These have no options of their own to come back to: the rail row is the
+                    // whole category, and it is the rail the user is leaving from. Without this
+                    // the flag keeps whatever an earlier visit to the pane left in it, and the
+                    // return aims at the options of a category that was never opened.
+                    allowDetailAutofocus = false
                     when (section.category) {
                         SettingsCategory.ACCOUNT -> onNavigateToAuthQrSignIn()
                         SettingsCategory.TRACKING -> onNavigateToTracking()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
@@ -133,6 +134,12 @@ private const val SETTINGS_DETAIL_FOCUS_DELAY_MS = 120L
 private const val SETTINGS_TAB_FOCUS_SELECT_DELAY_MS = 140L
 private const val SETTINGS_DETAIL_ANIM_IN_DURATION_MS = 200
 private const val SETTINGS_DETAIL_ANIM_OUT_DURATION_MS = 180
+
+// How long the pane gets to lay out, on top of the delay above, before focus falls back to a
+// directional move. Taken from the enter animation so the two cannot drift apart: the window
+// opens partway through it and closes well after it, which is what the request needs to stop
+// failing. Timed rather than counted in frames, since a frame count assumes a refresh rate.
+private const val SETTINGS_DETAIL_FOCUS_RETRY_WINDOW_MS = SETTINGS_DETAIL_ANIM_IN_DURATION_MS
 
 private sealed interface ExperienceModeLoadState {
     data object Loading : ExperienceModeLoadState
@@ -341,11 +348,16 @@ fun SettingsScreen(
     LaunchedEffect(pendingContentFocusRequestId) {
         val category = pendingContentFocusCategory ?: return@LaunchedEffect
         delay(SETTINGS_DETAIL_FOCUS_DELAY_MS)
-        val requester = contentFocusRequesters[category]
-        val requested = if (requester != null) {
-            runCatching { requester.requestFocus() }.isSuccess
-        } else {
-            false
+        // Asked once per frame until the pane takes focus or the window closes, rather than
+        // betting on one fixed delay. The pane is not always laid out when the delay expires,
+        // and the fallback below moves by direction, which lands wherever is nearest the rail
+        // row the user came from, usually the middle of the options.
+        var requested = false
+        val deadline = System.nanoTime() + SETTINGS_DETAIL_FOCUS_RETRY_WINDOW_MS * 1_000_000L
+        while (!requested && System.nanoTime() < deadline) {
+            requested = contentFocusRequesters[category]
+                ?.let { runCatching { it.requestFocus() }.getOrDefault(false) } ?: false
+            if (!requested) withFrameNanos { }
         }
         if (!requested) {
             focusManager.moveFocus(if (isHorizonStyle) FocusDirection.Down else FocusDirection.Right)
@@ -454,7 +466,7 @@ fun SettingsScreen(
                                     if (justGainedFocus) {
                                         val requester = railFocusRequesters[selectedCategory]
                                         val requested = if (requester != null) {
-                                            runCatching { requester.requestFocus() }.isSuccess
+                                            runCatching { requester.requestFocus() }.getOrDefault(false)
                                         } else {
                                             false
                                         }
@@ -613,7 +625,7 @@ fun SettingsScreen(
                                 if (justGainedFocus) {
                                     val requester = railFocusRequesters[selectedCategory]
                                     val requested = if (requester != null) {
-                                        runCatching { requester.requestFocus() }.isSuccess
+                                        runCatching { requester.requestFocus() }.getOrDefault(false)
                                     } else {
                                         false
                                     }
@@ -670,7 +682,7 @@ fun SettingsScreen(
                                 if (!movedLeft) {
                                     allowDetailAutofocus = false
                                     val requested = railFocusRequesters[selectedCategory]?.let { requester ->
-                                        runCatching { requester.requestFocus() }.isSuccess
+                                        runCatching { requester.requestFocus() }.getOrDefault(false)
                                     } ?: false
                                     if (!requested) {
                                         runCatching { railContainerFocusRequester.requestFocus() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -53,6 +54,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -65,6 +67,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
@@ -89,7 +92,9 @@ import com.nuvio.tv.R
 import com.nuvio.tv.core.build.AppFeaturePolicy
 import com.nuvio.tv.domain.model.ExperienceMode
 import com.nuvio.tv.domain.model.SettingsUiStyle
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.map
 import kotlin.math.roundToInt
 
@@ -131,14 +136,26 @@ internal data class SettingsSectionSpec(
 )
 
 private const val SETTINGS_DETAIL_FOCUS_DELAY_MS = 120L
+// The rail gets the same treatment as the options pane: bring the item into view, then keep
+// asking for a short while as it settles.
+private const val SETTINGS_RAIL_FOCUS_RETRY_WINDOW_MS = 200L
+
+/**
+ * Stands for "no attempt handed focus to the rail container". Attempts are numbered from one, so
+ * this has to sit outside that range: at zero it matches the number the counter starts on, and the
+ * first time the rail takes focus the mark reads as set and the restoration is skipped.
+ */
+private const val NO_RAIL_FALLBACK = -1L
 private const val SETTINGS_TAB_FOCUS_SELECT_DELAY_MS = 140L
 private const val SETTINGS_DETAIL_ANIM_IN_DURATION_MS = 200
 private const val SETTINGS_DETAIL_ANIM_OUT_DURATION_MS = 180
 
-// How long the pane gets to lay out, on top of the delay above, before focus falls back to a
-// directional move. Taken from the enter animation so the two cannot drift apart: the window
-// opens partway through it and closes well after it, which is what the request needs to stop
-// failing. Timed rather than counted in frames, since a frame count assumes a refresh rate.
+// The focus window has two parts: SETTINGS_DETAIL_FOCUS_DELAY_MS before the first request, then
+// this long retrying once per frame, so a category has both added together before focus falls
+// back to a directional move. This part is taken from the enter animation so the two cannot
+// drift apart, and is timed rather than counted in frames since a frame count assumes a
+// refresh rate. The worst case wait before the fallback is SETTINGS_DETAIL_FOCUS_DELAY_MS plus
+// this window, not this window alone.
 private const val SETTINGS_DETAIL_FOCUS_RETRY_WINDOW_MS = SETTINGS_DETAIL_ANIM_IN_DURATION_MS
 
 private sealed interface ExperienceModeLoadState {
@@ -322,6 +339,102 @@ fun SettingsScreen(
     // every return from those screens land on the rail rather than where the user had been.
     var allowDetailAutofocus by rememberSaveable { mutableStateOf(false) }
     var detailHasFocus by remember { mutableStateOf(false) }
+    // The rail item that last had focus. Not the same as the selected category: an external
+    // category such as tracking never becomes the selected one, and moving along the rail without
+    // opening anything does not change it either. Saveable so returning from the sidebar, or from
+    // a screen a category opened, comes back to the item the user left from.
+    var railFocusCategoryName by rememberSaveable { mutableStateOf<String?>(null) }
+    val railFocusCategory = railFocusCategoryName
+        ?.let { name -> SettingsCategory.entries.firstOrNull { it.name == name } }
+        // The name surviving is not enough. Which categories the rail shows depends on the profile
+        // and on essential mode, so the one that was left can be gone by the time it is returned
+        // to. Restoring to it would spend the whole retry window on an item that is not there.
+        ?.takeIf { category -> visibleSections.any { it.category == category } }
+        ?: selectedCategory
+    val railListState = rememberLazyListState()
+    val railScope = rememberCoroutineScope()
+
+    // The rail is a lazy list, so an item that has scrolled out of view has no attached requester
+    // and cannot take focus. Bring it back into view first, then ask, retrying while it composes.
+    // Without this, restoring to a scrolled out item silently failed and focus was left to the
+    // geometric search, which is how coming back from the sidebar landed on the wrong item.
+    var railHadFocus by remember { mutableStateOf(false) }
+    var railFocusJob by remember { mutableStateOf<Job?>(null) }
+    // The attempt whose fallback handed focus to the rail container, or 0. The container gaining
+    // focus is what triggers a restoration, so without this the fallback asks for the same
+    // unavailable item again instead of ending the attempt. Numbered rather than a flag so a
+    // newer attempt cannot inherit an older one's mark.
+    var railFallbackAttempt by remember { mutableLongStateOf(NO_RAIL_FALLBACK) }
+    // The category an attempt is currently working towards, so that item can end the attempt when
+    // it takes focus by any route. Only that item: cancelling on any other is how an earlier
+    // version let the rail's own choice of child kill a restoration and drift away from the user.
+    var railRestoringCategory by remember { mutableStateOf<SettingsCategory?>(null) }
+    // Identifies an attempt. Cancellation is cooperative, so a stopped attempt can still run as
+    // far as its next suspension point, and without this its cleanup would clear state belonging
+    // to the attempt that replaced it.
+    var railFocusAttempt by remember { mutableLongStateOf(0L) }
+    val focusRailCategory: (SettingsCategory) -> Unit = { category ->
+        railFocusJob?.cancel()
+        railFocusJob = null
+        // Cleared here, not only by the attempt that set it. A cancelled attempt is forbidden from
+        // clearing it once the number has moved on, and an attempt that lands straight away never
+        // sets one, so without this a target could outlive every attempt behind it.
+        railRestoringCategory = null
+        railFocusAttempt += 1L
+        val attempt = railFocusAttempt
+        // Try straight away first, without a coroutine: a suspension point before the request
+        // leaves a gap for the rail to settle on a child of its own, and that child then records
+        // itself as the item to come back to.
+        //
+        // The rail's own focusRestorer covers the ordinary case, where the item being returned to
+        // is still composed and is the one the rail last had focus on. This is for what it cannot
+        // do: a target that is off screen and so has no node to restore to, and a target that is
+        // not the child the rail last held, such as the category a Back press names. Only those
+        // reach the scroll and retry below.
+        val landed = railFocusRequesters[category]
+            ?.let { runCatching { it.requestFocus() }.getOrDefault(false) } ?: false
+        if (!landed) {
+            // Set before launching, so the attempt advertises its target from the start.
+            railRestoringCategory = category
+            railFocusJob = railScope.launch {
+                try {
+                    val index = visibleSections.indexOfFirst { it.category == category }
+                    // Only when it is not on screen at all. An item that is even partly on screen
+                    // can usually take focus as it is, and scrollToItem would drag it to the start
+                    // of the viewport and move the whole rail under the user for nothing.
+                    // Visibility is not the same as having an attached requester, which is what
+                    // the retry below is for.
+                    if (index >= 0 && !railListState.isItemVisible(index)) {
+                        runCatching { railListState.scrollToItem(index) }
+                    }
+                    val deadline =
+                        System.nanoTime() + SETTINGS_RAIL_FOCUS_RETRY_WINDOW_MS * 1_000_000L
+                    var focused = false
+                    while (!focused && attempt == railFocusAttempt && System.nanoTime() < deadline) {
+                        focused = railFocusRequesters[category]
+                            ?.let { runCatching { it.requestFocus() }.getOrDefault(false) } ?: false
+                        if (!focused) withFrameNanos { }
+                    }
+                    // Only when the rail does not already hold focus. If it does, focus is
+                    // somewhere sensible in it already, and asking the container again would
+                    // neither move anything nor produce the transition that clears the mark.
+                    if (!focused && !railHadFocus && attempt == railFocusAttempt) {
+                        val handedOver = runCatching {
+                            railContainerFocusRequester.requestFocus()
+                        }.getOrDefault(false)
+                        if (handedOver) railFallbackAttempt = attempt
+                    }
+                } finally {
+                    // Also on cancellation, so a stopped attempt does not leave its target or its
+                    // job behind, and only if this is still the current attempt.
+                    if (attempt == railFocusAttempt) {
+                        railRestoringCategory = null
+                        railFocusJob = null
+                    }
+                }
+            }
+        }
+    }
 
     // Back inside the options pane returns to the category rail before it leaves settings, the
     // way back inside a row returns to the start of that row. Anything the pane declares itself,
@@ -329,11 +442,10 @@ fun SettingsScreen(
     BackHandler(enabled = detailHasFocus) {
         // Cleared up front rather than after the request. The rail reports its own focus a frame
         // later, and until it does a second quick press would be consumed here again instead of
-        // reaching the sidebar. If the request fails this also leaves the next press free.
+        // leaving settings. The result of the request is deliberately not read: either way this
+        // press was the step back, and with the flag already cleared the next one carries on out.
         detailHasFocus = false
-        railFocusRequesters[selectedCategory]?.let { requester ->
-            runCatching { requester.requestFocus() }
-        }
+        focusRailCategory(railFocusCategory)
     }
 
     val focusManager = LocalFocusManager.current
@@ -392,8 +504,6 @@ fun SettingsScreen(
             modifier = Modifier
                 .fillMaxSize()
         ) {
-            var railHadFocus by remember { mutableStateOf(false) }
-            val railListState = rememberLazyListState()
 
             val onSectionClick: (SettingsSectionSpec) -> Unit = { section ->
                 if (section.destination == SettingsSectionDestination.External) {
@@ -477,23 +587,39 @@ fun SettingsScreen(
                             state = railListState,
                             modifier = Modifier
                                 .focusRequester(railContainerFocusRequester)
+                                // Lets the rail resolve its own focus enter to the item that was on it when
+                                // it last lost focus. Without this the enter is resolved by stepping on from
+                                // whatever holds focus, which lands an item further along and drags the rail
+                                // with it. It agrees with focusRailCategory rather than competing with it:
+                                // both name the item the rail was left on. It cannot restore an item that is
+                                // no longer composed, which is what the retry there is for.
+                                .focusRestorer()
                                 .fillMaxWidth()
                                 .onFocusChanged { state ->
                                     val justGainedFocus = !railHadFocus && state.hasFocus
                                     railHadFocus = state.hasFocus
                                     if (justGainedFocus) {
-                                        val requester = railFocusRequesters[selectedCategory]
-                                        val requested = if (requester != null) {
-                                            runCatching { requester.requestFocus() }.getOrDefault(false)
+                                        if (railFallbackAttempt == railFocusAttempt) {
+                                            railFallbackAttempt = NO_RAIL_FALLBACK
                                         } else {
-                                            false
-                                        }
-                                        if (!requested) {
-                                            focusManager.moveFocus(FocusDirection.Enter)
+                                            focusRailCategory(railFocusCategory)
                                         }
                                     }
                                 }
                                 .onPreviewKeyEvent { event ->
+                                    // The user moving is the one signal that is unambiguously
+                                    // theirs, unlike a focus change, which the rail also produces
+                                    // on its own. Stop a restoration still retrying.
+                                    if (event.type == KeyEventType.KeyDown && event.key.isDirection()) {
+                                        // Retired by number as well as cancelled. The loops check the
+                                        // attempt number rather than isActive, so bumping it is what
+                                        // actually stops them; the cancel is just the quicker of the
+                                        // two.
+                                        railFocusAttempt += 1L
+                                        railFocusJob?.cancel()
+                                        railFocusJob = null
+                                        railRestoringCategory = null
+                                    }
                                     if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown) {
                                         focusedTabCategory?.let(selectFocusedTab)
                                         allowDetailAutofocus = true
@@ -515,6 +641,17 @@ fun SettingsScreen(
                                     focusRequester = railFocusRequesters[section.category],
                                     onClick = { onSectionClick(section) },
                                     onFocused = {
+                                        val restoringTo = railRestoringCategory
+                                        if (section.category == restoringTo) {
+                                            // Cleared here rather than waiting for the attempt to
+                                            // reach its next suspension point. The attempt is left
+                                            // running: it ends on its own once the request lands, and
+                                            // a directional press stops it early.
+                                            railRestoringCategory = null
+                                            railFocusCategoryName = section.category.name
+                                        } else if (restoringTo == null) {
+                                            railFocusCategoryName = section.category.name
+                                        }
                                         if (section.destination == SettingsSectionDestination.Inline) {
                                             focusedTabCategory = section.category
                                         }
@@ -537,9 +674,7 @@ fun SettingsScreen(
                             .onFocusChanged { state ->
                                 detailHasFocus = state.hasFocus
                                 if (state.hasFocus && !allowDetailAutofocus) {
-                                    railFocusRequesters[selectedCategory]?.let { requester ->
-                                        runCatching { requester.requestFocus() }
-                                    }
+                                    focusRailCategory(railFocusCategory)
                                 }
                             }
                     ) {
@@ -636,23 +771,39 @@ fun SettingsScreen(
                         state = railListState,
                         modifier = Modifier
                             .focusRequester(railContainerFocusRequester)
+                            // Lets the rail resolve its own focus enter to the item that was on it when
+                            // it last lost focus. Without this the enter is resolved by stepping on from
+                            // whatever holds focus, which lands an item further along and drags the rail
+                            // with it. It agrees with focusRailCategory rather than competing with it:
+                            // both name the item the rail was left on. It cannot restore an item that is
+                            // no longer composed, which is what the retry there is for.
+                            .focusRestorer()
                             .fillMaxSize()
                             .onFocusChanged { state ->
                                 val justGainedFocus = !railHadFocus && state.hasFocus
                                 railHadFocus = state.hasFocus
                                 if (justGainedFocus) {
-                                    val requester = railFocusRequesters[selectedCategory]
-                                    val requested = if (requester != null) {
-                                        runCatching { requester.requestFocus() }.getOrDefault(false)
+                                    if (railFallbackAttempt == railFocusAttempt) {
+                                        railFallbackAttempt = NO_RAIL_FALLBACK
                                     } else {
-                                        false
-                                    }
-                                    if (!requested) {
-                                        focusManager.moveFocus(FocusDirection.Down)
+                                        focusRailCategory(railFocusCategory)
                                     }
                                 }
                             }
                             .onPreviewKeyEvent { event ->
+                                // The user moving is the one signal that is unambiguously theirs,
+                                // unlike a focus change, which the rail also produces on its own.
+                                // Stop a restoration still retrying.
+                                if (event.type == KeyEventType.KeyDown && event.key.isDirection()) {
+                                    // Retired by number as well as cancelled. The loops check the
+                                    // attempt number rather than isActive, so bumping it is what
+                                    // actually stops them; the cancel is just the quicker of the
+                                    // two.
+                                    railFocusAttempt += 1L
+                                    railFocusJob?.cancel()
+                                    railFocusJob = null
+                                    railRestoringCategory = null
+                                }
                                 val toDetailKey = if (isRtl) Key.DirectionLeft else Key.DirectionRight
                                 if (event.type == KeyEventType.KeyDown && event.key == toDetailKey) {
                                     allowDetailAutofocus = true
@@ -668,6 +819,19 @@ fun SettingsScreen(
                             key = { it.category }
                         ) { section ->
                             SettingsRailButton(
+                                onFocused = {
+                                    val restoringTo = railRestoringCategory
+                                    if (section.category == restoringTo) {
+                                        // Cleared here rather than waiting for the attempt to
+                                        // reach its next suspension point. The attempt is left
+                                        // running: it ends on its own once the request lands, and
+                                        // a directional press stops it early.
+                                        railRestoringCategory = null
+                                        railFocusCategoryName = section.category.name
+                                    } else if (restoringTo == null) {
+                                        railFocusCategoryName = section.category.name
+                                    }
+                                },
                                 title = section.title,
                                 icon = section.icon,
                                 rawIconRes = section.rawIconRes,
@@ -699,12 +863,7 @@ fun SettingsScreen(
                                 val movedLeft = focusManager.moveFocus(if (isRtl) FocusDirection.Right else FocusDirection.Left)
                                 if (!movedLeft) {
                                     allowDetailAutofocus = false
-                                    val requested = railFocusRequesters[selectedCategory]?.let { requester ->
-                                        runCatching { requester.requestFocus() }.getOrDefault(false)
-                                    } ?: false
-                                    if (!requested) {
-                                        runCatching { railContainerFocusRequester.requestFocus() }
-                                    }
+                                    focusRailCategory(railFocusCategory)
                                 }
                                 true
                             } else {
@@ -714,9 +873,7 @@ fun SettingsScreen(
                         .onFocusChanged { state ->
                             detailHasFocus = state.hasFocus
                             if (state.hasFocus && !allowDetailAutofocus) {
-                                railFocusRequesters[selectedCategory]?.let { requester ->
-                                    runCatching { requester.requestFocus() }
-                                }
+                                focusRailCategory(railFocusCategory)
                             }
                         }
                 ) {
@@ -1104,3 +1261,18 @@ private fun IntegrationSettingsContent(
         }
     }
 }
+
+/**
+ * Whether the item at [index] is on screen at all. Used to decide whether the rail has to be
+ * scrolled before an item can be reached, not whether the item can take focus: being listed here
+ * does not promise an attached requester, which is what the retry after the scroll is for.
+ */
+private fun LazyListState.isItemVisible(index: Int): Boolean =
+    layoutInfo.visibleItemsInfo.any { it.index == index }
+
+/** Whether [this] is one of the directional keys, so a press of it means the user is moving. */
+private fun Key.isDirection(): Boolean =
+    this == Key.DirectionUp ||
+        this == Key.DirectionDown ||
+        this == Key.DirectionLeft ||
+        this == Key.DirectionRight

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -311,6 +311,20 @@ fun SettingsScreen(
     var pendingContentFocusCategory by remember { mutableStateOf<SettingsCategory?>(null) }
     var pendingContentFocusRequestId by remember { mutableLongStateOf(0L) }
     var allowDetailAutofocus by remember { mutableStateOf(false) }
+    var detailHasFocus by remember { mutableStateOf(false) }
+
+    // Back inside the options pane returns to the category rail before it leaves settings, the
+    // way back inside a row returns to the start of that row. Anything the pane declares itself,
+    // such as the integrations sub sections, composes later and so is asked first.
+    BackHandler(enabled = detailHasFocus) {
+        // Cleared up front rather than after the request. The rail reports its own focus a frame
+        // later, and until it does a second quick press would be consumed here again instead of
+        // reaching the sidebar. If the request fails this also leaves the next press free.
+        detailHasFocus = false
+        railFocusRequesters[selectedCategory]?.let { requester ->
+            runCatching { requester.requestFocus() }
+        }
+    }
 
     val focusManager = LocalFocusManager.current
 
@@ -491,6 +505,7 @@ fun SettingsScreen(
                             .weight(1f)
                             .fillMaxWidth()
                             .onFocusChanged { state ->
+                                detailHasFocus = state.hasFocus
                                 if (state.hasFocus && !allowDetailAutofocus) {
                                     railFocusRequesters[selectedCategory]?.let { requester ->
                                         runCatching { requester.requestFocus() }
@@ -667,6 +682,7 @@ fun SettingsScreen(
                             }
                         }
                         .onFocusChanged { state ->
+                            detailHasFocus = state.hasFocus
                             if (state.hasFocus && !allowDetailAutofocus) {
                                 railFocusRequesters[selectedCategory]?.let { requester ->
                                     runCatching { requester.requestFocus() }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/ThemeSettingsScreen.kt
@@ -130,6 +130,7 @@ fun ThemeSettingsContent(
     }
 
     val styleFocusRequesters = remember { SettingsUiStyle.entries.associateWith { FocusRequester() } }
+    val firstThemeFocusRequester = remember { FocusRequester() }
     val appliedSettingsUiStyle = NuvioTheme.settingsUiStyle
     LaunchedEffect(Unit) {
         if (viewModel.consumeStyleFocusRestore()) {
@@ -168,14 +169,16 @@ fun ThemeSettingsContent(
                 Box(modifier = Modifier.fillMaxWidth()) {
                     LazyRow(
                         state = themeRowState,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .settingsOptionRow(firstThemeFocusRequester),
                         contentPadding = PaddingValues(horizontal = NuvioTheme.spacing.xs, vertical = NuvioTheme.spacing.xs),
                         horizontalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         itemsIndexed(
                             items = uiState.availableThemes,
                             key = { _, theme -> theme.name }
-                        ) { _, theme ->
+                        ) { themeIndex, theme ->
                             ThemeSwatchChip(
                                 theme = theme,
                                 isSelected = theme == uiState.selectedTheme,
@@ -188,7 +191,13 @@ fun ThemeSettingsContent(
                                     Modifier.focusRequester(initialFocusRequester)
                                 } else {
                                     Modifier
-                                }
+                                }.then(
+                                    if (themeIndex == 0) {
+                                        Modifier.focusRequester(firstThemeFocusRequester)
+                                    } else {
+                                        Modifier
+                                    }
+                                )
                             )
                         }
                     }
@@ -221,11 +230,14 @@ fun ThemeSettingsContent(
                 title = stringResource(R.string.appearance_settings_style),
                 subtitle = stringResource(R.string.appearance_settings_style_subtitle)
             ) {
+                val firstAvailableStyle = uiState.availableSettingsUiStyles.firstOrNull()
+                    ?: SettingsUiStyle.entries.first()
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(IntrinsicSize.Min)
-                        .padding(horizontal = NuvioTheme.spacing.xs, vertical = NuvioTheme.spacing.xs),
+                        .padding(horizontal = NuvioTheme.spacing.xs, vertical = NuvioTheme.spacing.xs)
+                        .settingsOptionRow(styleFocusRequesters.getValue(firstAvailableStyle)),
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     uiState.availableSettingsUiStyles.forEach { style ->


### PR DESCRIPTION
## Summary

Six fixes to how Settings behaves with a remote, covering the seven manifestations in the issue. All of them are in `ui/screens/settings`; nothing outside that package is touched.

- **Back steps back one level.** It returned to the category rail only in Integrations; everywhere else it left Settings entirely, regardless of how deep the user had navigated. Now the options pane returns to the rail first, and a second press leaves as before. Integrations keeps its own extra step.

- **Opening a category lands on its first option.** Focus was requested once after a fixed delay. If the pane had not laid out by then the request failed and the directional fallback selected an unrelated option. Focus is retried once per frame for a bounded window before that fallback is tried. The old code also counted a declined request as a hit, so the fallback never ran at all. The fallback paths now read what `requestFocus()` returns.

- **The rail comes back to the item it was left on, and stays where it was.** Two separate defects.

  It restored from the selected category rather than the item that had focus, which is not the same thing: an external category never becomes the selected one, and moving along the rail selects nothing. The rail is also a `LazyColumn`, so an item scrolled out of view could not take focus at all and the press fell through to a geometric search.

  Separately, the rail had no focus restoration of its own, so entering it fell back to a directional focus search from whatever currently held focus. That landed an item further along and dragged the rail with it, one item per visit, in both directions. It is a focus group with `focusRestorer()` now, so the enter resolves to the right item and nothing scrolls.

- **Debrid can be entered with no provider connected.** Its first two rows are gated on a connected provider and cannot take focus, so focus stayed on the rail and the next press walked to Playback. The entry point now follows what is connected:

  | Connected | Entry row |
  | --- | --- |
  | A provider supporting cloud library | Cloud library |
  | A resolver only | Debrid enable toggle |
  | Neither | First account row |

- **Returning from a screen a category opened lands where Settings was left.** The distinction is which way the screen was reached. A screen opened from inside a category's options, such as Plugins or Addons, returns to those options. A category that is a destination in itself, opened straight from the rail, such as Tracking or the account sign in, returns to its rail row.

  Both cases went to the rail before. The flag recording the pane as the last place focused was reset by leaving Settings, so the pane redirected focus back to the rail on arrival; it survives the trip now. And where the screen is a destination, Settings leaves composition entirely, so nothing asked for the pane and the rail was simply the first thing able to take focus; the same flag now decides what to aim for. Focus lands on a category's first option, not the row the screen was opened from.

- **Option rows enter predictably and remember the last option.** Rows of side by side options used a geometric search and were entered on whichever option sat nearest the row above, which is the middle one. They are focus groups with focus restoration now, so first entry takes the first option and coming back restores the option last used when it is still available.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Settings is reached only with a remote, so focus is the navigation model. These bugs strand focus on the category rail, make Back leave Settings unexpectedly, or prevent entry into settings that are available. Debrid cannot be entered when no provider is connected, and coming back from a screen a category opened never lands where it was left.

The fixes restore predictable navigation without changing the visual UI or adding functionality.

## Issue or approval

Fixes #3273

## Reproduction steps

One per fix, in the same order as the summary above.

1. Open Settings, move right into any category, press **Back**. Focus should return to that category's rail item and a second press should close Settings. Today the first press closes Settings.
2. Pick a later category, such as the fifth or sixth. Focus lands partway down the options.
3. From the rail, press **Left** to open the sidebar, then **Right** to come back. Focus is on a different rail item than the one it was left on, and the rail itself has scrolled by one item. Repeat it and the rail walks back and forth.
4. With no debrid provider connected, open Integrations and pick Debrid. Focus stays on the rail; pressing **Down** moves to Playback.
5. Open Content & Discovery and pick Plugins or Addons, then press **Back**. Focus is on the Content & Discovery rail item rather than in the options pane. Tracking is the same fix from the other side: it is a destination in itself, opened from the rail, and Back from it lands on whichever category was last opened rather than on Tracking.
6. In Appearance, move **Down** onto the row of style cards. The middle card takes focus regardless of which style is currently applied.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `ui/screens/settings` is touched. Back behaviour on Home, Search, Library and Discover is left alone, including the fact that Back with the sidebar open does not exit from those screens. That is a separate defect outside this PR.

Also deliberately not changed:

- **The Debug category.** It has no entry requester and `DebugSettingsContent()` takes none, so it still uses the directional fallback. Debug builds only, and fixing it means changing that component's signature.
- **Horizontal rows that are not finite option selectors.** Every horizontal row in the settings package was classified. Seven are finite option selectors and all seven use the shared modifier: appearance style cards, appearance theme cards, the layout catalogs row, the layout trailer target chips, the layout options chips, the subtitle colours, and the auto play presets. The category rail is left alone because it already has its own focus handling. The remaining horizontal rows were reviewed and are category rows, unbounded lists or dialog controls rather than finite selectors.
- **Rows of buttons in dialogs**, such as Cancel and Save in the Anime-Skip one. Grouping buttons changes how a dialog is dismissed, which is its own question. Option selectors that happen to live in a dialog, the subtitle colours and the auto play presets, are covered: they are the same finite selector as the ones on the pane, and grouping them changes only which option is entered first.

## Testing

Extensively tested on an **NVIDIA Shield TV**, debug build, with focus and rail scroll traced through logcat to confirm the cause of each defect rather than only the symptom.

**Verified:**

- Back from the options pane returns to the rail, and a second press leaves Settings. Integrations keeps its extra step: sub section, hub, rail, out.
- Opening a category lands on its first option, including later categories.
- Returning from a category that opens its own screen keeps focus in the options pane rather than dropping it on the rail.
- Debrid with no provider connected: focus enters the first account row rather than stalling on the rail, so the category is reachable.
- Option rows: moving into a row takes the first option; move right twice, leave the row vertically, come back, and the third option still has focus. Checked on the appearance style cards, the home layout cards, the layout catalogs row, the chips, the subtitle colours and the auto play presets.
- Rail restoration from the sidebar: focus a rail item, left into the sidebar, right back. The same item keeps focus and the rail does not move. Repeated several times, since the earlier defect only showed up as accumulating drift.
- Rail restoration through a category's own screen: open Integrations, open Connected services, press Back, then Back again. Focus returns to Integrations, and opening the sub screen leaves focus in the pane rather than pulling it back to the rail.
- A rail item scrolled out of view: leave to the sidebar and come back, and it still takes focus. This is the retry path for a lazy item that is not composed.
- User input beating a restoration: pressing up or down, or opening a category, immediately on returning to the rail.
- Returning from a category's own destination, such as Plugins or Addons, lands in the options pane rather than on the rail.
- Returning from Tracking, which is a destination in itself rather than a category with options, lands on its rail row rather than on an unrelated category's options.
- All three settings styles, Classic, Zen and Horizon. Horizon is a horizontal tab strip and rotates the directions, so it exercises the second rail implementation.

**Not verified on device:**

- Debrid with a resolver connected, and Debrid with a cloud library provider connected. Both branches require a real provider with a stored API key, which was not available on the test device. The no-provider branch is verified.
- Right to left. The pane to rail step and the rail restore both key off layout direction.

**Known limitation:** returning from a category's own destination lands on that category's first option, not the row the destination was opened from. A pane leaves composition with the screen, so restoring the exact row means every pane recording its own focused row in saveable state. That is a larger change than this PR.

**Known behaviour, unchanged by this PR:** the Appearance colour theme row does not remember the option last used. It takes the first option when that option is on screen and falls back to a geometric search when it is not, which is the same result as a first entry. The other six finite option rows restore the last focused option.

No automated tests are included. These are remote focus interactions that need a device to verify, and the repository has no workflow that exercises them.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3273