### PR TITLE
fix: stop an unknown runtime rendering as "0m"

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -862,7 +862,14 @@ private fun formatYearRange(releaseInfo: String?): String? {
     return releaseInfo.trim()
 }
 
-private fun formatRuntime(runtime: String): String {
+/**
+ * Null when the runtime is zero or unparseable-as-positive.
+ *
+ * TMDB answers with runtime 0, not null, for a title whose length it does not know yet, so
+ * every branch below could reach the end with a total of zero and render a literal "0m" in the
+ * metadata row. The caller already drops a null.
+ */
+private fun formatRuntime(runtime: String): String? {
     val trimmed = runtime.trim()
     // Already in "Xh Ym" or "Xh" format
     if (trimmed.contains('h') || trimmed.contains('m')) {
@@ -887,6 +894,7 @@ private fun formatRuntime(runtime: String): String {
     }
     // Plain number (minutes)
     val minutes = trimmed.filter { it.isDigit() }.toIntOrNull() ?: return runtime
+    if (minutes <= 0) return null
     return if (minutes >= 60) {
         val hours = minutes / 60
         val mins = minutes % 60

--- a/app/src/main/java/com/nuvio/tv/ui/util/HeroMetadataFormatter.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/HeroMetadataFormatter.kt
@@ -5,6 +5,10 @@ import com.nuvio.tv.core.util.parseRuntimeMinutes
 fun formatHeroRuntime(runtime: String?): String? {
     val normalized = runtime?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return null
     val totalMinutes = parseRuntimeMinutes(normalized) ?: return runtime
+    // TMDB answers with runtime 0, not null, for a title whose length it does not know yet --
+    // common for anything newly added. Formatting that produced a literal "0m" next to the
+    // genre. No runtime is the honest reading of zero, and callers already drop a null.
+    if (totalMinutes <= 0) return null
 
     val wholeHours = totalMinutes / 60
     val remainingMinutes = totalMinutes % 60

--- a/app/src/test/java/com/nuvio/tv/ui/util/HeroMetadataFormatterTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/util/HeroMetadataFormatterTest.kt
@@ -1,0 +1,42 @@
+package com.nuvio.tv.ui.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HeroMetadataFormatterTest {
+
+    @Test
+    fun `formats hours and minutes`() {
+        assertEquals("2h 5m", formatHeroRuntime("125"))
+        assertEquals("1h 30m", formatHeroRuntime("90 min"))
+        assertEquals("45m", formatHeroRuntime("45"))
+    }
+
+    @Test
+    fun `drops the minute part when a runtime is whole hours`() {
+        assertEquals("2h", formatHeroRuntime("120"))
+    }
+
+    /**
+     * TMDB answers with 0, not null, for a title whose length it does not know yet. That used to
+     * reach the screen as a literal "0m" beside the genre.
+     */
+    @Test
+    fun `returns null for a zero runtime`() {
+        assertNull(formatHeroRuntime("0"))
+        assertNull(formatHeroRuntime("0 min"))
+        assertNull(formatHeroRuntime("0h 0m"))
+    }
+
+    @Test
+    fun `returns null for a missing runtime`() {
+        assertNull(formatHeroRuntime(null))
+        assertNull(formatHeroRuntime("   "))
+    }
+
+    @Test
+    fun `passes through text it cannot read as minutes`() {
+        assertEquals("unknown", formatHeroRuntime("unknown"))
+    }
+}


### PR DESCRIPTION
## Summary

Stops a runtime of zero rendering as a literal `0m` in the hero and details metadata rows. Two guards, one in each runtime formatter, plus unit tests for the shared one.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

TMDB answers with `"runtime": 0` — not `null` — for a title whose length it does not know yet. That is common for anything recently added or just released. The enrichment passes the zero through as a string (`runtime = enrichment.runtimeMinutes?.toString()` in `HomeViewModelPresentationPipeline` and `MetaDetailsViewModel`), and both formatters then print it:

- `formatHeroRuntime` — `wholeHours` and `remainingMinutes` are both 0, so the `when` falls to `else -> "${remainingMinutes}m"`.
- `HeroSection.formatRuntime` — its two guarded branches correctly decline to return, because they sit behind `if (total > 0)`, but execution then reaches the "plain number" tail, which is unguarded.

So the metadata row claims the film is zero minutes long.

Both callers already drop a null or blank result — `ModernHomeHero` checks `isNullOrBlank`, `HeroSection` builds its secondary row with `runtimeText?.takeIf { it.isNotBlank() }` — so returning nothing for an unknown runtime needs no change at the call sites. The row is simply one segment shorter.

## Issue or approval

Fixes #3295.

## Reproduction steps

1. Enable TMDB enrichment (Settings → Integrations → TMDB) with basic info and details on.
2. Browse to any title whose TMDB runtime is 0. Reproducible example: TMDB movie **1530941** — `GET /3/movie/1530941` currently returns `"runtime": 0` with `"status": "Released"`.
3. Focus it on the home hero, then open its details page.
4. Read the metadata row in both places.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The only visible change is that a bogus `0m` segment disappears. Titles with a real runtime are untouched.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Deliberately **not** changed:

- The enrichment. Mapping `runtimeMinutes == 0` to null at the source would arguably be tidier, but it touches two view models and anything else reading that field, and the formatters have to be correct regardless of what feeds them.
- `HeroSection.formatRuntime` is left as a near-duplicate of `formatHeroRuntime`. Collapsing them is the obvious cleanup and is exactly the drive-by refactor the policy asks me not to bundle.
- No change to how runtimes are formatted or ordered otherwise, and no new strings.

## Testing

Fire TV Cube (`AFTGAZL`, Android 9 / Fire OS 7), `armeabi-v7a` release build, on TMDB movie 1530941:

```
                 before                             after
home hero        Movie • Animation • 0m             Movie • Animation
details page     16 | RELEASED • 0m • Japan • JA    16 | RELEASED • Japan • JA
```

The only difference is the runtime segment; nothing else in either row moves. Titles with real
runtimes are unchanged in the same session — `1h 59m` and `3h 1m` both still render.

Built and tested on a clean checkout of this branch off `dev`:

```
./gradlew :app:compileFullReleaseKotlin :app:testFullReleaseUnitTest
```

Compiles. Adds `HeroMetadataFormatterTest` — 5 tests over `formatHeroRuntime` covering zero (`"0"`, `"0 min"`, `"0h 0m"`), whole hours, hours-and-minutes, missing input, and text it cannot parse as minutes. All pass. The rest of the suite shows the same 14 pre-existing failures as `dev` at `f37e7ee` on this machine, no new ones. (`dev` alone: 1051 tests, 14 failed. This branch: 1056 tests, the same 14.)

## Screenshots / Video

The change is one text segment disappearing from a metadata row; the exact before/after strings are in the table above and in #3295. I have device screenshots of both screens in both states and can attach them if you would like them in the PR.

## Breaking changes

None. `HeroSection.formatRuntime` becomes nullable, but it is `private` and has exactly one
caller in the same file, which already handled a null/blank result. No config, schema or public
API changes.

## Linked issues

Fixes #3295.
