### PR TITLE
fix(home): keep item keys stable when a refresh prepends to a row

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -115,8 +115,33 @@ fun CatalogRowSection(
 ) {
     val catalogRowKey = remember(catalogRow) { catalogRow.stableKey() }
     val rowItemIdentities = remember(catalogRow.items) { catalogRow.stableItemKeys() }
+
+    // Item keys carry item identity, which the placeholder the ring sits on loses when real data
+    // arrives: its key changes and Compose tears the focused node down. Lend that one card a
+    // positional key for as long as the ring can be on it, so the node is reused instead.
+    //
+    // Armed from the item id, not a loading flag: a lazily loaded catalog composes its row
+    // before loading starts and would never see the flag go up.
+    val firstCardKey = remember(catalogRowKey) { catalogRowKey + "__first" }
+    val firstIsPlaceholder = catalogRow.items.firstOrNull()?.id?.startsWith("__placeholder_") == true
+    val pinFirstCard = remember(catalogRowKey) { mutableStateOf(firstIsPlaceholder) }
+    val pinSpent = remember(catalogRowKey) { mutableStateOf(false) }
+    // Lent to the card, not the slot: slot 0 would hand the key to whatever lands there.
+    val pinnedItemKey = remember(catalogRowKey) { mutableStateOf<String?>(null) }
+    if (firstIsPlaceholder && !pinSpent.value) pinFirstCard.value = true
+    if (pinFirstCard.value && !firstIsPlaceholder && pinnedItemKey.value == null) {
+        pinnedItemKey.value = rowItemIdentities.firstOrNull()
+    }
+
     fun rowItemFocusKey(index: Int, item: MetaPreview): String {
-        return "${catalogRowKey}_$index"
+        val identity = rowItemIdentities.getOrElse(index) { catalogRow.stableItemKey(item) }
+        if (!pinFirstCard.value) return identity
+        val pinned = pinnedItemKey.value
+        return when {
+            pinned != null -> if (identity == pinned) firstCardKey else identity
+            index == 0 -> firstCardKey
+            else -> identity
+        }
     }
 
     val seeAllCardShape = RoundedCornerShape(posterCardStyle.cornerRadius)
@@ -152,6 +177,13 @@ fun CatalogRowSection(
         blockingFocusExit.value = true
     }
     wasPlaceholderRef.value = firstItemId?.startsWith("__placeholder_") == true
+
+    // Released once the ring has left the row: swapping the node earlier is visible for nothing.
+    if (pinFirstCard.value && !firstIsPlaceholder && !rowHasFocusRef.value) {
+        pinFirstCard.value = false
+        pinnedItemKey.value = null
+        pinSpent.value = true
+    }
 
     LaunchedEffect(blockingFocusExit.value) {
         if (!blockingFocusExit.value) return@LaunchedEffect

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -1137,10 +1137,11 @@ internal fun HomeViewModel.mergeRefreshedCatalogRow(
     val rowHasFocus = focusedRowKey != null && focusedRowKey == fresh.stableKey()
 
     if (isPrepend) {
-        // Nothing is removed, so the focused card only shifts along. That holds in the modern
-        // layout, which keeps the whole row; the others cut it at a fixed length, where the
-        // focused card can be pushed past the cut.
-        if (!requestedByUser && rowHasFocus) {
+        // Nothing is removed and every card already on screen keeps its key, so the focused card
+        // only shifts along and its node is reused. That holds in the modern layout, which keeps
+        // the whole row; the others cut it at a fixed length, where the focused card can be
+        // pushed past the cut and no key brings back a card that has left the list.
+        if (!requestedByUser && rowHasFocus && _uiState.value.homeLayout != HomeLayout.MODERN) {
             return true
         }
         val shiftedSkip = if (current.supportsSkip && current.nextSkip > 0) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomePresentation.kt
@@ -183,7 +183,7 @@ internal fun buildModernHomePresentation(
                                     cachedItem.showImdbRatings == input.showImdbRatings
                                 ) {
                                     cachedItem.carouselItem.let { cached ->
-                                        val stableItemKey = "${rowKey}_$itemIndex"
+                                        val stableItemKey = row.stableItemKey(item, occurrence)
                                         if (cached.key == stableItemKey) cached
                                         else cached.copy(key = stableItemKey)
                                     }
@@ -198,7 +198,7 @@ internal fun buildModernHomePresentation(
                                         showFullReleaseDate = input.showFullReleaseDate,
                                         showImdbRatings = input.showImdbRatings,
                                         previousCachedItem = cachedItem?.carouselItem
-                                    ).copy(key = "${rowKey}_$itemIndex")
+                                    ).copy(key = row.stableItemKey(item, occurrence))
                                     rowItemCache[cacheKey] = CachedCarouselItem(
                                         source = item,
                                         useLandscapePosters = input.useLandscapePosters,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -488,6 +488,30 @@ internal fun ModernRowSection(
 
     // Blocks vertical focus exit during placeholder→data transition.
     val blockingFocusExit = remember { mutableStateOf(false) }
+
+    // Item keys carry item identity, which the placeholder the ring sits on loses when real data
+    // arrives: its key changes and Compose tears the focused node down. Lend that one card a
+    // positional key for as long as the ring can be on it, so the node is reused instead.
+    //
+    // Armed from the item id, not a loading flag: a lazily loaded catalog composes its row
+    // before loading starts and would never see the flag go up.
+    val firstCardKey = remember(rowKey) { "${rowKey}__first" }
+    val firstIsPlaceholder = (row.items.list.firstOrNull()?.payload as? ModernPayload.Catalog)
+        ?.itemId?.startsWith("__placeholder_") == true
+    val pinFirstCard = remember(rowKey) { mutableStateOf(firstIsPlaceholder) }
+    val pinSpent = remember(rowKey) { mutableStateOf(false) }
+    // Lent to the card, not the slot: slot 0 would hand the key to whatever lands there.
+    val pinnedItemKey = remember(rowKey) { mutableStateOf<String?>(null) }
+    if (firstIsPlaceholder && !pinSpent.value) pinFirstCard.value = true
+    if (pinFirstCard.value && !firstIsPlaceholder && pinnedItemKey.value == null) {
+        pinnedItemKey.value = row.items.list.firstOrNull()?.key
+    }
+    // Released once the ring has left the row: swapping the node earlier is visible for nothing.
+    if (pinFirstCard.value && !firstIsPlaceholder && !isActiveRow()) {
+        pinFirstCard.value = false
+        pinnedItemKey.value = null
+        pinSpent.value = true
+    }
     Column(
         modifier = Modifier.then(
             if (blockingFocusExit.value) {
@@ -877,7 +901,15 @@ internal fun ModernRowSection(
             ) {
                 itemsIndexed(
                     items = row.items.list,
-                    key = { _, item -> item.key },
+                    key = { index, item ->
+                        val pinned = pinnedItemKey.value
+                        when {
+                            !pinFirstCard.value -> item.key
+                            pinned != null -> if (item.key == pinned) firstCardKey else item.key
+                            index == 0 -> firstCardKey
+                            else -> item.key
+                        }
+                    },
                     contentType = { _, item ->
                         when (val payload = item.payload) {
                             is ModernPayload.ContinueWatching -> "modern_cw_card"


### PR DESCRIPTION
## Summary

Two changes, modern home layout only.

1. Row items are keyed by identity instead of position:

```diff
- .copy(key = "${rowKey}_$itemIndex")
+ .copy(key = row.stableItemKey(item, occurrence))
```

2. The first card of a row is pinned with a fixed key for as long as the focus ring can be on it. This keeps its node alive while the placeholder is replaced by real data, so Compose reuses the same node and the focus stays on the card.

With keys that survive a prepend, modern no longer has to withhold the update from the row holding focus:

```diff
- if (!requestedByUser && rowHasFocus) {
+ if (!requestedByUser && rowHasFocus && _uiState.value.homeLayout != HomeLayout.MODERN) {
```

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix

Neither box applies.

## Why

Keys built from position hand an existing key to a different item as soon as something is added in front of it.

They also disable a Compose mechanism. `LazyListScrollPosition` stores the key of the first visible item and re-resolves its index when items are inserted before it, so the viewport follows the content. A positional key still exists after the insert, it just points at another item, so nothing is detected and the row is left showing different cards. `ModernHomeContent` already works around this by rebuilding an identity from the payload for focus relocation, and its comment says so.

Keying by identity fixes this and lets modern apply prepends even while the row holds focus. It also means there is no need for a positional offset to keep the existing cards aligned.

Identity leaves one case where a key changes under the focus ring: the placeholder being replaced by real data, since `__placeholder_…` and the real id are different items.

The pin covers that case and nothing else. It is armed from the item id rather than a loading flag, because a lazily loaded catalog composes its row before loading starts and would never see the flag go up. It follows the card rather than slot 0, and is released once focus leaves the row.

## Issue or approval

Follow-up to #3245.
