### PR TITLE
fix: drop the MediaSession placeholder item that always threw

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSessionMetadata.kt
@@ -77,15 +77,12 @@ internal fun PlayerRuntimeController.updateMediaSessionMetadata() {
                     .setMediaMetadata(metadata)
                     .build()
                 player.replaceMediaItem(player.currentMediaItemIndex, updated)
-            } else {
-                // No current MediaItem yet (e.g. player just built, source not set).
-                // Set a placeholder MediaItem so the session advertises metadata immediately.
-                val placeholder = androidx.media3.common.MediaItem.Builder()
-                    .apply { mediaId?.let(::setMediaId) }
-                    .setMediaMetadata(metadata)
-                    .build()
-                player.setMediaItem(placeholder)
             }
+            // No current MediaItem yet (e.g. player just built, source not set) means there is
+            // nothing to attach metadata to. Setting a placeholder item was tried here and can
+            // never work: a MediaItem carrying only metadata has no localConfiguration, and
+            // DefaultMediaSourceFactory.createMediaSource requires one, so setMediaItem threw
+            // every time. The metadata is applied on the next call, once the real item exists.
         }
         Log.d(
             PlayerRuntimeController.TAG,


### PR DESCRIPTION
## Summary

Removes the `updateMediaSessionMetadata` fallback that builds a URI-less `MediaItem` and calls `setMediaItem` with it. That branch throws every time it runs and is swallowed as a warning.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When the player has no current `MediaItem`, the function falls back to:

```kotlin
val placeholder = androidx.media3.common.MediaItem.Builder()
    .apply { mediaId?.let(::setMediaId) }
    .setMediaMetadata(metadata)
    .build()
player.setMediaItem(placeholder)
```

A `MediaItem` built that way has no `localConfiguration`, and `DefaultMediaSourceFactory.createMediaSource` opens with `Assertions.checkNotNull(mediaItem.localConfiguration)`. So the call throws every time it is reached:

```
W/PlayerViewModel: Failed to update MediaSession metadata
W/PlayerViewModel: java.lang.NullPointerException: Attempt to invoke virtual method
    'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at androidx.media3.common.util.Assertions.checkNotNull
    at androidx.media3.exoplayer.source.DefaultMediaSourceFactory.createMediaSource
    at androidx.media3.exoplayer.ExoPlayerImpl.createMediaSources
    at androidx.media3.exoplayer.ExoPlayerImpl.setMediaItems
    at androidx.media3.common.BasePlayer.setMediaItems
    at androidx.media3.common.BasePlayer.setMediaItem
```

Nothing is lost by removing it — the metadata is applied on the next call, once a real item exists, which is the path that was already doing the work. What is gained is that a genuine metadata failure is no longer indistinguishable from this one in the log.

## Issue or approval

Related to #3056, where I posted the same finding as a comment.

I want to be careful not to overclaim: I could **not** confirm this is the whole of #3056. On my device the later `replaceMediaItem` populates the session either way, so metadata is not permanently lost here. This PR removes a code path that cannot work as written and the log noise it produces. If you would rather hold it until #3056 is understood end to end, that is completely reasonable — say so and I will close it.

## Reproduction steps

1. Start playback of anything with the internal player.
2. `adb logcat -d | grep -A5 "Failed to update MediaSession metadata"`.

One `NullPointerException` stack per playback, every time.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The behavior change is that a call which always threw no longer runs. Nothing that previously succeeded stops happening.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Deliberately **not** changed:

- The `replaceMediaItem` path, `buildMediaSessionMetadata`, or anything else about what the session advertises.
- No attempt to make the "no current item yet" case advertise metadata early by another route (for example a `MediaItem` with `Uri.EMPTY`). That would be a behavior change beyond the bug, and it is not obviously wanted.
- Nothing touched in the wider #3056 investigation.

## Testing

Fire TV Cube (`AFTGAZL`, Android 9 / Fire OS 7), `armeabi-v7a` release build, starting playback of a movie:

Before — one stack per playback. After:

```
$ adb logcat -d | grep -c "Failed to update MediaSession metadata"
0
$ adb shell dumpsys media_session | grep metadata
metadata:size=10, description=<film title>, <year>, ...
```

Playback, resume position and the session's transport controls all behave as before.

Built and tested on a clean checkout of this branch off `dev`:

```
./gradlew :app:compileFullReleaseKotlin :app:testFullReleaseUnitTest
```

Compiles. Unit tests show the same 14 pre-existing failures as `dev` at `f37e7ee` on this machine, no new ones. (`dev` alone: 1051 tests, 14 failed. This branch: 1051 tests, the same 14.)

## Screenshots / Video

Not a UI change.

## Breaking changes

None. The removed branch threw on every execution, so nothing that previously succeeded stops
happening. No config, schema or public API changes.

## Linked issues

Related to #3056 — see the "Issue or approval" section above for why this is scoped as the dead
code path and the log noise rather than a claimed end-to-end fix for that report.
