### PR TITLE
fix: start a date-only episode release at the viewer's local midnight

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/util/EpisodeReleaseDateParser.kt
+++ b/app/src/main/java/com/nuvio/tv/core/util/EpisodeReleaseDateParser.kt
@@ -6,7 +6,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
-import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 private val ISO_DATE_PATTERN = Regex("(?<!\\d)\\d{4}-\\d{2}-\\d{2}(?!\\d)")
@@ -29,8 +28,9 @@ internal fun parseEpisodeReleaseLocalDate(
 
 /**
  * Returns whether a known release has been reached. Zoned timestamps use their exact instant,
- * while date-only values use UTC midnight. A local timestamp without a zone is interpreted in
- * the viewer's timezone.
+ * while date-only values start at midnight in the viewer's timezone, so a release never counts
+ * as aired while the viewer's calendar still shows the previous day. A local timestamp without
+ * a zone is interpreted in the viewer's timezone too.
  */
 internal fun isEpisodeReleaseAired(
     raw: String?,
@@ -48,8 +48,8 @@ internal fun parseEpisodeReleaseInstant(
 
     return parseExplicitReleaseInstant(value)
         ?: runCatching { LocalDateTime.parse(value).atZone(zoneId).toInstant() }.getOrNull()
-        ?: runCatching { LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant() }.getOrNull()
-        ?: parseEmbeddedReleaseDate(value)?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+        ?: runCatching { LocalDate.parse(value).atStartOfDay(zoneId).toInstant() }.getOrNull()
+        ?: parseEmbeddedReleaseDate(value)?.atStartOfDay(zoneId)?.toInstant()
 }
 
 /**

--- a/app/src/test/java/com/nuvio/tv/core/util/EpisodeReleaseDateParserTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/util/EpisodeReleaseDateParserTest.kt
@@ -96,12 +96,14 @@ class EpisodeReleaseDateParserTest {
     }
 
     @Test
-    fun `date only release starts at utc midnight`() {
-        val beforeMidnight = Clock.fixed(Instant.parse("2026-07-14T23:59:59Z"), eastern)
-        val utcMidnight = Clock.fixed(Instant.parse("2026-07-15T00:00:00Z"), eastern)
+    fun `date only release stays unaired until the viewers local midnight`() {
+        // 2026-07-15T01:00Z is still 2026-07-14 21:00 in Detroit, so an episode dated
+        // 2026-07-15 has not aired for that viewer yet.
+        val previousLocalEvening = Clock.fixed(Instant.parse("2026-07-15T01:00:00Z"), eastern)
+        val localMidnight = Clock.fixed(Instant.parse("2026-07-15T04:00:00Z"), eastern)
 
-        assertFalse(isEpisodeReleaseAired("2026-07-15", beforeMidnight)!!)
-        assertTrue(isEpisodeReleaseAired("2026-07-15", utcMidnight)!!)
+        assertFalse(isEpisodeReleaseAired("2026-07-15", previousLocalEvening)!!)
+        assertTrue(isEpisodeReleaseAired("2026-07-15", localMidnight)!!)
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/core/util/ReleaseInfoUtilsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/util/ReleaseInfoUtilsTest.kt
@@ -34,20 +34,22 @@ class ReleaseInfoUtilsTest {
     }
 
     @Test
-    fun `catalog date only release starts at utc midnight`() {
+    fun `catalog date only release starts at the viewers local midnight`() {
         val item = preview(released = "2026-07-15")
         val today = LocalDate.of(2026, 7, 14)
 
+        // 2026-07-15T01:00Z is still the evening of 2026-07-14 in Detroit, so the title
+        // must not surface while the viewer's calendar shows the previous day.
         assertTrue(
             item.isUnreleased(
                 today = today,
-                clock = Clock.fixed(Instant.parse("2026-07-14T23:59:59Z"), eastern)
+                clock = Clock.fixed(Instant.parse("2026-07-15T01:00:00Z"), eastern)
             )
         )
         assertFalse(
             item.isUnreleased(
                 today = today,
-                clock = Clock.fixed(Instant.parse("2026-07-15T00:00:00Z"), eastern)
+                clock = Clock.fixed(Instant.parse("2026-07-15T04:00:00Z"), eastern)
             )
         )
     }


### PR DESCRIPTION
## Summary

`EpisodeReleaseDateParser` reads the same value two different ways. `parseEpisodeReleaseLocalDate` treats a plain `"2026-07-15"` as a calendar date and returns it unchanged — its own comment says plain dates "are preserved as supplied by the provider". `parseEpisodeReleaseInstant` anchors that same string at UTC midnight:

```kotlin
LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant()
```

This PR resolves a date-only value in the viewer's zone instead, so the two entry points agree by construction: the date the app displays is the date on which the title becomes available. Timestamps that carry a zone or an offset are untouched — they keep using their exact instant.

One production file, two lines:

```diff
-        ?: runCatching { LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant() }.getOrNull()
-        ?: parseEmbeddedReleaseDate(value)?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+        ?: runCatching { LocalDate.parse(value).atStartOfDay(zoneId).toInstant() }.getOrNull()
+        ?: parseEmbeddedReleaseDate(value)?.atStartOfDay(zoneId)?.toInstant()
```

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

West of UTC the two readings disagree by a day. In UTC-3, `"2026-07-15"` is an instant that has already passed at 21:00 on 2026-07-14, so `isEpisodeReleaseAired` reports the episode as aired while the viewer's calendar still reads the 14th. Episodes surface as released a day early, which is what #3236 reports.

Every release gate goes through `isEpisodeReleaseAired`, so the day is wrong in several places at once: `MetaPreview.isUnreleased` and `CatalogRow.filterReleasedItems` (hiding unreleased catalog items), `Meta.isFutureRelease`, the Continue Watching and next-up rules in `HomeViewModelContinueWatching`, and `PlayerNextEpisodeRules.hasEpisodeAired`.

`AirDateUtils` contains the contradiction on its own. It computes `daysUntil` from `LocalDate.now()`, which is local, but suppresses the badge with `isEpisodeReleaseAired`, which is not. On the evening of the 14th its own date math says "Airs Tomorrow" while the guard above it has already decided the episode is out, so no badge is drawn at all.

The repository's own tests already expect the local reading. `ContinueWatchingAiringRulesTest` asserts `tomorrow.atStartOfDay(ZoneId.systemDefault())`, which only matches an implementation anchored to the viewer's zone, so that test passes on a UTC runner and fails everywhere else. That file is not touched by this PR — it starts passing because the implementation now matches what it always asserted.

## Issue or approval

Fixes #3236 — "Episodes appear as released a day early due to missing timezone offset".

## Reproduction steps

1. Set the device timezone to any zone west of UTC (reproduced on UTC-3; the report is from a viewer seeing the same effect).
2. Pick a currently-airing series whose next episode carries a date-only release value, for example `2026-07-15`, supplied by the metadata addon or by TMDB air dates.
3. On the evening of 2026-07-14 local time, that is any moment after 00:00 UTC on the 15th, open Home.
4. The episode is already treated as released: it moves into Continue Watching, `isUnreleased` stops hiding it in catalog rows, and the "Airs Tomorrow" badge is suppressed, a full day before the viewer's calendar reaches the air date.

The same thing is reproducible without a device, on `dev` unmodified, on any machine whose default zone is not UTC:

```
$ ./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.home.ContinueWatchingAiringRulesTest"

ContinueWatchingAiringRulesTest > earliestUpcomingEpisodeMs uses next mid-season air time
    not only next season FAILED
10 tests completed, 1 failed
```

With this change the same run is green.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the date-only branch of `parseEpisodeReleaseInstant` changes. Values that carry a zone or an offset keep resolving to their exact instant, and `parseEpisodeReleaseLocalDate` is not modified at all — the fix makes the instant reading match the local-date reading that function already had.

No call site is touched, no UI is touched, and no other timezone handling in the app is changed. `ContinueWatchingAiringRulesTest` is deliberately left as it is on `dev`, so its pass/fail is independent evidence rather than something this PR adjusted. No formatting, renames, or drive-by cleanups are included; the only incidental edit is dropping the now-unused `ZoneOffset` import.

## Testing

Full unit suite on this branch: `1275 tests completed, 0 failed, 1 skipped` (`./gradlew :app:testFullDebugUnitTest`), run on a machine in UTC-3.

Before/after on `dev` for the untouched `ContinueWatchingAiringRulesTest`: fails on `dev` in UTC-3 with `earliestUpcomingEpisodeMs uses next mid-season air time not only next season`, green with this change applied.

Updated the two tests that pinned the UTC reading (`EpisodeReleaseDateParserTest`, `ReleaseInfoUtilsTest`) and added coverage for the boundary the report is about: an episode dated `2026-07-15` is not aired at `2026-07-15T01:00Z` for a viewer in `America/Detroit`, and is aired at `2026-07-15T04:00Z`, that viewer's local midnight. Both tests were watched failing against the unfixed parser before the change was made.

## Screenshots / Video

Not a UI change. The effect is which day a title counts as released; there is no visual change to any screen.

## Breaking changes

None. No config, schema, or public API changes. Stored watch progress and release values are unaffected; only the instant a date-only release resolves to changes, and only for viewers outside UTC.

## Linked issues

Fixes #3236
