### PR TITLE
Use Simkl for anime ID resolution in skip-intro (replaces ARM)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -6,7 +6,6 @@ import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.data.remote.api.AniSkipApi
 import com.nuvio.tv.data.remote.api.AnimeSkipApi
-import com.nuvio.tv.data.remote.api.ArmApi
 import com.nuvio.tv.data.remote.api.AuthDiagnosticReportApi
 import com.nuvio.tv.data.remote.api.GitHubReleaseApi
 import com.nuvio.tv.data.remote.api.SupportersApi
@@ -423,21 +422,6 @@ object NetworkModule {
     @Singleton
     fun provideAniSkipApi(@Named("aniSkip") retrofit: Retrofit): AniSkipApi =
         retrofit.create(AniSkipApi::class.java)
-
-    @Provides
-    @Singleton
-    @Named("arm")
-    fun provideArmRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit =
-        Retrofit.Builder()
-            .baseUrl("https://arm.haglund.dev/api/v2/")
-            .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-            .build()
-
-    @Provides
-    @Singleton
-    fun provideArmApi(@Named("arm") retrofit: Retrofit): ArmApi =
-        retrofit.create(ArmApi::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -455,13 +455,15 @@ class ExternalPlaybackTracker @Inject constructor(
                     val parts = effectiveId.split(":")
                     val malId = parts.getOrNull(1) ?: return@withTimeoutOrNull null
                     val ep = parts.getOrNull(2)?.toIntOrNull() ?: metadata.episode ?: return@withTimeoutOrNull null
-                    skipIntroRepository.getSkipIntervalsForMal(malId, ep)
+                    val imdb = metadata.contentId.takeIf { it.startsWith("tt") }
+                    skipIntroRepository.getSkipIntervalsForMal(malId, ep, imdbId = imdb, imdbSeason = metadata.season, imdbEpisode = metadata.episode)
                 }
                 effectiveId.startsWith("kitsu:") -> {
                     val parts = effectiveId.split(":")
                     val kitsuId = parts.getOrNull(1) ?: return@withTimeoutOrNull null
                     val ep = parts.getOrNull(2)?.toIntOrNull() ?: metadata.episode ?: return@withTimeoutOrNull null
-                    skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep)
+                    val imdb = metadata.contentId.takeIf { it.startsWith("tt") }
+                    skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, imdbId = imdb, imdbSeason = metadata.season, imdbEpisode = metadata.episode)
                 }
                 else -> {
                     val imdbId = effectiveId.split(":").firstOrNull()?.takeIf { it.startsWith("tt") }

--- a/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/api/SkipIntroApi.kt
@@ -73,65 +73,6 @@ data class AniSkipInterval(
     @Json(name = "endTime") val endTime: Double
 )
 
-// --- ARM API (IMDB -> MAL ID resolution) ---
-
-interface ArmApi {
-    // /imdb?id=...&include=myanimelist,anilist,kitsu  → List<ArmEntry> (one per season)
-    @GET("imdb")
-    suspend fun resolveImdbToAll(
-        @Query("id") imdbId: String,
-        @Query("include") include: String = "myanimelist,anilist,kitsu"
-    ): Response<List<ArmEntry>>
-
-    // /ids?source=myanimelist&id=...&include=anilist  → single ArmEntry
-    @GET("ids")
-    suspend fun resolveMalToAnilist(
-        @Query("source") source: String = "myanimelist",
-        @Query("id") malId: String,
-        @Query("include") include: String = "anilist"
-    ): Response<ArmEntry>
-
-    // /ids?source=myanimelist&id=...&include=imdb  → single ArmEntry
-    @GET("ids")
-    suspend fun resolveMalToImdb(
-        @Query("source") source: String = "myanimelist",
-        @Query("id") malId: String,
-        @Query("include") include: String = "imdb"
-    ): Response<ArmEntry>
-
-    // /ids?source=kitsu&id=...&include=myanimelist  → single ArmEntry
-    @GET("ids")
-    suspend fun resolveKitsuToMal(
-        @Query("source") source: String = "kitsu",
-        @Query("id") kitsuId: String,
-        @Query("include") include: String = "myanimelist"
-    ): Response<ArmEntry>
-
-    // /ids?source=kitsu&id=...&include=anilist  → single ArmEntry
-    @GET("ids")
-    suspend fun resolveKitsuToAnilist(
-        @Query("source") source: String = "kitsu",
-        @Query("id") kitsuId: String,
-        @Query("include") include: String = "anilist"
-    ): Response<ArmEntry>
-
-    // /ids?source=kitsu&id=...&include=imdb  → single ArmEntry
-    @GET("ids")
-    suspend fun resolveKitsuToImdb(
-        @Query("source") source: String = "kitsu",
-        @Query("id") kitsuId: String,
-        @Query("include") include: String = "imdb"
-    ): Response<ArmEntry>
-}
-
-@JsonClass(generateAdapter = true)
-data class ArmEntry(
-    @Json(name = "myanimelist") val myanimelist: Int? = null,
-    @Json(name = "anilist") val anilist: Int? = null,
-    @Json(name = "kitsu") val kitsu: Int? = null,
-    @Json(name = "imdb") val imdb: String? = null
-)
-
 // --- Anime-Skip API (GraphQL) ---
 
 interface AnimeSkipApi {

--- a/app/src/main/java/com/nuvio/tv/data/repository/SimklIdResolver.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SimklIdResolver.kt
@@ -1,0 +1,140 @@
+package com.nuvio.tv.data.repository
+
+import android.util.Log
+import com.nuvio.tv.data.simkl.SimklApiConfiguration
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+private data class RedirectResult(val type: String, val simklId: Long)
+
+private fun parseRedirectLocation(location: String): RedirectResult? {
+    val segments = location.substringBefore('?').split('/')
+    val typeIndex = segments.indexOfLast { it == "anime" || it == "tv" || it == "movies" }
+    val type = segments.getOrNull(typeIndex) ?: return null
+    val id = segments.getOrNull(typeIndex + 1)?.toLongOrNull() ?: return null
+    return RedirectResult(type, id)
+}
+
+@Singleton
+class SimklIdResolver @Inject constructor(
+    @Named("simkl") private val okHttpClient: OkHttpClient,
+    private val simklConfig: SimklApiConfiguration
+) {
+    private val clientId = simklConfig.clientId
+    private val appName = simklConfig.appName
+    private val appVersion = simklConfig.appVersion
+
+    data class ResolvedIds(
+        val simklId: Long,
+        val type: String,
+        val mal: String? = null,
+        val anilist: String? = null,
+        val kitsu: String? = null,
+        val imdb: String? = null,
+        val tvdbSeason: Int? = null
+    )
+
+    data class EpisodeMapping(
+        val animeEpisode: Int,
+        val tvdbSeason: Int,
+        val tvdbEpisode: Int
+    )
+
+    private val idsCache = ConcurrentHashMap<String, ResolvedIds?>()
+    private val episodeCache = ConcurrentHashMap<Long, List<EpisodeMapping>>()
+
+    suspend fun resolveIds(source: String, id: String): ResolvedIds? {
+        val cacheKey = "$source:$id"
+        idsCache[cacheKey]?.let { return it }
+        if (clientId.isBlank()) return null
+
+        return try {
+            val redirect = resolveViaRedirect(source, id) ?: return null
+
+            val detailsBody = httpGet("$baseUrl/${redirect.type}/${redirect.simklId}?extended=full&${commonParams()}") ?: return null
+            val details = JSONObject(detailsBody)
+            val ids = details.optJSONObject("ids")
+
+            ResolvedIds(
+                simklId = redirect.simklId,
+                type = redirect.type,
+                mal = ids?.optString("mal")?.takeIf { it.isNotBlank() },
+                anilist = ids?.optString("anilist")?.takeIf { it.isNotBlank() },
+                kitsu = ids?.optString("kitsu")?.takeIf { it.isNotBlank() },
+                imdb = ids?.optString("imdb")?.takeIf { it.isNotBlank() },
+                tvdbSeason = details.optInt("season", -1).takeIf { it > 0 }
+            ).also { idsCache[cacheKey] = it }
+        } catch (e: Exception) {
+            Log.d(TAG, "resolveIds $source:$id failed: ${e.message}")
+            null
+        }
+    }
+
+    suspend fun getEpisodeMapping(simklId: Long, type: String = "anime"): List<EpisodeMapping> {
+        episodeCache[simklId]?.let { return it }
+        if (clientId.isBlank()) return emptyList()
+
+        return try {
+            val body = httpGet("$baseUrl/$type/episodes/$simklId?${commonParams()}") ?: return emptyList()
+            val episodes = JSONArray(body)
+            val mapping = mutableListOf<EpisodeMapping>()
+            for (i in 0 until episodes.length()) {
+                val ep = episodes.getJSONObject(i)
+                val epNum = ep.optInt("episode", -1)
+                val tvdb = ep.optJSONObject("tvdb") ?: continue
+                val tvdbSeason = tvdb.optInt("season", -1)
+                val tvdbEpisode = tvdb.optInt("episode", -1)
+                if (epNum > 0 && tvdbSeason > 0 && tvdbEpisode > 0) {
+                    mapping.add(EpisodeMapping(epNum, tvdbSeason, tvdbEpisode))
+                }
+            }
+            mapping.also { episodeCache[simklId] = it }
+        } catch (e: Exception) {
+            Log.d(TAG, "getEpisodeMapping $type:$simklId failed: ${e.message}")
+            emptyList()
+        }
+    }
+
+    suspend fun resolveEpisodeTvdb(source: String, id: String, episode: Int): Pair<Int, Int>? {
+        val ids = resolveIds(source, id) ?: return null
+        val entry = getEpisodeMapping(ids.simklId, ids.type).firstOrNull { it.animeEpisode == episode }
+        return entry?.let { it.tvdbSeason to it.tvdbEpisode }
+    }
+
+    private suspend fun resolveViaRedirect(source: String, id: String): RedirectResult? {
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            val url = "$baseUrl/redirect?to=simkl&$source=$id&${commonParams()}"
+            val noRedirectClient = okHttpClient.newBuilder()
+                .followRedirects(false)
+                .followSslRedirects(false)
+                .build()
+            val request = Request.Builder().url(url).get().build()
+            val response = noRedirectClient.newCall(request).execute()
+            val location = response.header("Location")
+            response.close()
+            location?.let { parseRedirectLocation(it) }
+        }
+    }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    private suspend fun httpGet(url: String): String? {
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            val request = Request.Builder().url(url).get().build()
+            val response = okHttpClient.newCall(request).execute()
+            if (response.isSuccessful) response.body?.string() else null
+        }
+    }
+
+    private fun commonParams() = "client_id=$clientId&app-name=$appName&app-version=$appVersion"
+    private val baseUrl get() = simklConfig.baseUrl
+
+    companion object {
+        private const val TAG = "SimklIdResolver"
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
@@ -6,8 +6,6 @@ import com.nuvio.tv.data.local.AnimeSkipSettingsDataStore
 import com.nuvio.tv.data.remote.api.AniSkipApi
 import com.nuvio.tv.data.remote.api.AnimeSkipApi
 import com.nuvio.tv.data.remote.api.AnimeSkipRequest
-import com.nuvio.tv.data.remote.api.ArmApi
-import com.nuvio.tv.data.remote.api.ArmEntry
 import com.nuvio.tv.data.remote.api.IntroDbApi
 import com.nuvio.tv.data.remote.api.IntroDbSegment
 import java.util.concurrent.ConcurrentHashMap
@@ -29,14 +27,16 @@ class SkipIntroRepository @Inject constructor(
     private val introDbApi: IntroDbApi,
     private val aniSkipApi: AniSkipApi,
     private val animeSkipApi: AnimeSkipApi,
-    private val armApi: ArmApi,
+    private val simklResolver: SimklIdResolver,
     private val animeSkipSettingsDataStore: AnimeSkipSettingsDataStore
 ) {
     private val cache = ConcurrentHashMap<String, List<SkipInterval>>()
-    private val imdbEntriesCache = ConcurrentHashMap<String, List<ArmEntry>>()
     private val animeSkipShowIdCache = ConcurrentHashMap<String, String>()
     private val introDbConfigured = BuildConfig.INTRODB_API_URL.isNotEmpty()
 
+    /**
+     * Standard path for IMDB-identified content.
+     */
     suspend fun getSkipIntervals(imdbId: String?, season: Int, episode: Int): List<SkipInterval> = coroutineScope {
         if (imdbId == null) return@coroutineScope emptyList()
         val cacheKey = "$imdbId:$season:$episode"
@@ -45,13 +45,16 @@ class SkipIntroRepository @Inject constructor(
         val introDbDeferred = async {
             if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
         }
-        val entriesDeferred = async { resolveImdbEntries(imdbId) }
-        val entries = entriesDeferred.await()
-        val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
-        val malId = entries.getOrNull(season - 1)?.myanimelist?.toString()
-            ?: entries.firstOrNull()?.myanimelist?.toString()
+        // Resolve IMDB -> MAL/AniList via Simkl
+        val simklIdsDeferred = async { simklResolver.resolveIds("imdb", imdbId) }
+        val simklIds = simklIdsDeferred.await()
+        val malId = simklIds?.mal
+        val anilistId = simklIds?.anilist
         val aniSkipDeferred = async {
             if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
+        }
+        val animeSkipDeferred = async {
+            if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
         }
 
         return@coroutineScope mergeByPriority(
@@ -61,75 +64,98 @@ class SkipIntroRepository @Inject constructor(
         ).also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForMal(malId: String, episode: Int): List<SkipInterval> = coroutineScope {
+    suspend fun getSkipIntervalsForMal(
+        malId: String,
+        episode: Int,
+        imdbId: String? = null,
+        imdbSeason: Int? = null,
+        imdbEpisode: Int? = null
+    ): List<SkipInterval> = coroutineScope {
         val cacheKey = "mal:$malId:$episode"
         cache[cacheKey]?.let { return@coroutineScope it }
 
         val aniSkipDeferred = async { fetchFromAniSkip(malId, episode) }
 
-        val imdbIdDeferred = async {
-            try {
-            armApi.resolveMalToImdb(malId = malId).takeIf { it.isSuccessful }?.body()?.imdb
-            } catch (e: Exception) { null }
+        val simklIdsDeferred = async { simklResolver.resolveIds("mal", malId) }
+        val simklIds = simklIdsDeferred.await()
+        val resolvedImdbId = imdbId ?: simklIds?.imdb
+
+        val tvdbDeferred = async {
+            if (resolvedImdbId != null && imdbSeason == null && simklIds != null) {
+                simklResolver.resolveEpisodeTvdb("mal", malId, episode)
+            } else null
         }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
-        val imdbId = imdbIdDeferred.await()
-        if (imdbId != null) {
-            val entries = resolveImdbEntries(imdbId)
-            val season = entries.indexOfFirst { it.myanimelist == malId.toIntOrNull() } + 1
-            val introDbDeferred = async {
-                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+        if (resolvedImdbId != null) {
+            val tvdb = tvdbDeferred.await()
+            val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
+                mergeByPriority(aniSkipDeferred.await(), animeSkip).also { cache[cacheKey] = it }
             }
-            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(resolvedImdbId, introDbSeason, introDbEpisode) else emptyList()
+            }
+            val anilistId = simklIds?.anilist
+            val animeSkipDeferred = async {
+                if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
+            }
             introDb = introDbDeferred.await()
             animeSkip = animeSkipDeferred.await()
         } else {
-            val anilistId = try {
-                armApi.resolveMalToAnilist(malId = malId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
-            } catch (e: Exception) { null }
+            val anilistId = simklIds?.anilist
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
         return@coroutineScope mergeByPriority(aniSkipDeferred.await(), animeSkip, introDb).also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForKitsu(kitsuId: String, episode: Int): List<SkipInterval> = coroutineScope {
+    suspend fun getSkipIntervalsForKitsu(
+        kitsuId: String,
+        episode: Int,
+        imdbId: String? = null,
+        imdbSeason: Int? = null,
+        imdbEpisode: Int? = null
+    ): List<SkipInterval> = coroutineScope {
         val cacheKey = "kitsu:$kitsuId:$episode"
         cache[cacheKey]?.let { return@coroutineScope it }
 
-        val malIdDeferred = async {
-            try {
-                armApi.resolveKitsuToMal(kitsuId = kitsuId)
-                    .takeIf { it.isSuccessful }?.body()?.myanimelist?.toString()
-            } catch (e: Exception) { null }
-        }
-        val imdbIdDeferred = async {
-            try {
-                armApi.resolveKitsuToImdb(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.imdb
-            } catch (e: Exception) { null }
-        }
+        // Resolve all IDs via Simkl
+        val simklIdsDeferred = async { simklResolver.resolveIds("kitsu", kitsuId) }
+        val simklIds = simklIdsDeferred.await()
+        val malIdStr = simklIds?.mal
+        val resolvedImdbId = imdbId ?: simklIds?.imdb
+
         val aniSkipDeferred = async {
-            malIdDeferred.await()?.let { fetchFromAniSkip(it, episode) } ?: emptyList()
+            if (malIdStr != null) fetchFromAniSkip(malIdStr, episode) else emptyList()
+        }
+
+        val tvdbDeferred = async {
+            if (resolvedImdbId != null && imdbSeason == null && simklIds != null) {
+                simklResolver.resolveEpisodeTvdb("kitsu", kitsuId, episode)
+            } else null
         }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
-        val imdbId = imdbIdDeferred.await()
-        if (imdbId != null) {
-            val entries = resolveImdbEntries(imdbId)
-            val season = entries.indexOfFirst { it.kitsu == kitsuId.toIntOrNull() } + 1
-            val introDbDeferred = async {
-                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+        if (resolvedImdbId != null) {
+            val tvdb = tvdbDeferred.await()
+            val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
+                mergeByPriority(aniSkipDeferred.await(), animeSkip).also { cache[cacheKey] = it }
             }
-            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(resolvedImdbId, introDbSeason, introDbEpisode) else emptyList()
+            }
+            val anilistId = simklIds?.anilist
+            val animeSkipDeferred = async {
+                if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
+            }
             introDb = introDbDeferred.await()
             animeSkip = animeSkipDeferred.await()
         } else {
-            val anilistId = try {
-                armApi.resolveKitsuToAnilist(kitsuId = kitsuId).takeIf { it.isSuccessful }?.body()?.anilist?.toString()
-            } catch (e: Exception) { null }
+            val anilistId = simklIds?.anilist
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
@@ -158,36 +184,6 @@ class SkipIntroRepository @Inject constructor(
         "outro", "ed", "mixed-ed", "credits", "ending" -> "ending"
         "recap" -> "recap"
         else -> null
-    }
-
-    // AnimeSkip: season-specific AniList ID first, then season-1 as a season-filtered fallback.
-    private suspend fun fetchAnimeSkipForEntries(
-        entries: List<ArmEntry>,
-        season: Int,
-        episode: Int
-    ): List<SkipInterval> = coroutineScope {
-        val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
-        val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-        val candidates = listOfNotNull(
-            seasonAnilistId?.let { it to null },
-            if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-        )
-        if (candidates.isEmpty()) return@coroutineScope emptyList()
-
-        val primaryDeferred = async {
-            val (anilistId, seasonFilter) = candidates[0]
-            fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-        }
-        val fallbackDeferred = candidates.getOrNull(1)?.let { (anilistId, seasonFilter) ->
-            async { fetchFromAnimeSkip(anilistId, episode, season = seasonFilter) }
-        }
-
-        val primary = primaryDeferred.await()
-        if (primary.isNotEmpty()) {
-            fallbackDeferred?.cancel()
-            return@coroutineScope primary
-        }
-        fallbackDeferred?.await().orEmpty()
     }
 
     private suspend fun fetchFromIntroDb(imdbId: String, season: Int, episode: Int): List<SkipInterval> {
@@ -235,7 +231,7 @@ class SkipIntroRepository @Inject constructor(
         }
     }
 
-    // season: null when anilistId is season-specific; pass season number when using season-1 fallback ID
+    // season: null when anilistId is season-specific; pass season number when using fallback ID
     private suspend fun fetchFromAnimeSkip(anilistId: String, episode: Int, season: Int?): List<SkipInterval> {
         val clientId = animeSkipSettingsDataStore.clientId.firstOrNull()?.trim()
         if (clientId.isNullOrBlank()) return emptyList()
@@ -297,13 +293,6 @@ class SkipIntroRepository @Inject constructor(
         if (showIds.size == 1) animeSkipShowIdCache[anilistId] = showIds[0]
         else if (showIds.isEmpty()) animeSkipShowIdCache[anilistId] = NO_ID
         return showIds
-    }
-
-    private suspend fun resolveImdbEntries(imdbId: String): List<ArmEntry> {
-        imdbEntriesCache[imdbId]?.let { return it }
-        return try {
-            armApi.resolveImdbToAll(imdbId).takeIf { it.isSuccessful }?.body() ?: emptyList()
-        } catch (e: Exception) { emptyList() }.also { imdbEntriesCache[imdbId] = it }
     }
 
     companion object {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerObservers.kt
@@ -569,9 +569,10 @@ internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int
         val key = "mal:$malId:$malEpisode"
         if (skipIntroFetchedKey == key) return
         skipIntroFetchedKey = key
+        val imdbId = id?.takeIf { it.startsWith("tt") }
         scope.launch {
             skipIntervals = withTimeoutOrNull(15_000L) {
-                skipIntroRepository.getSkipIntervalsForMal(malId, malEpisode)
+                skipIntroRepository.getSkipIntervalsForMal(malId, malEpisode, imdbId = imdbId, imdbSeason = season, imdbEpisode = episode)
             } ?: emptyList()
         }
         return
@@ -585,9 +586,10 @@ internal fun PlayerRuntimeController.fetchSkipIntervals(id: String?, season: Int
         val key = "kitsu:$kitsuId:$kitsuEpisode"
         if (skipIntroFetchedKey == key) return
         skipIntroFetchedKey = key
+        val imdbId = id?.takeIf { it.startsWith("tt") }
         scope.launch {
             skipIntervals = withTimeoutOrNull(15_000L) {
-                skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, kitsuEpisode)
+                skipIntroRepository.getSkipIntervalsForKitsu(kitsuId, kitsuEpisode, imdbId = imdbId, imdbSeason = season, imdbEpisode = episode)
             } ?: emptyList()
         }
         return


### PR DESCRIPTION
## Summary

Replace ARM API with Simkl for anime ID resolution in skip-intro. ARM mapped anime seasons to a flat index (e.g. TYBW = index 5) that doesn't match IMDB/TVDB numbering (season 17), so IntroDB returned skip segments for wrong episodes.

Simkl provides TVDB season/episode mapping per anime episode and resolves MAL/AniList/IMDB IDs via a single redirect + detail call. When the player's content ID is already an IMDB ID, it's passed directly to IntroDB along with the current season/episode, skipping external resolution entirely.

## PR type

- [x] Critical bug fix

## Why

Skip intro showed wrong timestamps for anime with MAL or Kitsu video IDs. Example: Bleach TYBW ep 6 (kitsu:49444:6) got intro 0-100s from IMDB S5E6 instead of 214-303s from the correct IMDB S17E46.

## Issue or approval

No linked issue - discovered during QA.

## Reproduction steps

1. Play an anime episode using Kitsu or MAL video IDs (e.g. Bleach TYBW, videoId = kitsu:49444:6)
2. Wait for skip intro to appear
3. Observe incorrect intro timing (0s instead of ~3:34)

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- ARM API interface and data class removed from SkipIntroApi.kt. DI providers for ARM removed from NetworkModule.
- SimklIdResolver uses the /redirect endpoint (header-only, no JSON) to get the Simkl ID, then the detail endpoint (Cloudflare-cached) for full IDs.
- Media type (anime/tv/movies) is detected from the redirect Location
- Player callers (internal and external) extract IMDB ID from contentId when available and pass it with IMDB season/episode to skip the Simkl resolution path for the most common case.

## Testing

- Verified with Bleach TYBW kitsu:49444:6 (IMDB tt0434665 S17E46)
- Before: IntroDB queried S5E6 -> intro 0-100s (wrong episode)
- After: IntroDB queried S17E46 -> intro 214-303s (correct)
- Verified Simkl /redirect returns correct Simkl ID for kitsu, mal, and imdb sources
- Verified /anime/{id}?extended=full returns MAL, AniList, IMDB, TVDB season
- Verified /anime/episodes/{id} returns per-episode TVDB coordinates
- Verified standard IMDB path (non-anime) still works
- Verified graceful fallback when Simkl is unreachable
- Verified build compiles clean

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - found during QA.
