### PR TITLE
fix(trailer): stop a cancelled lookup being cached as "no trailer"

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/trailer/TrailerService.kt
@@ -110,6 +110,13 @@ class TrailerService(
                 cache[cacheKey] = NEGATIVE_CACHE
             }
             null
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // The detail screen cancels the previous trailer job every time it starts a new
+            // one, so this is routine. Swallowing it returned null, which the caller cannot
+            // tell apart from "this title has no trailer" -- it wrote that null over a URL a
+            // later job had already resolved, and the NEGATIVE_CACHE line above pinned the
+            // miss for the rest of the process, so the trailer button stayed gone.
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error fetching trailer for $title: ${e.message}", e)
             null
@@ -326,6 +333,8 @@ class TrailerService(
             } else {
                 response.body()?.results.orEmpty()
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "TMDB movie videos error ($tmdbId/$language): ${e.message}")
             emptyList()
@@ -345,6 +354,8 @@ class TrailerService(
             } else {
                 response.body()?.results.orEmpty()
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "TMDB tv videos error ($tmdbId/$language): ${e.message}")
             emptyList()

--- a/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCancellationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/trailer/TrailerServiceCancellationTest.kt
@@ -1,0 +1,138 @@
+package com.nuvio.tv.data.trailer
+
+import android.util.Log
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.data.local.TmdbSettingsDataStore
+import com.nuvio.tv.data.remote.api.TmdbApi
+import com.nuvio.tv.data.remote.api.TmdbVideoResult
+import com.nuvio.tv.data.remote.api.TmdbVideosResponse
+import com.nuvio.tv.data.remote.api.TrailerApi
+import com.nuvio.tv.domain.model.TmdbSettings
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+/**
+ * The detail screen cancels the in-flight trailer job every time it starts a new one
+ * (MetaDetailsViewModel.fetchTrailerUrl), so a cancelled TMDB lookup is routine, not
+ * exceptional. It must not be reported as "this title has no trailer".
+ */
+class TrailerServiceCancellationTest {
+
+    private val tmdbId = 123
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `a cancelled TMDB lookup propagates instead of reporting no trailer`() = runTest {
+        val harness = newService()
+        coEvery { harness.tmdbApi.getMovieVideos(any(), any(), any()) } throws
+            CancellationException("job cancelled")
+
+        val thrown = runCatching { harness.lookup() }.exceptionOrNull()
+
+        assertTrue(
+            "A cancelled lookup must surface as CancellationException, not a null trailer, " +
+                "but was: $thrown",
+            thrown is CancellationException
+        )
+    }
+
+    @Test
+    fun `a cancelled lookup does not hide the trailer from the next attempt`() = runTest {
+        val harness = newService()
+
+        coEvery { harness.tmdbApi.getMovieVideos(any(), any(), any()) } throws
+            CancellationException("job cancelled")
+        runCatching { harness.lookup() }
+
+        // TMDB answers normally now, exactly as it would on the user's next visit.
+        coEvery { harness.tmdbApi.getMovieVideos(any(), any(), any()) } returns Response.success(
+            TmdbVideosResponse(
+                id = tmdbId,
+                results = listOf(
+                    TmdbVideoResult(
+                        iso6391 = "en",
+                        name = "Official Trailer",
+                        key = "abcdefghijk",
+                        site = "YouTube",
+                        type = "Trailer",
+                        official = true
+                    )
+                )
+            )
+        )
+        coEvery { harness.extractor.extractPlaybackSource(any()) } returns
+            TrailerPlaybackSource(videoUrl = "https://example.test/trailer.mp4")
+
+        val result = harness.lookup()
+
+        assertNotNull(
+            "The earlier cancellation must not be cached as 'no trailer' for this title",
+            result
+        )
+        assertEquals("https://example.test/trailer.mp4", result?.videoUrl)
+    }
+
+    private class Harness(
+        val target: TrailerService,
+        val tmdbApi: TmdbApi,
+        val extractor: InAppYouTubeExtractor
+    ) {
+        suspend fun lookup(): TrailerPlaybackSource? = target.getTrailerPlaybackSource(
+            title = "Some Movie",
+            year = "2024",
+            tmdbId = "123",
+            type = "movie"
+        )
+    }
+
+    private fun newService(): Harness {
+        val trailerApi = mockk<TrailerApi>(relaxed = true)
+        val tmdbApi = mockk<TmdbApi>(relaxed = true)
+        val extractor = mockk<InAppYouTubeExtractor>(relaxed = true)
+        val tmdbSettingsDataStore = mockk<TmdbSettingsDataStore> {
+            every { settings } returns MutableStateFlow(
+                TmdbSettings(language = "en", useTrailers = true)
+            )
+        }
+        val tmdbService = mockk<TmdbService> {
+            every { apiKey() } returns "tmdb-key"
+        }
+        return Harness(
+            target = TrailerService(
+                trailerApi = trailerApi,
+                tmdbApi = tmdbApi,
+                inAppYouTubeExtractor = extractor,
+                tmdbSettingsDataStore = tmdbSettingsDataStore,
+                tmdbService = tmdbService
+            ),
+            tmdbApi = tmdbApi,
+            extractor = extractor
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Three `catch (e: Exception)` blocks in `TrailerService` also catch `CancellationException`, turning a cancelled coroutine into a normal-looking "nothing found" answer. They now rethrow it first, matching `getTrailerPlaybackSourceFromYouTubeUrl`, which already does this in the same file.

```diff
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
```

Applied to `getTrailerPlaybackSource`, `fetchTmdbMovieVideosOnce` and `fetchTmdbTvVideosOnce`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`MetaDetailsViewModel.fetchTrailerUrl` calls `trailerFetchJob?.cancel()` and relaunches every time it runs, so a cancelled trailer lookup is routine, not exceptional.

`fetchTmdbMovieVideosOnce` and `fetchTmdbTvVideosOnce` return `emptyList()` from their catch, so a cancelled TMDB call is indistinguishable from "TMDB lists no videos for this title". `getTrailerPlaybackSourceFromTmdbId` then finds no candidates and returns null, and `getTrailerPlaybackSource` reaches:

```kotlin
if (tmdbId != null) {
    cache[cacheKey] = NEGATIVE_CACHE
}
```

`cache` is a plain `ConcurrentHashMap` with no eviction, so that entry is permanent for the process. Every later lookup for the same `"title|year|tmdbId|type"` key short-circuits to null, and the trailer button never returns for that title until the app is restarted. That is why the symptom is sticky per title rather than flickering, and why it looks like the title simply has no trailer.

`getTrailerPlaybackSource` has the same swallow in its own catch, with a second effect: the cancelled coroutine returns instead of unwinding, so the caller's `_uiState.update { ... trailerUrl = url ... }` still runs and can write null over a URL the replacing job already resolved.

## Issue or approval

Fixes #3298 — the trailer button staying hidden for a title after a cancelled lookup is cached as a definitive miss.

## Reproduction steps

1. Open a details page for a movie whose TMDB entry does have a trailer.
2. Leave before the trailer lookup finishes, or scroll a hero/expanded row quickly so several lookups start and are cancelled in turn.
3. Return to that same title's details page and let it settle. The trailer button is absent.
4. It stays absent on every later visit to that title, because the negative cache entry is never evicted.
5. Force-stop and reopen the app, then open the same title without interrupting the lookup — the button is there.

Observed on a Fire TV Cube (AFTGAZL, Android 9), 45 such lines in one session, titles and ids redacted:

```
E TrailerService: Error fetching trailer for <title>: StandaloneCoroutine was cancelled
W TrailerService: TMDB movie videos error (<tmdbId>/en-US): StandaloneCoroutine was cancelled
```

The `W` line is the one that becomes a poisoned cache entry, since that path returns `emptyList()` and lets `NEGATIVE_CACHE` be written.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

No UI code is touched. The trailer button visibility is already driven by whether a trailer URL resolves; this only stops a cancelled lookup from being recorded as a permanent miss.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the three catch blocks change; the eleven added lines are entirely catch, throw and comment. No call site, no caching policy and no UI is touched, and `NEGATIVE_CACHE` is deliberately kept — after this change it means what it was intended to mean, that TMDB answered and had nothing.

Nothing here addresses trailer resolution or stream selection: that is #3127, and its open PR #3128 covers that area. This PR stays out of `InAppYouTubeExtractor` entirely so the two do not overlap.

I also did not add eviction or a TTL to `cache`. That would be a broader design change, and with cancellation no longer poisoning it there is no longer a known way to get a wrong permanent entry.

## Testing

`./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.data.trailer.*"` on this branch, built on dev @ 64c1f5e0: green.

Adds `TrailerServiceCancellationTest` covering both halves of the fault, each watched failing against the unfixed code first:

- `a cancelled TMDB lookup propagates instead of reporting no trailer` — before the fix this returned null instead of throwing.
- `a cancelled lookup does not hide the trailer from the next attempt` — before the fix the second lookup still returned null, because the first, cancelled one had already written `NEGATIVE_CACHE`. This is the user-visible half.

## Screenshots / Video

Not a UI change. The observable difference is that the trailer button stops disappearing permanently for a title after an interrupted lookup; there is no visual change to any screen.

## Breaking changes

None. No config, schema or public API changes. The only behavioral difference is that a cancelled lookup now unwinds instead of being recorded as a result.

## Linked issues

Fixes #3298
