### PR TITLE
Fix addon manifest failures and refresh lifecycle

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -96,28 +96,64 @@ class AddonRepositoryImpl @Inject constructor(
     private val manifestCacheLock = Any()
     private val manifestCacheRevision = MutableStateFlow(0L)
     @Volatile
-    private var lastManifestRefreshTime = 0L
+    private var lastManifestRefreshAttemptTime = 0L
     private var manifestRefreshJob: Job? = null
+    private val manifestRefreshLock = Any()
 
     init {
         syncScope.launch { loadManifestCacheFromDisk() }
     }
 
     private fun isCacheStale(): Boolean =
-        System.currentTimeMillis() - lastManifestRefreshTime > MANIFEST_CACHE_TTL_MS
+        System.currentTimeMillis() - lastManifestRefreshAttemptTime > MANIFEST_CACHE_TTL_MS
 
+    /**
+     * Scheduling is serialised so that the staleness check, the timestamp and the job assignment
+     * happen as one step. Without the lock two recomputations can each observe a stale clock and
+     * an inactive job before either launched coroutine runs, and both sweep - the timestamp alone
+     * cannot prevent that, because it is written on the dispatcher rather than at the call site.
+     *
+     * The attempt is recorded here rather than after the fetches complete, so the record does not
+     * depend on the sweep finishing or on fetchAddon staying exception-free. The cost is that a
+     * cancelled sweep still counts as an attempt; nothing cancels this job or syncScope today, so
+     * that only arises at process death, where the field dies with the process anyway.
+     *
+     * The policy this encodes is a minimum interval between refresh *starts*, not a guarantee of
+     * freshness for a period after one completes. A sweep that outlived the TTL would therefore be
+     * eligible to run again as soon as it finished. Do not "fix" that by moving the assignment to
+     * completion: on an all-failed sweep that reinstates the bug this exists to prevent.
+     */
     private fun scheduleManifestRefresh(urls: List<String>) {
-        if (manifestRefreshJob?.isActive == true) return
-        manifestRefreshJob = syncScope.launch {
-            val refreshed = urls.map { url ->
-                async {
-                    fetchAddon(url)
+        if (urls.isEmpty()) {
+            // Nothing to attempt, so nothing is recorded - otherwise enabling an addon straight
+            // afterwards inherits a full TTL window it never had.
+            Log.d(TAG, "Background manifest refresh skipped: no enabled addons")
+            return
+        }
+        synchronized(manifestRefreshLock) {
+            if (manifestRefreshJob?.isActive == true) return
+            // Re-checked under the lock: the caller tested this before we got here.
+            if (!isCacheStale()) return
+            lastManifestRefreshAttemptTime = System.currentTimeMillis()
+            manifestRefreshJob = syncScope.launch {
+                val refreshed = urls.map { url ->
+                    async {
+                        fetchAddon(url)
+                    }
+                }.awaitAll()
+                // isCacheStale() is re-evaluated every time installedAddonsFlow's combine emits -
+                // on any addon add, remove, rename, enable or disable, and on any manifest cache
+                // mutation - so leaving the clock unset after a failed sweep makes each of those
+                // schedule another full fetch of every addon, indefinitely, while offline or
+                // while an addon is down. Manifests that are missing entirely are recovered by
+                // the cache-miss path above, which does not consult this clock, so waiting out
+                // the TTL here only delays refreshing manifests that are already cached and
+                // usable.
+                if (refreshed.any { it is NetworkResult.Success }) {
+                    Log.d(TAG, "Background manifest refresh completed")
+                } else {
+                    Log.w(TAG, "Background manifest refresh failed for all ${urls.size} addon(s)")
                 }
-            }.awaitAll()
-            val anyUpdated = refreshed.any { it is NetworkResult.Success }
-            if (anyUpdated) {
-                lastManifestRefreshTime = System.currentTimeMillis()
-                Log.d(TAG, "Background manifest refresh completed")
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import com.nuvio.tv.core.auth.AuthManager
@@ -463,7 +464,10 @@ class AddonRepositoryImpl @Inject constructor(
         }
 
     private fun bumpManifestCacheRevision() {
-        manifestCacheRevision.value = manifestCacheRevision.value + 1
+        // scheduleManifestRefresh fetches every addon in parallel and each success can call
+        // this through putCachedManifestIfChanged, so a plain read-modify-write can lose an
+        // increment and with it one re-emission of installedAddonsFlow.
+        manifestCacheRevision.update { it + 1 }
     }
 
     private fun hasManifestChanged(existing: Addon, incoming: Addon): Boolean =

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.nuvio.tv.data.remote.api.AddonApi
 import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.repository.AddonRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -43,13 +44,38 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * get its own instance, with its own manifest cache, refresh clock and stateIn collector.
  */
 @Singleton
-class AddonRepositoryImpl @Inject constructor(
+class AddonRepositoryImpl(
     private val api: AddonApi,
     private val preferences: AddonPreferences,
     private val addonSyncService: AddonSyncService,
     private val authManager: AuthManager,
-    @ApplicationContext private val context: Context
+    private val context: Context,
+    /**
+     * The dispatcher backing syncScope, the manifest cache disk IO and installedAddonsFlow.
+     * Injectable so tests can drive the flow and the background sweep on a test dispatcher
+     * instead of racing real IO threads; production always gets Dispatchers.IO.
+     */
+    private val dispatcher: CoroutineDispatcher,
+    /** Source of the refresh clock, injectable so the TTL policy can be tested without waiting. */
+    private val clock: () -> Long
 ) : AddonRepository {
+
+    @Inject
+    constructor(
+        api: AddonApi,
+        preferences: AddonPreferences,
+        addonSyncService: AddonSyncService,
+        authManager: AuthManager,
+        @ApplicationContext context: Context
+    ) : this(
+        api = api,
+        preferences = preferences,
+        addonSyncService = addonSyncService,
+        authManager = authManager,
+        context = context,
+        dispatcher = Dispatchers.IO,
+        clock = System::currentTimeMillis
+    )
 
     companion object {
         private const val TAG = "AddonRepository"
@@ -60,7 +86,7 @@ class AddonRepositoryImpl @Inject constructor(
         private const val MANIFEST_CACHE_TTL_MS = 6 * 60 * 60 * 1000L 
     }
 
-    private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val syncScope = CoroutineScope(SupervisorJob() + dispatcher)
     private var syncJob: Job? = null
     var isSyncingFromRemote = false
 
@@ -113,7 +139,7 @@ class AddonRepositoryImpl @Inject constructor(
     }
 
     private fun isCacheStale(): Boolean =
-        System.currentTimeMillis() - lastManifestRefreshAttemptTime > MANIFEST_CACHE_TTL_MS
+        clock() - lastManifestRefreshAttemptTime > MANIFEST_CACHE_TTL_MS
 
     /**
      * Scheduling is serialised so that the staleness check, the timestamp and the job assignment
@@ -142,7 +168,7 @@ class AddonRepositoryImpl @Inject constructor(
             if (manifestRefreshJob?.isActive == true) return
             // Re-checked under the lock: the caller tested this before we got here.
             if (!isCacheStale()) return
-            lastManifestRefreshAttemptTime = System.currentTimeMillis()
+            lastManifestRefreshAttemptTime = clock()
             manifestRefreshJob = syncScope.launch {
                 val refreshed = urls.map { url ->
                     async {
@@ -166,7 +192,7 @@ class AddonRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun loadManifestCacheFromDisk() = kotlinx.coroutines.withContext(Dispatchers.IO) {
+    private suspend fun loadManifestCacheFromDisk() = kotlinx.coroutines.withContext(dispatcher) {
         try {
             val prefs = context.getSharedPreferences(MANIFEST_CACHE_PREFS, Context.MODE_PRIVATE)
             if (prefs.contains(LEGACY_MANIFEST_CACHE_KEY)) {
@@ -263,7 +289,7 @@ class AddonRepositoryImpl @Inject constructor(
                         urls.filter { url -> enabledByUrl[canonicalizeUrl(url)] ?: true }
                     )
                 }
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(dispatcher)
         }
         .stateIn(syncScope, SharingStarted.Eagerly, emptyList<Addon>())
 

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -195,12 +195,20 @@ class AddonRepositoryImpl @Inject constructor(
                                         ?.copy(enabled = false)
                                         ?: placeholderAddon(canonical, userNames, enabled = false)
                                 }
+                                // On failure fall back to a placeholder rather than null. Returning
+                                // null drops the addon from the emitted list entirely, so an installed
+                                // URL whose manifest has never been fetched successfully becomes
+                                // invisible in the addon manager - and unremovable, because removal is
+                                // driven by the listed row. The disabled branch above already does this.
+                                // A placeholder carries no resources or catalogs, so it is not queried
+                                // for streams and contributes no catalog rows until a real manifest
+                                // arrives.
                                 (getCachedManifest(canonical) ?: when (val result = fetchAddon(url)) {
                                     is NetworkResult.Success -> result.data
-                                    else -> null
-                                })?.copy(enabled = enabled)
+                                    else -> placeholderAddon(canonical, userNames, enabled)
+                                }).copy(enabled = enabled)
                             }
-                        }.awaitAll().filterNotNull()
+                        }.awaitAll()
                     }
 
                     if (fresh != cached) {

--- a/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/AddonRepositoryImpl.kt
@@ -34,8 +34,15 @@ import kotlinx.coroutines.launch
 import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.sync.AddonSyncService
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+/**
+ * Scoped @Singleton on the class, not only on the @Binds in RepositoryModule. The binding scopes
+ * the AddonRepository *interface*; anything injecting AddonRepositoryImpl directly would otherwise
+ * get its own instance, with its own manifest cache, refresh clock and stateIn collector.
+ */
+@Singleton
 class AddonRepositoryImpl @Inject constructor(
     private val api: AddonApi,
     private val preferences: AddonPreferences,

--- a/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/StreamRepositoryImpl.kt
@@ -190,7 +190,7 @@ class StreamRepositoryImpl @Inject constructor(
                 streamAddons.forEach { addon ->
                     launch {
                         try {
-                            val streamsResult = getStreamsFromAddon(addon.baseUrl, type, videoId)
+                            val streamsResult = getStreamsFromAddon(addon, type, videoId)
                             when (streamsResult) {
                                 is NetworkResult.Success -> {
                                     if (streamsResult.data.isNotEmpty()) {
@@ -561,11 +561,11 @@ class StreamRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getStreamsFromAddon(
-        baseUrl: String,
+        addon: Addon,
         type: String,
         videoId: String
     ): NetworkResult<List<Stream>> {
-        val cleanBaseUrl = baseUrl.trimEnd('/')
+        val cleanBaseUrl = addon.baseUrl.trimEnd('/')
         val queryStart = cleanBaseUrl.indexOf('?')
         val basePath = if (queryStart >= 0) cleanBaseUrl.substring(0, queryStart).trimEnd('/') else cleanBaseUrl
         val baseQuery = if (queryStart >= 0) cleanBaseUrl.substring(queryStart) else ""
@@ -574,16 +574,12 @@ class StreamRepositoryImpl @Inject constructor(
         val streamUrl = "$basePath/stream/$encodedType/$encodedVideoId.json$baseQuery"
         Log.d(TAG, "Fetching streams type=$type videoId=$videoId url=$streamUrl")
 
-        // First, get addon info for name and logo
-        val addonResult = addonRepository.fetchAddon(baseUrl)
-        val addonName = when (addonResult) {
-            is NetworkResult.Success -> addonResult.data.displayName
-            else -> context.getString(com.nuvio.tv.R.string.stream_addon_unknown)
-        }
-        val addonLogo = when (addonResult) {
-            is NetworkResult.Success -> addonResult.data.logo
-            else -> null
-        }
+        // Display info comes from the installed addon the caller already holds. Calling
+        // addonRepository.fetchAddon() here caused an unconditional manifest GET ahead of every
+        // queried addon's stream request: fetchAddon is the low-level fetch that does not consult
+        // the cache, so this sidestepped the manifest-cache policy in AddonRepositoryImpl.
+        val addonName = addon.displayName
+        val addonLogo = addon.logo
 
         return when (val result = safeApiCall(context) { api.getStreams(streamUrl) }) {
             is NetworkResult.Success -> {

--- a/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/StreamRepository.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.domain.repository
 
 import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.Addon
 import com.nuvio.tv.domain.model.AddonStreams
 import com.nuvio.tv.domain.model.Stream
 import kotlinx.coroutines.flow.Flow
@@ -26,14 +27,18 @@ interface StreamRepository {
     ): Flow<NetworkResult<List<AddonStreams>>>
 
     /**
-     * Fetches streams from a specific addon
-     * @param baseUrl The addon base URL
+     * Fetches streams from a specific addon.
+     *
+     * Takes the installed [Addon] rather than a bare base URL so the display name and logo
+     * stamped onto the returned streams come from the manifest already held in memory.
+     *
+     * @param addon The installed addon to query
      * @param type The content type
      * @param videoId The video ID
      * @return NetworkResult containing list of streams
      */
     suspend fun getStreamsFromAddon(
-        baseUrl: String,
+        addon: Addon,
         type: String,
         videoId: String
     ): NetworkResult<List<Stream>>

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
@@ -1,0 +1,200 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.core.auth.AuthManager
+import com.nuvio.tv.core.sync.AddonSyncService
+import com.nuvio.tv.data.local.AddonPreferences
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.AddonManifestDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * An installed addon whose manifest cannot be fetched must still be emitted, so it stays visible
+ * in the addon manager and can be removed. Before the placeholder fallback it resolved to null and
+ * was dropped by filterNotNull(), leaving the URL installed but unreachable from the UI.
+ *
+ * Uses runBlocking rather than runTest: AddonRepositoryImpl publishes installedAddonsFlow through
+ * stateIn() on a scope hardcoded to Dispatchers.IO, so virtual time would not advance it. The
+ * withTimeout() calls are therefore scheduling-dependent rather than deterministic.
+ *
+ * Each repository built here leaks its stateIn collector: syncScope is a SupervisorJob the class
+ * never cancels, and there is no close/dispose. Harmless for a handful of instances in a unit-test
+ * JVM, but a reason not to grow this file much further without making the scope injectable.
+ */
+class AddonManifestPlaceholderTest {
+
+    private val addonUrl = "https://addon.example"
+
+    private companion object {
+        const val REAL_NAME = "Test Addon"
+        const val REAL_VERSION = "1.0.0"
+        /** A placeholder carries no version; a resolved manifest does. */
+        const val PLACEHOLDER_VERSION = ""
+    }
+
+    @Test
+    fun `unreachable addon is emitted as a placeholder`() = runBlocking {
+        val harness = newRepository()
+
+        val addons = withTimeout(5_000) {
+            harness.repository.getInstalledAddons().first { it.isNotEmpty() }
+        }
+
+        assertEquals(1, addons.size)
+        val addon = addons.single()
+        assertEquals(addonUrl, addon.baseUrl)
+        assertTrue(addon.enabled)
+        // placeholderAddon derives a name from the URL's last path segment, which is what the
+        // addon manager renders until a real manifest arrives.
+        assertEquals("addon.example", addon.displayName)
+        assertEquals(null, addon.logo)
+    }
+
+    @Test
+    fun `placeholder can be removed`() = runBlocking {
+        val harness = newRepository()
+
+        val addon = withTimeout(5_000) {
+            harness.repository.getInstalledAddons().first { it.isNotEmpty() }
+        }.single()
+
+        // The addon manager drives removal from the emitted row's baseUrl, so this is the
+        // property the placeholder exists to preserve: before the fix there was no row to
+        // remove from.
+        harness.repository.removeAddon(addon.baseUrl)
+
+        coVerify(exactly = 1) { harness.preferences.removeAddon(addonUrl) }
+    }
+
+    /**
+     * A failed manifest fetch is retried whenever the flow recomputes, because the placeholder is
+     * never written to the cache, so the addon stays a cache miss. That is deliberate, and the TTL fix in the sibling commit does not
+     * throttle it: an addon added while offline must be able to recover without waiting out a
+     * six-hour window that only governs manifests already cached. Pinned so it is not mistaken
+     * for a retry storm and optimised away.
+     */
+    @Test
+    fun `failed manifest fetch is retried when the flow recomputes`() = runBlocking {
+        val userSetNames = MutableStateFlow<Map<String, String>>(emptyMap())
+        val harness = newRepository(userSetNames = userSetNames)
+
+        withTimeout(5_000) {
+            harness.repository.getInstalledAddons().first { it.isNotEmpty() }
+        }
+        val before = harness.manifestCalls.get()
+        assertTrue(before >= 1)
+
+        // Renaming the addon recomputes installedAddonsFlow. Comparing the call count across the
+        // mutation ties the extra fetch to the recomputation, rather than merely asserting that
+        // two fetches happened at some point.
+        userSetNames.value = mapOf(addonUrl to "Renamed")
+        withTimeout(5_000) {
+            harness.repository.getInstalledAddons()
+                .first { list -> list.singleOrNull()?.displayName == "Renamed" }
+        }
+
+        assertTrue(harness.manifestCalls.get() > before)
+    }
+
+    @Test
+    fun `placeholder carries no resources or catalogs`() = runBlocking {
+        val harness = newRepository()
+
+        val addon = withTimeout(5_000) {
+            harness.repository.getInstalledAddons().first { it.isNotEmpty() }
+        }.single()
+
+        // The placeholder has no resources and no catalogs, which supplies the inputs
+        // StreamRepositoryImpl uses to exclude it from stream and catalog processing -
+        // supportsStreamResource() reads resources, and catalog rows are built from catalogs.
+        // That predicate is private to StreamRepositoryImpl, so this asserts its inputs rather
+        // than the exclusion itself.
+        assertTrue(addon.resources.isEmpty())
+        assertTrue(addon.catalogs.isEmpty())
+    }
+
+    /**
+     * The placeholder must be a temporary stand-in, not a sticky one: once the manifest becomes
+     * reachable, the real addon has to replace it. The placeholder is never written to the cache,
+     * so the next recomputation refetches and the resolved manifest wins.
+     */
+    @Test
+    fun `placeholder is replaced once the manifest becomes available`() = runBlocking {
+        val userSetNames = MutableStateFlow<Map<String, String>>(emptyMap())
+        val harness = newRepository(userSetNames = userSetNames)
+
+        val placeholder = withTimeout(5_000) {
+            harness.repository.getInstalledAddons().first { it.isNotEmpty() }
+        }.single()
+        assertEquals(PLACEHOLDER_VERSION, placeholder.version)
+
+        harness.reachable.set(true)
+        // Names a different key, so the recomputation is triggered without renaming this addon.
+        userSetNames.value = mapOf("https://other.example" to "Other")
+
+        val resolved = withTimeout(5_000) {
+            harness.repository.getInstalledAddons()
+                .first { list -> list.singleOrNull()?.version == REAL_VERSION }
+        }.single()
+        assertEquals(REAL_NAME, resolved.name)
+        assertEquals(addonUrl, resolved.baseUrl)
+    }
+
+    private data class Harness(
+        val repository: AddonRepositoryImpl,
+        val preferences: AddonPreferences,
+        val manifestCalls: AtomicInteger,
+        val reachable: AtomicBoolean
+    )
+
+    private fun newRepository(
+        userSetNames: kotlinx.coroutines.flow.Flow<Map<String, String>> = flowOf(emptyMap()),
+        reachable: Boolean = false
+    ): Harness {
+        val manifestCalls = AtomicInteger()
+        val isReachable = AtomicBoolean(reachable)
+        val api = mockk<AddonApi>()
+        coEvery { api.getManifest(any()) } coAnswers {
+            manifestCalls.incrementAndGet()
+            if (!isReachable.get()) throw IOException("offline")
+            Response.success(
+                AddonManifestDto(id = "test-addon", name = REAL_NAME, version = REAL_VERSION)
+            )
+        }
+
+        val preferences = mockk<AddonPreferences>()
+        every { preferences.installedAddonUrls } returns flowOf(listOf(addonUrl))
+        every { preferences.userSetNames } returns userSetNames
+        every { preferences.addonEnabledStates } returns flowOf(emptyMap())
+        coEvery { preferences.removeAddon(any()) } returns true
+
+        return Harness(
+            repository = AddonRepositoryImpl(
+                api = api,
+                preferences = preferences,
+                addonSyncService = mockk<AddonSyncService>(relaxed = true),
+                authManager = mockk<AuthManager>(relaxed = true),
+                context = mockk<Context>(relaxed = true)
+            ),
+            preferences = preferences,
+            manifestCalls = manifestCalls,
+            reachable = isReachable
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
@@ -156,6 +156,8 @@ class AddonManifestPlaceholderTest {
         assertEquals(addonUrl, resolved.baseUrl)
     }
 
+    private fun newContext(): Context = mockk(relaxed = true)
+
     private data class Harness(
         val repository: AddonRepositoryImpl,
         val preferences: AddonPreferences,
@@ -190,7 +192,7 @@ class AddonManifestPlaceholderTest {
                 preferences = preferences,
                 addonSyncService = mockk<AddonSyncService>(relaxed = true),
                 authManager = mockk<AuthManager>(relaxed = true),
-                context = mockk<Context>(relaxed = true)
+                context = newContext()
             ),
             preferences = preferences,
             manifestCalls = manifestCalls,

--- a/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/AddonManifestPlaceholderTest.kt
@@ -10,12 +10,16 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,19 +27,20 @@ import retrofit2.Response
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * An installed addon whose manifest cannot be fetched must still be emitted, so it stays visible
  * in the addon manager and can be removed. Before the placeholder fallback it resolved to null and
  * was dropped by filterNotNull(), leaving the URL installed but unreachable from the UI.
  *
- * Uses runBlocking rather than runTest: AddonRepositoryImpl publishes installedAddonsFlow through
- * stateIn() on a scope hardcoded to Dispatchers.IO, so virtual time would not advance it. The
- * withTimeout() calls are therefore scheduling-dependent rather than deterministic.
+ * The placeholder tests use runBlocking and Dispatchers.IO, matching production scheduling. The
+ * refresh-clock test injects a test dispatcher and a settable clock instead, so the TTL policy is
+ * asserted without waiting on real time or real IO threads.
  *
  * Each repository built here leaks its stateIn collector: syncScope is a SupervisorJob the class
  * never cancels, and there is no close/dispose. Harmless for a handful of instances in a unit-test
- * JVM, but a reason not to grow this file much further without making the scope injectable.
+ * JVM.
  */
 class AddonManifestPlaceholderTest {
 
@@ -46,6 +51,8 @@ class AddonManifestPlaceholderTest {
         const val REAL_VERSION = "1.0.0"
         /** A placeholder carries no version; a resolved manifest does. */
         const val PLACEHOLDER_VERSION = ""
+        /** Mirrors AddonRepositoryImpl.MANIFEST_CACHE_TTL_MS, which is private. */
+        const val MANIFEST_CACHE_TTL_MS = 6 * 60 * 60 * 1000L
     }
 
     @Test
@@ -156,6 +163,68 @@ class AddonManifestPlaceholderTest {
         assertEquals(addonUrl, resolved.baseUrl)
     }
 
+    /**
+     * The bug: the refresh timestamp was only advanced when a fetch succeeded, so a sweep that
+     * failed for every addon left isCacheStale() true and the next recomputation of
+     * installedAddonsFlow scheduled another full sweep. Any addon rename, enable or disable while
+     * offline therefore re-armed it indefinitely.
+     *
+     * Deterministic because the dispatcher and the clock are injected: the unconfined test
+     * dispatcher runs the disk load, the flow and the sweep to completion at their launch points,
+     * so a manifest-call count sampled after an emission is stable.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun `an all-failed sweep does not re-arm on the next recomputation`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val now = AtomicLong(0L)
+        val names = MutableStateFlow(emptyMap<String, String>())
+        val harness = newRepository(
+            userSetNames = names,
+            reachable = true,
+            dispatcher = dispatcher,
+            clock = { now.get() }
+        )
+
+        // Resolve the manifest once so it is cached. While it is not, every recomputation takes
+        // the cache-miss branch, which never consults the clock.
+        harness.repository.getInstalledAddons().first { list ->
+            list.singleOrNull()?.version == REAL_VERSION
+        }
+        val afterCaching = harness.manifestCalls.get()
+
+        // Server goes away, clock moves past the TTL. The cache is now stale with no cache miss,
+        // so the next recomputation schedules a sweep, and every fetch in it fails.
+        harness.reachable.set(false)
+        now.set(MANIFEST_CACHE_TTL_MS + 1)
+        names.value = mapOf(addonUrl to "renamed once")
+        val afterFailedSweep = harness.manifestCalls.get()
+        assertEquals(
+            "the stale cache should have produced exactly one sweep",
+            afterCaching + 1,
+            afterFailedSweep
+        )
+
+        // The sweep failed, but it was still an attempt. Further recomputations must not re-arm it.
+        names.value = mapOf(addonUrl to "renamed twice")
+        names.value = mapOf(addonUrl to "renamed three times")
+        assertEquals(
+            "a failed sweep must not re-arm on later recomputations",
+            afterFailedSweep,
+            harness.manifestCalls.get()
+        )
+
+        // Once the TTL has elapsed again the sweep is eligible, which is what makes the assertion
+        // above a throttle rather than a permanent stop.
+        now.set(now.get() + MANIFEST_CACHE_TTL_MS + 1)
+        names.value = mapOf(addonUrl to "renamed four times")
+        assertEquals(
+            "a new TTL window should allow one further sweep",
+            afterFailedSweep + 1,
+            harness.manifestCalls.get()
+        )
+    }
+
     private fun newContext(): Context = mockk(relaxed = true)
 
     private data class Harness(
@@ -167,7 +236,9 @@ class AddonManifestPlaceholderTest {
 
     private fun newRepository(
         userSetNames: kotlinx.coroutines.flow.Flow<Map<String, String>> = flowOf(emptyMap()),
-        reachable: Boolean = false
+        reachable: Boolean = false,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        clock: () -> Long = System::currentTimeMillis
     ): Harness {
         val manifestCalls = AtomicInteger()
         val isReachable = AtomicBoolean(reachable)
@@ -192,7 +263,9 @@ class AddonManifestPlaceholderTest {
                 preferences = preferences,
                 addonSyncService = mockk<AddonSyncService>(relaxed = true),
                 authManager = mockk<AuthManager>(relaxed = true),
-                context = newContext()
+                context = newContext(),
+                dispatcher = dispatcher,
+                clock = clock
             ),
             preferences = preferences,
             manifestCalls = manifestCalls,

--- a/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/StreamRepositoryPluginIsolationTest.kt
@@ -78,6 +78,50 @@ class StreamRepositoryPluginIsolationTest {
         coVerify(exactly = 1) { harness.api.getStreams(any()) }
     }
 
+    /**
+     * The stream path must read addon display info from the installed [Addon] it was given, not
+     * refetch the manifest. fetchAddon is deliberately left stubbed on the harness so this asserts
+     * the call is available and still not made, rather than merely un-stubbed.
+     */
+    @Test
+    fun `stream lookup issues no manifest request`() = runTest {
+        val harness = newHarness(emptyList())
+
+        val results = harness.repository.getStreamsFromAllAddons(
+            type = "movie",
+            videoId = "tt1341338",
+            season = null,
+            episode = null
+        ).toList()
+
+        val success = results.last() as NetworkResult.Success
+        assertEquals(listOf("Fast Addon"), success.data.map { it.addonName })
+        // Pins the URL too: the regression is not merely "one call happened", it is that the
+        // stream request is the only request, built from the addon's own baseUrl.
+        coVerify(exactly = 1) { harness.api.getStreams("https://addon.example/stream/movie/tt1341338.json") }
+        coVerify(exactly = 0) { harness.addonRepository.fetchAddon(any()) }
+    }
+
+    @Test
+    fun `streams carry the installed addon name and logo`() = runTest {
+        val harness = newHarness(emptyList())
+
+        val results = harness.repository.getStreamsFromAllAddons(
+            type = "movie",
+            videoId = "tt1341338",
+            season = null,
+            episode = null
+        ).toList()
+
+        val success = results.last() as NetworkResult.Success
+        val groups = success.data
+        assertEquals(listOf("Fast Addon"), groups.map { it.addonName })
+        assertEquals(listOf(ADDON_LOGO), groups.map { it.addonLogo })
+        assertTrue(groups.single().streams.all { it.addonName == "Fast Addon" })
+        assertTrue(groups.single().streams.all { it.addonLogo == ADDON_LOGO })
+        coVerify(exactly = 0) { harness.addonRepository.fetchAddon(any()) }
+    }
+
     private fun newHarness(enabledScrapers: List<ScraperInfo>): Harness {
         val addon = compatibleAddon()
         val api = mockk<AddonApi>()
@@ -133,7 +177,8 @@ class StreamRepositoryPluginIsolationTest {
                 localDebridAvailabilityService = availability
             ),
             api = api,
-            tmdbService = tmdbService
+            tmdbService = tmdbService,
+            addonRepository = addonRepository
         )
     }
 
@@ -142,7 +187,7 @@ class StreamRepositoryPluginIsolationTest {
         name = "Fast Addon",
         version = "1.0.0",
         description = null,
-        logo = null,
+        logo = ADDON_LOGO,
         baseUrl = "https://addon.example",
         catalogs = emptyList(),
         types = emptyList(),
@@ -171,9 +216,14 @@ class StreamRepositoryPluginIsolationTest {
         type = RepositoryType.NUVIO_JS
     )
 
+    private companion object {
+        const val ADDON_LOGO = "https://addon.example/logo.png"
+    }
+
     private data class Harness(
         val repository: StreamRepositoryImpl,
         val api: AddonApi,
-        val tmdbService: TmdbService
+        val tmdbService: TmdbService,
+        val addonRepository: AddonRepository
     )
 }


### PR DESCRIPTION
## Summary

Four bug fixes and one concurrency hardening change in the addon manifest lifecycle:

- Stop the stream path fetching `/manifest.json` before every stream request.
- Keep an installed addon visible and removable when its manifest cannot be fetched.
- Throttle a failed background refresh instead of re-arming it on every addon-state change.
- Make the manifest-cache revision increment atomic.
- Scope `AddonRepositoryImpl` as a singleton so the app shares one cache and one refresh clock.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The primary user-facing bug is an addon becoming unreachable. If its manifest cannot be fetched, `getInstalledAddons()` drops it. The URL stays installed on disk, but the addon manager gets its list from that flow, leaving the addon installed, invisible, and unremovable without clearing app data. Adding an addon while its server is down, or restoring a synced list on a fresh install while offline, both land there.

The stream path calls `fetchAddon` before every stream request for metadata the caller already holds. A fully failed sweep also never advanced the refresh timestamp, so it stayed stale and could be rescheduled on every recomputation.

## Issue or approval

Fixes #3300

## Reproduction steps

1. With addons installed, open a title and watch network traffic: each queried addon fetches `/manifest.json` before `/stream/….json`, even with a fresh cache.
2. Add a valid addon while its server is unreachable. It disappears from the addon manager, though its URL remains installed.
3. With all enabled addons unreachable, change addon state repeatedly. After a completely failed sweep, each recomputation schedules another one.
4. The revision race has no deterministic reproduction.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Changed:

- **Stream path.** `getStreamsFromAddon` takes the resolved `Addon` instead of a base URL. `fetchAddon` bypasses the cache and was called only for the name and logo, which the caller already has. This removes one manifest request per queried addon from every stream search.

- **Failed manifests.** When an enabled addon has no cached manifest and the fetch fails, it resolves to `placeholderAddon` instead of `null`. The placeholder carries no resources or catalogs, so it is not queried for streams and contributes no catalog rows; it keeps the addon visible and removable until a real manifest arrives. The disabled branch already did this.

- **Refresh scheduling.** The timestamp is recorded when a sweep is scheduled rather than only when a fetch succeeds, so an all-failed sweep stops re-arming. The staleness check, timestamp write, and job assignment are `synchronized` together, preventing two recomputations from scheduling the same sweep. The field is `lastManifestRefreshAttemptTime` because it records an attempt, not a completion.

  The cache-miss path is unchanged: an addon with no cached manifest is still fetched on every recomputation, which is what lets an addon added while offline recover. The sweep is the `else` branch of `hasCacheMiss`, so a recomputation either resolves misses in the foreground or schedules the sweep, never both. The scheduling change therefore only affects addons that already have a cached manifest.

- **Cache revision.** `bumpManifestCacheRevision` uses `update { it + 1 }` instead of a read-modify-write. Parallel sweeps can otherwise lose an increment. This is hardening, not a fix for an observed failure.

- **Repository scope.** `AddonRepositoryImpl` is now `@Singleton`. `@Binds @Singleton` scopes the `AddonRepository` binding, but the concrete `AddonRepositoryImpl` binding was unscoped. The three sites that inject the implementation directly can therefore receive separate instances, each with its own cache, clock, job, and sync state.

- **Testability of the refresh clock.** `AddonRepositoryImpl` takes its dispatcher and its clock as constructor parameters. The `@Inject` constructor is now a secondary one supplying `Dispatchers.IO` and `System.currentTimeMillis`, so production, the Hilt graph, and every call site are unchanged. This exists to make the refresh policy testable, which it previously was not.

Deliberately not changed:

- `fetchAddon` is not given a read-through cache. Passing the addon the caller already holds is smaller and avoids the invalidation questions.
- The refresh timestamp stays global rather than per-addon, so a sweep where one addon succeeds and two fail advances the clock for all three. Inherent in the existing design.
- Uncached manifests are still retried on every recomputation, and the TTL does not throttle that because the placeholder is never cached. Per-addon retry/backoff is a separate improvement; a test pins the current behaviour so it is not accidentally changed.
- `R.string.stream_addon_unknown` is now unused. Removing it would touch roughly thirty `values-*/strings.xml` files, so it belongs in a localization cleanup.
- `syncScope` still has no lifecycle. It is a `SupervisorJob` the class never cancels, which matters more now that one long-lived instance owns it. Cancelling it needs an owner to cancel from, so it stays follow-up work.
- `StreamRepositoryImpl` and `SubtitleRepositoryImpl` stay unscoped: same shape, but no concrete injection exists today, so there is no symptom to fix.

## Testing

Built and tested on an **NVIDIA Shield Pro (2019)**, against LAN containers that could be stopped to force failures.

**Unit tests.** `:app:testFullDebugUnitTest --tests "*StreamRepositoryPluginIsolationTest" --tests "*AddonManifestPlaceholderTest"`: ten green, run against the patch applied to a clean `dev`. The full suite has 13 failures in the player, Trakt/Simkl, and Matroska tests; they fail identically on `dev` at the same assertions, and none of them touch this code.

The refresh-clock policy is covered by injecting the dispatcher and the clock. The test caches a manifest, stops the server, moves the clock past the TTL, and asserts the resulting sweep runs exactly once across three further recomputations, then that a new TTL window allows one more. That last assertion is what makes it a throttle rather than a permanent stop.

**On device:**

- *Stream path.* With the stream addon's container stopped, a search logged only `Fetching streams …` / `Streams failed …`. The manifest fetch previously preceded it and would have logged its own connection failure, so there was no manifest request. Name and logo still render on source rows.
- *Placeholder.* An addon synced while its container was stopped rendered a removable row, was not queried during a stream search, and resolved to its real name and logo once the container started.
- *Refresh clock.* With only unreachable addons enabled, startup logged `Background manifest refresh failed for all 2 addon(s)`; five enable/disable cycles produced no further sweeps. With every addon disabled: `Background manifest refresh skipped: no enabled addons`.
- *One instance.* `Loaded N cached manifests from disk` runs only in `init`, so it provides an instance count: one per launch across three cold starts, with none added by navigating to addon or account screens. It appeared 2–6 times before.
- *Sync.* After a sign-out/sign-in, toggling addons produced `push result=true` and matching state on nuvio.tv. This also verifies the shared-instance path used by `isSyncingFromRemote`.
- *Home.* With only an unresolved addon installed, Home settled on "No catalog addons installed" rather than hanging.

**Not covered by unit tests.** The atomic revision bump. A lost read-modify-write is a timing window, so a test for it would pass against the broken implementation most of the time.

## Screenshots / Video

Not a UI change.

## Breaking changes

`StreamRepository.getStreamsFromAddon` changes from `(baseUrl: String, type: String, videoId: String)` to `(addon: Addon, type: String, videoId: String)`.

There is one call site in this repository, plus the interface declaration and its implementation. All three are updated together. No addon API or HTTP contract changes.

The interface is source-incompatible for any external implementation or caller outside this repository. Separately compiled clients using the old method signature would also need to be rebuilt against the new API.

## Linked issues

Fixes #3300