### PR TITLE
Fix Home retry failed metadata enrichment

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/network/NetworkResult.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/NetworkResult.kt
@@ -13,5 +13,12 @@ sealed class NetworkResult<out T> {
          * catalog data as sufficient and mark the item as resolved.
          */
         const val SOURCE_SUFFICIENT_CODE = -9999
+
+        /**
+         * Sentinel error code used by MetaRepository when every addon answered and none of them
+         * carries the requested item. The lookup did not fail, so callers should treat the result
+         * as final and not retry it; a transport failure returns a plain Error instead.
+         */
+        const val META_NOT_FOUND_CODE = -9998
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/MetaRepositoryImpl.kt
@@ -81,7 +81,13 @@ class MetaRepositoryImpl @Inject constructor(
          *  others reporting nothing. */
         data class NotFound(
             val attemptedAddonNames: List<String> = emptyList(),
-            val failures: List<MetaAttemptFailure> = emptyList()
+            val failures: List<MetaAttemptFailure> = emptyList(),
+            /**
+             * Every candidate was attempted and every one of them answered "no such item". Set by
+             * the lookup loop, which is the only place that knows how many candidates there were,
+             * rather than inferred from [failures] by a caller.
+             */
+            val allAttemptsMissing: Boolean = false
         ) : MetaLookupResult()
         /** The first viable candidate is the same addon that served the catalog,
          *  so the item already has its meta — no request needed. */
@@ -346,7 +352,16 @@ class MetaRepositoryImpl @Inject constructor(
                     failures = attemptedFailures
                 )
             }
-            emit(NetworkResult.Error(fallbackMessage))
+            // Classified like the main path below. No addon declaring the type is final, and so is
+            // every legacy candidate answering "no such item"; only a request failure is retryable.
+            val fallbackFinal = fallbackAddons.isEmpty() ||
+                attemptedFailures.all { it.kind == MetaFailureKind.MISSING }
+            emit(
+                NetworkResult.Error(
+                    fallbackMessage,
+                    code = if (fallbackFinal) NetworkResult.META_NOT_FOUND_CODE else null
+                )
+            )
             return@flow
         }
 
@@ -358,6 +373,8 @@ class MetaRepositoryImpl @Inject constructor(
                     // everyone else would report "no addon found" for addons tried.
                     val loopAddonNames = linkedSetOf<String>()
                     val loopFailures = mutableListOf<MetaAttemptFailure>()
+                    var attempted = 0
+                    var allMissing = true
 
                     // Normalize source addon URL for comparison so we can detect
                     // when the candidate is the same addon that served the catalog.
@@ -378,6 +395,7 @@ class MetaRepositoryImpl @Inject constructor(
                         val url = buildMetaUrl(addon.baseUrl, candidateType, id)
                         Log.d(TAG, "Trying meta addonId=${addon.id} addonName=${addon.name} type=$candidateType id=$id url=$url")
                         loopAddonNames += addon.displayName
+                        attempted++
                         try {
                             val response = api.getMeta(url)
                             if (response.isSuccessful) {
@@ -399,6 +417,7 @@ class MetaRepositoryImpl @Inject constructor(
                                     kind = if (response.code() == 404) MetaFailureKind.MISSING else MetaFailureKind.REQUEST_FAILED,
                                     detail = response.message() ?: "HTTP ${response.code()}"
                                 )
+                                if (response.code() != 404) allMissing = false
                             }
                         } catch (e: kotlinx.coroutines.CancellationException) {
                             throw e
@@ -409,10 +428,19 @@ class MetaRepositoryImpl @Inject constructor(
                                 kind = MetaFailureKind.REQUEST_FAILED,
                                 detail = e.message ?: context.getString(R.string.network_error_unknown)
                             )
+                            allMissing = false
                             /* try next */
                         }
                     }
-                    MetaLookupResult.NotFound(loopAddonNames.toList(), loopFailures)
+                    // Comparing against the candidate list makes "every candidate was attempted"
+                    // explicit rather than implied by the loop never breaking early.
+                    MetaLookupResult.NotFound(
+                        attemptedAddonNames = loopAddonNames.toList(),
+                        failures = loopFailures,
+                        allAttemptsMissing = attempted > 0 &&
+                            attempted == prioritizedCandidates.size &&
+                            allMissing
+                    )
                 } finally {
                     inFlightAddonMeta.remove(cacheKey)
                 }
@@ -429,6 +457,10 @@ class MetaRepositoryImpl @Inject constructor(
             is MetaLookupResult.NotFound -> {
                 // The loop reports its own attempts. The enclosing lists are only used
                 // by the legacy raw-type path, which returns before reaching here.
+                // Every addon answering "no such item" is a final answer, not a failure. Flag it
+                // so callers can cache the outcome instead of asking again on every focus. Only a
+                // request failure stays retryable.
+                val allMissing = lookupResult.allAttemptsMissing
                 emit(
                     NetworkResult.Error(
                         buildAggregateFailureMessage(
@@ -436,7 +468,8 @@ class MetaRepositoryImpl @Inject constructor(
                             id = id,
                             attemptedAddonNames = lookupResult.attemptedAddonNames,
                             failures = lookupResult.failures
-                        )
+                        ),
+                        code = if (allMissing) NetworkResult.META_NOT_FOUND_CODE else null
                     )
                 )
             }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModel.kt
@@ -179,6 +179,35 @@ class HomeViewModel @Inject constructor(
     internal val _failedEnrichmentIds = MutableStateFlow<Set<String>>(emptySet())
     val failedEnrichmentIds: StateFlow<Set<String>> = _failedEnrichmentIds.asStateFlow()
 
+    /**
+     * Bounded like the enrichment and prefetch caches beside it. This set is only a hint for the
+     * hero, telling it to stop waiting and render catalog data, so evicting the oldest entry costs
+     * at most one frame of the loading state the next time that item is focused.
+     *
+     * Insertion order is part of the contract even though the type is a plain Set: eviction drops
+     * the oldest entry, and both this and clearEnrichmentFailure preserve order.
+     */
+    internal fun markEnrichmentFailed(id: String) {
+        _failedEnrichmentIds.update { current ->
+            if (id in current) return@update current
+            val updated = LinkedHashSet(current).apply { add(id) }
+            while (updated.size > MAX_ENRICHMENT_CACHE_SIZE) {
+                updated.remove(updated.first())
+            }
+            updated
+        }
+    }
+
+    /** Enrichment succeeded after a previous failure, so the item is no longer a failed one. */
+    internal fun clearEnrichmentFailure(id: String) {
+        _failedEnrichmentIds.update { current -> if (id in current) current - id else current }
+    }
+
+    /** Drops every failure marker, for the resets that clear the caches beside this one. */
+    internal fun clearEnrichmentFailures() {
+        _failedEnrichmentIds.value = emptySet()
+    }
+
     internal val catalogStateLock = Any()
     internal val catalogsMap = linkedMapOf<String, CatalogRow>()
     internal val catalogItemKeyIndex = mutableMapOf<String, MutableSet<String>>()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelCatalogPipeline.kt
@@ -120,6 +120,7 @@ internal fun HomeViewModel.observeTmdbSettingsPipeline() {
                     prefetchedExternalMetaIds.clear()
                     _enrichedPreviews.value = emptyMap()
                     _lastEnrichedPreview.value = null
+                    clearEnrichmentFailures()
                 }
                 scheduleUpdateCatalogRows()
             }
@@ -189,6 +190,7 @@ internal suspend fun HomeViewModel.loadAllCatalogsPipeline(
     prefetchedTmdbIds.clear()
     tmdbEnrichFocusJob?.cancel()
     pendingTmdbEnrichItemId = null
+    clearEnrichmentFailures()
     lastHeroEnrichmentSignature = null
     lastHeroEnrichedItems = emptyList()
     heroItemOrder = emptyList()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -856,6 +856,11 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
     clearEnrichmentFailure(itemId)
 
     _uiState.update { state ->
+        // Modern layout reads enrichment through enrichedPreviews / lastEnrichedPreview, populated
+        // just below, so rebuilding catalogRows here buys nothing and forces a full-home
+        // recomposition. The layout is read from the state being updated rather than from
+        // _uiState.value beforehand, so a concurrent layout change cannot make this stale.
+        if (state.homeLayout == HomeLayout.MODERN) return@update state
         var changed = false
         val updatedRows = state.catalogRows.map { row ->
             val itemIndex = row.items.indexOfFirst { it.id == itemId }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -772,6 +772,7 @@ private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: 
     }
 
     updateIndexedCatalogItem(itemId, ::mergeItem)
+    clearEnrichmentFailure(itemId)
 
     // Modern layout reads enrichment via enrichedPreviews / lastEnrichedPreview.
     // Rebuilding catalogRows here triggers a useless full-home recomposition.
@@ -852,6 +853,7 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
     )
 
     updateIndexedCatalogItem(itemId, ::mergeItem)
+    clearEnrichmentFailure(itemId)
 
     _uiState.update { state ->
         var changed = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.screens.home
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import androidx.lifecycle.viewModelScope
 import com.nuvio.tv.LocaleCache
 import com.nuvio.tv.core.build.AppFeaturePolicy
@@ -442,18 +443,67 @@ internal fun HomeViewModel.requestTrailerPreviewPipeline(
     }
 }
 
+/**
+ * What an external meta prefetch produced. A failed fetch must be distinguishable from an addon
+ * that answered with nothing to add: the first is retried on the next focus, the second is not.
+ * Both used to collapse to null, so one unreachable addon suppressed enrichment for the session.
+ *
+ * Callers own the in-flight id: they claim it before launching and release it on completion.
+ */
+private sealed interface ExternalMetaOutcome {
+    data class Resolved(val meta: Meta) : ExternalMetaOutcome
+    /**
+     * The addons answered and there is nothing more to fetch: either the catalog item is already
+     * sufficient, or no addon carries this item. Both are final, so neither is retried.
+     */
+    object Final : ExternalMetaOutcome
+    object Failed : ExternalMetaOutcome
+}
+
+/**
+ * Whether an external meta fetch is still outstanding. A TMDB success must not stand in for one
+ * that has not resolved, and both gates ask this rather than keeping their own copy of the rule.
+ */
+private fun HomeViewModel.externalEnrichmentOutstanding(itemId: String): Boolean =
+    externalMetaPrefetchEnabled && itemId !in prefetchedExternalMetaIds
+
+private suspend fun HomeViewModel.fetchExternalMetaOutcome(item: MetaPreview): ExternalMetaOutcome =
+    try {
+        val result = metaRepository.getMetaFromAllAddons(item.apiType, item.id, item.sourceAddonBaseUrl)
+            .first { it is NetworkResult.Success || it is NetworkResult.Error }
+        when {
+            result is NetworkResult.Success -> ExternalMetaOutcome.Resolved(result.data)
+            result is NetworkResult.Error &&
+                (result.code == NetworkResult.SOURCE_SUFFICIENT_CODE ||
+                    result.code == NetworkResult.META_NOT_FOUND_CODE) ->
+                ExternalMetaOutcome.Final
+            else -> ExternalMetaOutcome.Failed
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // The repository reports request failures as NetworkResult.Error, so this is the path it
+        // does not promise: anything thrown outside its own per-addon handling. It used to leave
+        // the launched enrichment coroutine to fail with it, which loses the focus pipeline for
+        // that item. Treating it as Failed keeps the outcome exhaustive and lets the next focus
+        // retry, which is what any other failure does.
+        Log.w(HomeViewModel.TAG, "External meta fetch threw for ${item.id}: ${e.message}")
+        ExternalMetaOutcome.Failed
+    }
+
 internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
     if (startupGracePeriodActive) {
         deferredEnrichItem = item
         return
     }
     if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) {
-        // Even if TMDB enriched, re-enter when artwork is still missing and external addon can help.
-        val artworkStillNeeded = item.id !in prefetchedExternalMetaIds &&
-            externalMetaPrefetchEnabled &&
-            !currentTmdbSettings.useArtwork &&
-            item.logo.isNullOrBlank()
-        if (!artworkStillNeeded) {
+        // Only external enrichment re-opens this gate, so a cached external result still shuts out
+        // an unresolved TMDB fetch. That is unchanged from before and deliberate: TMDB is never
+        // marked prefetched when an item has no TMDB match, so gating on it too would re-enter on
+        // every focus and call ensureTmdbId each time. Fixing it needs a terminal marker for TMDB
+        // first. The fetches below are gated per source, so re-entering issues only the external
+        // request.
+        if (!externalEnrichmentOutstanding(item.id)) {
             // Ensure enrichedPreviews contains this item so the UI can display
             // hero data immediately (e.g. when adjacent prefetch resolved it
             // before the user focused on it).
@@ -496,11 +546,7 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
         }
         if (willEnrich) setEnrichingItemId(item.id)
         if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) {
-            val artworkStillNeeded = item.id !in prefetchedExternalMetaIds &&
-                externalMetaPrefetchEnabled &&
-                !currentTmdbSettings.useArtwork &&
-                item.logo.isNullOrBlank()
-            if (!artworkStillNeeded) {
+            if (!externalEnrichmentOutstanding(item.id)) {
                 if (_enrichingItemId.value == item.id) setEnrichingItemId(null)
                 // Still prefetch full meta in background for instant detail screen.
                 if (item.id !in backgroundMetaPrefetchedIds) {
@@ -521,7 +567,7 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
             // Which sources are used depends on settings:
             // - tmdbEnabledForCurrentLayout: controls TMDB enrichment
             // - externalMetaPrefetchEnabled: controls external meta addon fetch
-            val tmdbDeferred = if (tmdbEnabledForCurrentLayout) {
+            val tmdbDeferred = if (tmdbEnabledForCurrentLayout && item.id !in prefetchedTmdbIds) {
                 val tmdbId = runCatching { tmdbService.ensureTmdbId(item.id, item.apiType) }.getOrNull()
                 if (tmdbId != null) async {
                     runCatching {
@@ -538,28 +584,25 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
                 item.id !in prefetchedExternalMetaIds &&
                 externalMetaPrefetchInFlightIds.add(item.id)
             ) {
-                async {
-                    try {
-                        val result = metaRepository.getMetaFromAllAddons(item.apiType, item.id, item.sourceAddonBaseUrl)
-                            .first { it is NetworkResult.Success || it is NetworkResult.Error }
-                        when {
-                            result is NetworkResult.Success -> result.data
-                            result is NetworkResult.Error && result.code == NetworkResult.SOURCE_SUFFICIENT_CODE -> null
-                            else -> null
-                        }
-                    } finally {
-                        externalMetaPrefetchInFlightIds.remove(item.id)
-                    }
-                }
+                // The id is claimed here, in the enclosing coroutine, but released when the
+                // deferred completes rather than inside its body. A focus that moves on during
+                // the debounce cancels this job before the body runs, and a body that never runs
+                // never reaches its own finally, which would strand the id in the in-flight set
+                // and block every later fetch for that item.
+                async { fetchExternalMetaOutcome(item) }
+                    .also { d -> d.invokeOnCompletion { externalMetaPrefetchInFlightIds.remove(item.id) } }
             } else null
 
             // Await both results
             val tmdbEnrichment = tmdbDeferred?.await()
-            val externalMeta = externalMetaDeferred?.await()
+            val externalOutcome = externalMetaDeferred?.await()
+            val externalMeta = (externalOutcome as? ExternalMetaOutcome.Resolved)?.meta
 
             // Mark as prefetched
             if (tmdbEnrichment != null) prefetchedTmdbIds.add(item.id)
-            if (externalMetaDeferred != null) prefetchedExternalMetaIds.add(item.id)
+            if (externalOutcome != null && externalOutcome != ExternalMetaOutcome.Failed) {
+                prefetchedExternalMetaIds.add(item.id)
+            }
 
             // Merge results: apply external meta first (base layer), then TMDB on top
             // respecting which TMDB settings are enabled.
@@ -571,9 +614,11 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
             }
 
             // If neither source produced anything, mark enrichment in previews
-            // so UI doesn't keep showing spinner.
-            if (tmdbEnrichment == null && externalMeta == null) {
-                addEnrichedPreview(item.id, item)
+            // so UI doesn't keep showing spinner. Take the indexed item rather than the argument,
+            // and only when nothing is published yet: a retry that fails again must not overwrite
+            // enrichment an earlier pass already resolved.
+            if (tmdbEnrichment == null && externalMeta == null && item.id !in _enrichedPreviews.value) {
+                addEnrichedPreview(item.id, findCatalogItemById(item.id) ?: item)
             }
 
             // Always prefetch full meta in background for instant detail screen loading.
@@ -600,13 +645,18 @@ internal fun HomeViewModel.onItemFocusPipeline(item: MetaPreview) {
                 if (item.id !in _enrichedPreviews.value &&
                     item.id !in prefetchedExternalMetaIds &&
                     item.id !in prefetchedTmdbIds) {
-                    _failedEnrichmentIds.value = _failedEnrichmentIds.value + item.id
+                    markEnrichmentFailed(item.id)
                 }
             }
         }
     }
 }
 
+/**
+ * Shares the fetch with the focused path but deliberately not its gate: an item whose TMDB fetch
+ * succeeded is skipped here even when external metadata is outstanding. Adjacent prefetch is
+ * opportunistic and the focused path retries anyway, so aligning the two would only add requests.
+ */
 internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
     if (startupGracePeriodActive) return
     if (item.id in prefetchedTmdbIds || item.id in prefetchedExternalMetaIds) return
@@ -641,26 +691,23 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
                 item.id !in prefetchedExternalMetaIds &&
                 externalMetaPrefetchInFlightIds.add(item.id)
             ) {
-                async {
-                    try {
-                        val result = metaRepository.getMetaFromAllAddons(item.apiType, item.id, item.sourceAddonBaseUrl)
-                            .first { it is NetworkResult.Success || it is NetworkResult.Error }
-                        when {
-                            result is NetworkResult.Success -> result.data
-                            result is NetworkResult.Error && result.code == NetworkResult.SOURCE_SUFFICIENT_CODE -> null
-                            else -> null
-                        }
-                    } finally {
-                        externalMetaPrefetchInFlightIds.remove(item.id)
-                    }
-                }
+                // The id is claimed here, in the enclosing coroutine, but released when the
+                // deferred completes rather than inside its body. A focus that moves on during
+                // the debounce cancels this job before the body runs, and a body that never runs
+                // never reaches its own finally, which would strand the id in the in-flight set
+                // and block every later fetch for that item.
+                async { fetchExternalMetaOutcome(item) }
+                    .also { d -> d.invokeOnCompletion { externalMetaPrefetchInFlightIds.remove(item.id) } }
             } else null
 
             val tmdbEnrichment = tmdbDeferred?.await()
-            val externalMeta = externalMetaDeferred?.await()
+            val externalOutcome = externalMetaDeferred?.await()
+            val externalMeta = (externalOutcome as? ExternalMetaOutcome.Resolved)?.meta
 
             if (tmdbEnrichment != null) prefetchedTmdbIds.add(item.id)
-            if (externalMetaDeferred != null) prefetchedExternalMetaIds.add(item.id)
+            if (externalOutcome != null && externalOutcome != ExternalMetaOutcome.Failed) {
+                prefetchedExternalMetaIds.add(item.id)
+            }
 
             if (externalMeta != null) {
                 updateCatalogItemWithMeta(item.id, externalMeta)

--- a/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryNotFoundClassificationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/MetaRepositoryNotFoundClassificationTest.kt
@@ -1,0 +1,191 @@
+package com.nuvio.tv.data.repository
+
+import android.content.Context
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+
+/**
+ * A meta lookup that produced no result has to say why. An addon answering "no such item" is a
+ * final answer and callers cache it; an addon that could not be reached is not, and callers retry.
+ * Both used to arrive as the same codeless Error, so Home marked an item enriched after a failed
+ * request and never asked again for the rest of the session.
+ */
+class MetaRepositoryNotFoundClassificationTest {
+
+    private val contentId = "tt0944947"
+
+    @Test
+    fun `every addon reporting the item missing is final`() = runTest {
+        val repository = newRepository(apiAnswering { notFound() }, addon("a"), addon("b"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertEquals(NetworkResult.META_NOT_FOUND_CODE, (result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `an unreachable addon is retryable`() = runTest {
+        val repository = newRepository(apiAnswering { throw IOException("offline") }, addon("a"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertNull(
+            "a transport failure must stay retryable, not be cached as a final answer",
+            (result as NetworkResult.Error).code
+        )
+    }
+
+    @Test
+    fun `one unreachable addon among missing ones is retryable`() = runTest {
+        // Keyed on the requested URL rather than a call counter, so the outcome does not depend
+        // on the order the repository happens to try the addons in.
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } coAnswers {
+            if (firstArg<String>().startsWith("https://a.")) notFound() else throw IOException("offline")
+        }
+        val repository = newRepository(api, addon("a"), addon("b"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        // The reachable addon genuinely does not have it, but the other one was never asked
+        // successfully, so the lookup is not final.
+        assertNull((result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `a single addon answering successfully with no meta is final`() = runTest {
+        // The only attempt produced an empty body. That has to be recorded as a missing result,
+        // or the lookup would reach the caller with no failures and be treated as retryable.
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns
+            Response.success(com.nuvio.tv.data.remote.dto.MetaResponseDto(meta = null))
+        val repository = newRepository(api, addon("a"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertEquals(NetworkResult.META_NOT_FOUND_CODE, (result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `a successful response carrying no meta counts as missing`() = runTest {
+        // The addon answered and has nothing for this id, which is the same final answer as a 404.
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } coAnswers {
+            if (firstArg<String>().startsWith("https://a.")) {
+                Response.success(com.nuvio.tv.data.remote.dto.MetaResponseDto(meta = null))
+            } else {
+                notFound()
+            }
+        }
+        val repository = newRepository(api, addon("a"), addon("b"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertEquals(NetworkResult.META_NOT_FOUND_CODE, (result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `a non-404 error response is retryable`() = runTest {
+        // Only 404 counts as the addon answering "no such item". A 500 is the server failing, so
+        // the lookup must stay retryable even though the addon did respond.
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns Response.error(
+            500,
+            "".toResponseBody("application/json".toMediaType())
+        )
+        val repository = newRepository(api, addon("a"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertNull((result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `no addon supporting the type is final`() = runTest {
+        val repository = newRepository(
+            apiAnswering { notFound() },
+            addon("a", metaTypes = listOf("series"), rawTypes = listOf("series"))
+        )
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        // Nothing was even eligible to ask, so retrying cannot reach anything new. This path
+        // returns before the addon loop, so it needs its own classification.
+        assertEquals(NetworkResult.META_NOT_FOUND_CODE, (result as NetworkResult.Error).code)
+    }
+
+    @Test
+    fun `a successful lookup is not an error at all`() = runTest {
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } returns Response.success(
+            com.nuvio.tv.data.remote.dto.MetaResponseDto(
+                meta = com.nuvio.tv.data.remote.dto.MetaDto(
+                    id = contentId,
+                    type = "movie",
+                    name = "Test Meta"
+                )
+            )
+        )
+        val repository = newRepository(api, addon("a"))
+
+        val result = repository.getMetaFromAllAddons("movie", contentId).last()
+
+        assertTrue(result is NetworkResult.Success)
+    }
+
+    private fun notFound(): Response<com.nuvio.tv.data.remote.dto.MetaResponseDto> =
+        Response.error(404, "".toResponseBody("application/json".toMediaType()))
+
+    private fun apiAnswering(
+        answer: suspend () -> Response<com.nuvio.tv.data.remote.dto.MetaResponseDto>
+    ): AddonApi = mockk<AddonApi>().also { api ->
+        coEvery { api.getMeta(any()) } coAnswers { answer() }
+    }
+
+    private fun addon(
+        key: String,
+        metaTypes: List<String> = listOf("movie", "series"),
+        rawTypes: List<String> = listOf("movie", "series")
+    ) = Addon(
+        id = "test.addon.$key",
+        name = "Test Addon $key",
+        version = "1.0.0",
+        description = null,
+        logo = null,
+        baseUrl = "https://$key.addon.example",
+        catalogs = emptyList(),
+        types = listOf(ContentType.MOVIE, ContentType.SERIES),
+        rawTypes = rawTypes,
+        resources = listOf(AddonResource(name = "meta", types = metaTypes, idPrefixes = null)),
+        idPrefixes = listOf("tt")
+    )
+
+    private fun newRepository(api: AddonApi, vararg addons: Addon): MetaRepositoryImpl {
+        val context = mockk<Context>(relaxed = true) {
+            every { getString(any()) } returns "Episode"
+            every { getString(any(), *anyVararg()) } returns "No supported addon"
+        }
+        val addonRepository = mockk<AddonRepository>(relaxed = true) {
+            every { getInstalledAddons() } returns flowOf(addons.toList())
+        }
+        return MetaRepositoryImpl(context = context, api = api, addonRepository = addonRepository)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRepositoryBoundaryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRepositoryBoundaryTest.kt
@@ -1,0 +1,208 @@
+package com.nuvio.tv.ui.screens.home
+
+import android.content.Context
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.data.remote.api.AddonApi
+import com.nuvio.tv.data.remote.dto.MetaDto
+import com.nuvio.tv.data.remote.dto.MetaResponseDto
+import com.nuvio.tv.data.repository.MetaRepositoryImpl
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.AddonResource
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.model.TmdbSettings
+import com.nuvio.tv.domain.repository.AddonRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The retry depends on a contract between two classes: MetaRepositoryImpl reports a transport
+ * failure as a codeless NetworkResult.Error, and the focus pipeline treats exactly that as
+ * retryable. The other tests mock one side or the other, so this one runs the real repository
+ * against a mocked AddonApi to keep the two from drifting apart.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class HomeEnrichmentRepositoryBoundaryTest {
+
+    private val itemId = "tt0944947"
+    private val otherId = "tt0903747"
+    private val catalogSourceUrl = "https://catalog.example"
+
+    private val created = mutableListOf<HomeViewModel>()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(Dispatchers.Unconfined)
+
+    @After
+    fun tearDown() {
+        created.forEach { it.viewModelScope.cancel() }
+        created.clear()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a real repository transport failure is retried and then resolves`() = runBlocking {
+        val metaCalls = AtomicInteger()
+        val reachable = AtomicBoolean(false)
+        val api = mockk<AddonApi>()
+        coEvery { api.getMeta(any()) } coAnswers {
+            metaCalls.incrementAndGet()
+            if (!reachable.get()) throw IOException("offline")
+            Response.success(
+                MetaResponseDto(meta = MetaDto(id = itemId, type = "series", name = "Test Meta"))
+            )
+        }
+        val viewModel = newViewModel(realRepository(api))
+        viewModel.seedCatalog(item(itemId))
+
+        viewModel.onItemFocusPipeline(item(itemId))
+        awaitAtLeast(metaCalls, 1)
+
+        reachable.set(true)
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        // The failed lookup came back as a codeless Error, so the item was never marked prefetched
+        // and the focus gate let it through again.
+        awaitAtLeast(metaCalls, 2)
+        assertEquals(
+            "the resolved item should now be cached",
+            true,
+            itemId in viewModel.prefetchedExternalMetaIds
+        )
+    }
+
+    private suspend fun focusAndSettle(viewModel: HomeViewModel, item: MetaPreview) {
+        viewModel.onItemFocusPipeline(item)
+        delay(HomeViewModel.EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS + 400)
+    }
+
+    private suspend fun awaitAtLeast(counter: AtomicInteger, expected: Int) {
+        val reached = runCatching {
+            withTimeout(5_000) { while (counter.get() < expected) delay(25) }
+        }.isSuccess
+        assertEquals("expected at least $expected meta requests", true, reached)
+    }
+
+    private fun realRepository(api: AddonApi): MetaRepositoryImpl {
+        val context = mockk<Context>(relaxed = true) {
+            every { getString(any()) } returns "Episode"
+            every { getString(any(), *anyVararg()) } returns "No supported addon"
+        }
+        val addonRepository = mockk<AddonRepository>(relaxed = true) {
+            every { getInstalledAddons() } returns flowOf(listOf(metaAddon()))
+        }
+        return MetaRepositoryImpl(context = context, api = api, addonRepository = addonRepository)
+    }
+
+    /** Deliberately not the catalog source, or the lookup short-circuits as source-sufficient. */
+    private fun metaAddon() = Addon(
+        id = "meta.addon",
+        name = "Meta Addon",
+        version = "1.0.0",
+        description = null,
+        logo = null,
+        baseUrl = "https://meta.example",
+        catalogs = emptyList(),
+        types = listOf(ContentType.MOVIE, ContentType.SERIES),
+        rawTypes = listOf("movie", "series"),
+        resources = listOf(
+            AddonResource(name = "meta", types = listOf("movie", "series"), idPrefixes = null)
+        ),
+        idPrefixes = listOf("tt")
+    )
+
+    private fun HomeViewModel.seedCatalog(item: MetaPreview) {
+        synchronized(catalogStateLock) {
+            val rowKey = "seeded-row"
+            catalogsMap[rowKey] = com.nuvio.tv.domain.model.CatalogRow(
+                addonId = "catalog.addon",
+                addonName = "Catalog Addon",
+                addonBaseUrl = catalogSourceUrl,
+                catalogId = "test.catalog",
+                catalogName = "Test Catalog",
+                type = ContentType.SERIES,
+                items = listOf(item)
+            )
+            catalogItemKeyIndex.getOrPut(item.id) { mutableSetOf() }.add(rowKey)
+        }
+    }
+
+    private fun item(id: String) = MetaPreview(
+        id = id,
+        type = ContentType.SERIES,
+        name = "Test Item",
+        poster = null,
+        posterShape = PosterShape.POSTER,
+        background = null,
+        logo = null,
+        description = null,
+        releaseInfo = null,
+        imdbRating = null,
+        genres = emptyList(),
+        sourceAddonBaseUrl = catalogSourceUrl
+    )
+
+    private fun newViewModel(metaRepository: MetaRepositoryImpl): HomeViewModel {
+        val profileManager = mockk<com.nuvio.tv.core.profile.ProfileManager>(relaxed = true) {
+            every { activeProfileReady } returns MutableStateFlow(false)
+            every { activeProfileId } returns MutableStateFlow(1)
+        }
+        val cwEnrichmentCache =
+            mockk<com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache>(relaxed = true) {
+                every { cacheCleared } returns MutableStateFlow(0)
+            }
+        val watchProgressRepository =
+            mockk<com.nuvio.tv.domain.repository.WatchProgressRepository>(relaxed = true) {
+                every { getAllEpisodeProgress(any()) } returns flowOf(emptyMap())
+            }
+        val viewModel = HomeViewModel(
+            appContext = mockk(relaxed = true),
+            addonRepository = mockk(relaxed = true),
+            startupSyncService = mockk(relaxed = true),
+            catalogRepository = mockk(relaxed = true),
+            watchProgressRepository = watchProgressRepository,
+            libraryRepository = mockk(relaxed = true),
+            metaRepository = metaRepository,
+            collectionsDataStore = mockk(relaxed = true),
+            layoutPreferenceDataStore = mockk(relaxed = true),
+            playerSettingsDataStore = mockk(relaxed = true),
+            tmdbSettingsDataStore = mockk(relaxed = true),
+            mdbListSettingsDataStore = mockk(relaxed = true),
+            traktSettingsDataStore = mockk(relaxed = true),
+            authSessionNoticeDataStore = mockk(relaxed = true),
+            tmdbService = mockk(relaxed = true),
+            tmdbMetadataService = mockk(relaxed = true),
+            mdbListRepository = mockk(relaxed = true),
+            trailerService = mockk(relaxed = true),
+            watchedSeriesStateHolder = mockk(relaxed = true),
+            cwEnrichmentCache = cwEnrichmentCache,
+            profileManager = profileManager,
+            tvRecommendationManager = mockk(relaxed = true)
+        )
+        viewModel.startupGracePeriodActive = false
+        viewModel.externalMetaPrefetchEnabled = true
+        viewModel.currentTmdbSettings = TmdbSettings(enabled = false)
+        created += viewModel
+        return viewModel
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRetryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRetryTest.kt
@@ -1,0 +1,456 @@
+package com.nuvio.tv.ui.screens.home
+
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.Meta
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.core.tmdb.TmdbEnrichment
+import com.nuvio.tv.core.tmdb.TmdbMetadataService
+import com.nuvio.tv.core.tmdb.TmdbService
+import com.nuvio.tv.domain.model.TmdbSettings
+import com.nuvio.tv.domain.repository.MetaRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The regression this branch exists for: an external meta fetch that failed used to mark the item
+ * prefetched anyway, so the focus gate skipped it for the rest of the session and it never
+ * recovered once the addon came back.
+ *
+ * Only the enrichment collaborators are stubbed with behaviour; everything else the ViewModel
+ * takes is a relaxed mock. Its init block suspends on profileManager.activeProfileReady, which a
+ * relaxed mock never completes, so nothing beyond the pipeline under test runs.
+ *
+ * Uses runBlocking and polling rather than virtual time: onItemFocusPipeline launches on
+ * Dispatchers.IO and debounces for 220ms, so the assertions wait for a monotonic call count
+ * instead of advancing a scheduler the pipeline does not use.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class HomeEnrichmentRetryTest {
+
+    private val itemId = "tt0944947"
+    private val otherId = "tt0903747"
+
+    /**
+     * A focus can reach getMetaFromAllAddons twice: the enrichment fetch passes the item's source
+     * addon, and the background detail prefetch takes the parameter's default. Both reach the same
+     * method, so the counters below separate them by that argument rather than lumping them
+     * together, which also makes an accidental extra enrichment call visible.
+     */
+    private val sourceUrl = "https://catalog.example"
+
+    private val created = mutableListOf<HomeViewModel>()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(Dispatchers.Unconfined)
+
+    /**
+     * The pipeline leaves background prefetch coroutines running on the view model's scope, and
+     * nothing here calls onCleared. Cancel them before the Main dispatcher is reset, so they
+     * cannot outlive the test and dispatch into whatever runs next.
+     */
+    @After
+    fun tearDown() {
+        created.forEach { it.viewModelScope.cancel() }
+        created.clear()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a failed external fetch is retried on a later focus and the success is recorded`() = runBlocking {
+        val calls = AtomicInteger()
+        val reachable = java.util.concurrent.atomic.AtomicBoolean(false)
+        val backgroundCalls = AtomicInteger()
+        val repository = metaRepository(calls, reachable, backgroundCalls)
+        val viewModel = newViewModel(repository)
+        viewModel.seedCatalog(item(itemId))
+
+        viewModel.onItemFocusPipeline(item(itemId))
+        awaitCalls(calls, expected = 1, what = "the first focus should have attempted one fetch")
+
+        // The addon comes back. Focus has to move away and back, which is what a remote does.
+        reachable.set(true)
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        awaitCalls(calls, expected = 2, what = "a failed fetch should be retried on a later focus")
+        assertTrue(
+            "the successful retry should be recorded, so it is not fetched a third time",
+            itemId in viewModel.prefetchedExternalMetaIds
+        )
+        assertTrue(
+            "the item should not be left marked as failed",
+            itemId !in viewModel.failedEnrichmentIds.value
+        )
+        assertEquals(
+            "the retried metadata should reach the enriched preview, not just the bookkeeping",
+            ENRICHED_DESCRIPTION,
+            viewModel.enrichedPreviews.value[itemId]?.description
+        )
+
+        // A further focus must not refetch now that the item resolved.
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+        assertEquals("a resolved item must not be refetched", 2, calls.get())
+        assertEquals(
+            "the background detail prefetch runs once per distinct item, not once per focus",
+            2,
+            backgroundCalls.get()
+        )
+    }
+
+    /**
+     * The gate used to short-circuit when either enrichment cache held the item, so a TMDB success
+     * that supplied a logo suppressed the external retry. The two sources are independent: a
+     * resolved TMDB fetch must not stand in for an external fetch that failed, and re-entering
+     * must not refetch TMDB.
+     */
+    @Test
+    fun `a TMDB success does not suppress the external retry`() = runBlocking {
+        val calls = AtomicInteger()
+        val reachable = java.util.concurrent.atomic.AtomicBoolean(false)
+        val repository = metaRepository(calls, reachable, AtomicInteger())
+        // Distinct ids per item: focusing the other item also fetches TMDB, so the verification
+        // below has to name the one under test rather than counting every enrichment call.
+        val tmdbService = mockk<TmdbService>(relaxed = true) {
+            coEvery { ensureTmdbId(eq(itemId), any()) } returns "1399"
+            coEvery { ensureTmdbId(eq(otherId), any()) } returns "2000"
+        }
+        val tmdbMetadataService = mockk<TmdbMetadataService>(relaxed = true) {
+            coEvery { fetchEnrichment(any(), any(), any()) } returns mockk<TmdbEnrichment>(relaxed = true)
+        }
+        val viewModel = newViewModel(repository, tmdbService, tmdbMetadataService)
+        viewModel.currentTmdbSettings = TmdbSettings(enabled = true, modernHomeEnabled = true)
+        viewModel.seedCatalog(item(itemId))
+
+        viewModel.onItemFocusPipeline(item(itemId))
+        awaitCalls(calls, 1, "TMDB succeeding should not stop the external fetch being attempted")
+
+        // The state the second gate reads: TMDB resolved and is cached, external failed and is not.
+        assertTrue("TMDB should be cached after it resolved", itemId in viewModel.prefetchedTmdbIds)
+        assertTrue(
+            "a failed external fetch must not be cached",
+            itemId !in viewModel.prefetchedExternalMetaIds
+        )
+
+        reachable.set(true)
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        awaitCalls(calls, 2, "a TMDB success must not suppress the external retry")
+        assertTrue(
+            "the external retry resolved, so it should now be cached too",
+            itemId in viewModel.prefetchedExternalMetaIds
+        )
+        coVerify(exactly = 1) { tmdbMetadataService.fetchEnrichment(eq("1399"), any(), any()) }
+    }
+
+    /**
+     * fetchExternalMetaOutcome promises to turn a thrown exception into Failed. The repository
+     * reports request failures as NetworkResult.Error, so this covers what it does not promise.
+     */
+    /**
+     * The in-flight id is claimed before the fetch is launched and released when it completes. A
+     * focus that moves on during the debounce cancels the job before its body runs, so releasing
+     * inside the body would strand the id and block every later fetch for that item.
+     */
+    @Test
+    fun `a focus cancelled during the debounce does not block later fetches`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = metaRepository(calls, java.util.concurrent.atomic.AtomicBoolean(true), AtomicInteger())
+        val viewModel = newViewModel(repository)
+        viewModel.seedCatalog(item(itemId))
+
+        // Claim the id, then move on before the debounce elapses so the fetch never runs.
+        viewModel.onItemFocusPipeline(item(itemId))
+        viewModel.onItemFocusPipeline(item(otherId))
+        delay(HomeViewModel.EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS + 400)
+        assertEquals("the cancelled focus should not have fetched", 0, calls.get())
+
+        focusAndSettle(viewModel, item(itemId))
+
+        awaitCalls(calls, 1, "the item must still be fetchable after a cancelled focus")
+    }
+
+    @Test
+    fun `an exception thrown by the repository is retried`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = newMetaRepository()
+        coEvery { repository.getMetaFromAllAddons(any(), eq(itemId), eq(sourceUrl)) } answers {
+            calls.incrementAndGet()
+            throw IllegalStateException("boom")
+        }
+        val viewModel = newViewModel(repository)
+        viewModel.seedCatalog(item(itemId))
+
+        viewModel.onItemFocusPipeline(item(itemId))
+        awaitCalls(calls, 1, "the first focus should have attempted one fetch")
+
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        awaitCalls(calls, 2, "a thrown exception should be retried like any other failure")
+        assertTrue(
+            "a thrown exception must not be cached as a resolved lookup",
+            itemId !in viewModel.prefetchedExternalMetaIds
+        )
+    }
+
+    /**
+     * The inverse of the test above, pinning the asymmetry rather than leaving it to be
+     * rediscovered: a cached external result closes the gate even when TMDB has not run. TMDB is
+     * only ever marked prefetched on a successful enrichment, so gating on it as well would
+     * re-enter on every focus for any item TMDB has no match for.
+     */
+    @Test
+    fun `a cached external result does not reopen the gate for TMDB`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = metaRepository(calls, java.util.concurrent.atomic.AtomicBoolean(true), AtomicInteger())
+        val tmdbService = mockk<TmdbService>(relaxed = true) {
+            coEvery { ensureTmdbId(any(), any()) } returns "1399"
+        }
+        val tmdbMetadataService = mockk<TmdbMetadataService>(relaxed = true) {
+            coEvery { fetchEnrichment(any(), any(), any()) } returns mockk<TmdbEnrichment>(relaxed = true)
+        }
+        val viewModel = newViewModel(repository, tmdbService, tmdbMetadataService)
+        viewModel.currentTmdbSettings = TmdbSettings(enabled = true, modernHomeEnabled = true)
+        viewModel.prefetchedExternalMetaIds.add(itemId)
+        viewModel.seedCatalog(item(itemId))
+
+        focusAndSettle(viewModel, item(itemId))
+
+        assertEquals("external already resolved, so it is not fetched again", 0, calls.get())
+        coVerify(exactly = 0) { tmdbMetadataService.fetchEnrichment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `external enrichment disabled means a TMDB-prefetched item does no external work`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = metaRepository(calls, java.util.concurrent.atomic.AtomicBoolean(true), AtomicInteger())
+        val viewModel = newViewModel(repository)
+        viewModel.externalMetaPrefetchEnabled = false
+        viewModel.prefetchedTmdbIds.add(itemId)
+        viewModel.seedCatalog(item(itemId))
+
+        focusAndSettle(viewModel, item(itemId))
+
+        assertEquals("external enrichment is off, so nothing should be fetched", 0, calls.get())
+    }
+
+    @Test
+    fun `an addon reporting nothing to add is not retried`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = newMetaRepository()
+        coEvery { repository.getMetaFromAllAddons(any(), eq(itemId), eq(sourceUrl)) } answers {
+            calls.incrementAndGet()
+            flowOf(NetworkResult.Error("source sufficient", NetworkResult.SOURCE_SUFFICIENT_CODE))
+        }
+        val viewModel = newViewModel(repository)
+
+        focusAndSettle(viewModel, item(itemId))
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        assertEquals("a final answer must not be refetched", 1, calls.get())
+    }
+
+    @Test
+    fun `an item no addon carries is not retried`() = runBlocking {
+        val calls = AtomicInteger()
+        val repository = newMetaRepository()
+        coEvery { repository.getMetaFromAllAddons(any(), eq(itemId), eq(sourceUrl)) } answers {
+            calls.incrementAndGet()
+            flowOf(NetworkResult.Error("not found", NetworkResult.META_NOT_FOUND_CODE))
+        }
+        val viewModel = newViewModel(repository)
+
+        focusAndSettle(viewModel, item(itemId))
+        focusAndSettle(viewModel, item(otherId))
+        focusAndSettle(viewModel, item(itemId))
+
+        assertEquals("a not-found answer must not be refetched", 1, calls.get())
+    }
+
+    private suspend fun focusAndSettle(viewModel: HomeViewModel, item: MetaPreview) {
+        viewModel.onItemFocusPipeline(item)
+        // Debounce plus the fetch itself; the assertions that need a specific count poll instead.
+        delay(HomeViewModel.EXTERNAL_META_PREFETCH_FOCUS_DEBOUNCE_MS + 400)
+    }
+
+    /**
+     * The pipeline debounces by 220ms and then fetches on Dispatchers.IO, so the count is polled
+     * rather than sampled after a fixed wait.
+     */
+    private suspend fun awaitCalls(calls: AtomicInteger, expected: Int, what: String) {
+        val reached = runCatching {
+            withTimeout(5_000) {
+                while (calls.get() < expected) delay(25)
+            }
+        }.isSuccess
+        assertEquals(what, expected, if (reached) expected else calls.get())
+    }
+
+    /**
+     * The background detail prefetch calls the same method with the parameter's default. It is not
+     * counted, but it still needs a flow that terminates, or its first {} throws into the view
+     * model scope and kotlinx-coroutines-test reports it against the next test to run.
+     */
+    private fun newMetaRepository(backgroundCalls: AtomicInteger = AtomicInteger()): MetaRepository =
+        mockk(relaxed = true) {
+            coEvery { getMetaFromAllAddons(any(), any(), isNull()) } answers {
+                backgroundCalls.incrementAndGet()
+                flowOf(NetworkResult.Error("background prefetch, not part of this test"))
+            }
+        }
+
+    private fun metaRepository(
+        calls: AtomicInteger,
+        reachable: java.util.concurrent.atomic.AtomicBoolean,
+        backgroundCalls: AtomicInteger
+    ): MetaRepository = newMetaRepository(backgroundCalls).apply {
+        coEvery { getMetaFromAllAddons(any(), eq(itemId), eq(sourceUrl)) } answers {
+            calls.incrementAndGet()
+            if (reachable.get()) {
+                flowOf(NetworkResult.Success(meta()))
+            } else {
+                flowOf(NetworkResult.Error("Failed to connect"))
+            }
+        }
+    }
+
+    private fun meta() = Meta(
+        id = itemId,
+        type = ContentType.SERIES,
+        name = "Test Item",
+        poster = null,
+        posterShape = PosterShape.POSTER,
+        background = null,
+        logo = null,
+        description = ENRICHED_DESCRIPTION,
+        releaseInfo = null,
+        imdbRating = 8.5f,
+        genres = listOf("Drama"),
+        runtime = null,
+        director = emptyList(),
+        cast = emptyList(),
+        videos = emptyList(),
+        country = null,
+        awards = null,
+        language = null,
+        links = emptyList()
+    )
+
+    /**
+     * updateCatalogItemWithMeta publishes through findCatalogItemById, so an item that is not in
+     * the catalog index enriches its bookkeeping but never its preview.
+     */
+    private fun HomeViewModel.seedCatalog(item: MetaPreview) {
+        synchronized(catalogStateLock) {
+            val rowKey = "seeded-row"
+            catalogsMap[rowKey] = CatalogRow(
+                addonId = "test.addon",
+                addonName = "Test Addon",
+                addonBaseUrl = sourceUrl,
+                catalogId = "test.catalog",
+                catalogName = "Test Catalog",
+                type = ContentType.SERIES,
+                items = listOf(item)
+            )
+            catalogItemKeyIndex.getOrPut(item.id) { mutableSetOf() }.add(rowKey)
+        }
+    }
+
+    private fun item(id: String) = MetaPreview(
+        id = id,
+        type = ContentType.SERIES,
+        name = "Test Item",
+        poster = null,
+        posterShape = PosterShape.POSTER,
+        background = null,
+        logo = null,
+        description = null,
+        releaseInfo = null,
+        imdbRating = null,
+        genres = emptyList(),
+        sourceAddonBaseUrl = sourceUrl
+    )
+
+    private fun newViewModel(
+        metaRepository: MetaRepository,
+        tmdbService: TmdbService = mockk(relaxed = true),
+        tmdbMetadataService: TmdbMetadataService = mockk(relaxed = true)
+    ): HomeViewModel {
+        // Relaxed mocks hand back flows that complete without emitting, and the pipeline calls
+        // first {} on several of them from launches that do not catch. Those throw
+        // NoSuchElementException into the view model scope, which kotlinx-coroutines-test then
+        // reports against whichever test runs next. Stub the ones this pipeline touches.
+        val profileManager = mockk<com.nuvio.tv.core.profile.ProfileManager>(relaxed = true) {
+            // Never ready, so the init chain parks instead of running the whole home pipeline.
+            every { activeProfileReady } returns MutableStateFlow(false)
+            every { activeProfileId } returns MutableStateFlow(1)
+        }
+        val cwEnrichmentCache =
+            mockk<com.nuvio.tv.data.local.ContinueWatchingEnrichmentCache>(relaxed = true) {
+                every { cacheCleared } returns MutableStateFlow(0)
+            }
+        val watchProgressRepository =
+            mockk<com.nuvio.tv.domain.repository.WatchProgressRepository>(relaxed = true) {
+                every { getAllEpisodeProgress(any()) } returns flowOf(emptyMap())
+            }
+        val viewModel = HomeViewModel(
+            appContext = mockk(relaxed = true),
+            addonRepository = mockk(relaxed = true),
+            startupSyncService = mockk(relaxed = true),
+            catalogRepository = mockk(relaxed = true),
+            watchProgressRepository = watchProgressRepository,
+            libraryRepository = mockk(relaxed = true),
+            metaRepository = metaRepository,
+            collectionsDataStore = mockk(relaxed = true),
+            layoutPreferenceDataStore = mockk(relaxed = true),
+            playerSettingsDataStore = mockk(relaxed = true),
+            tmdbSettingsDataStore = mockk(relaxed = true),
+            mdbListSettingsDataStore = mockk(relaxed = true),
+            traktSettingsDataStore = mockk(relaxed = true),
+            authSessionNoticeDataStore = mockk(relaxed = true),
+            tmdbService = tmdbService,
+            tmdbMetadataService = tmdbMetadataService,
+            mdbListRepository = mockk(relaxed = true),
+            trailerService = mockk(relaxed = true),
+            watchedSeriesStateHolder = mockk(relaxed = true),
+            cwEnrichmentCache = cwEnrichmentCache,
+            profileManager = profileManager,
+            tvRecommendationManager = mockk(relaxed = true)
+        )
+        // The pipeline defers everything while the startup grace period is active, and TMDB is
+        // switched off so the external addon is the only enrichment source under test.
+        viewModel.startupGracePeriodActive = false
+        viewModel.externalMetaPrefetchEnabled = true
+        viewModel.currentTmdbSettings = TmdbSettings(enabled = false)
+        created += viewModel
+        return viewModel
+    }
+
+    private companion object {
+        const val ENRICHED_DESCRIPTION = "Enriched from the addon"
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRetryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/HomeEnrichmentRetryTest.kt
@@ -216,6 +216,29 @@ class HomeEnrichmentRetryTest {
         )
     }
 
+    @Test
+    fun `the failed-enrichment set is cleared on success and stays bounded`() = runBlocking {
+        val viewModel = newViewModel(newMetaRepository())
+
+        viewModel.markEnrichmentFailed(itemId)
+        assertTrue("a failure should be recorded", itemId in viewModel.failedEnrichmentIds.value)
+
+        viewModel.clearEnrichmentFailure(itemId)
+        assertTrue(
+            "enrichment landing should drop the marker",
+            itemId !in viewModel.failedEnrichmentIds.value
+        )
+
+        // One past the bound: the oldest entry is dropped, the newest is kept.
+        repeat(65) { viewModel.markEnrichmentFailed("id-$it") }
+        assertEquals(64, viewModel.failedEnrichmentIds.value.size)
+        assertTrue("the oldest entry should be evicted", "id-0" !in viewModel.failedEnrichmentIds.value)
+        assertTrue("the newest entry should be kept", "id-64" in viewModel.failedEnrichmentIds.value)
+
+        viewModel.clearEnrichmentFailures()
+        assertTrue("a reset should empty the set", viewModel.failedEnrichmentIds.value.isEmpty())
+    }
+
     /**
      * The inverse of the test above, pinning the asymmetry rather than leaving it to be
      * rediscovered: a cached external result closes the gate even when TMDB has not run. TMDB is


### PR DESCRIPTION
## Summary

- Retry external metadata enrichment after a request failure.
- Cache terminal source-sufficient and not-found results.
- Bound and clear `_failedEnrichmentIds`.
- Stop rebuilding `catalogRows` for metadata enrichment in the modern layout.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

When an external metadata addon was unavailable, Home marked the item prefetched even though the request had failed. Later focuses skipped the request, leaving the item un-enriched for the lifetime of the `HomeViewModel` unless the app was restarted or the entry aged out of the 64-item cache.

The repository already tracked whether each addon reported "not found" or a request failure, but lost that distinction in the aggregate result. It now returns `META_NOT_FOUND_CODE` only when every eligible addon was attempted and none had the item.

The pipeline treats the outcomes as:

- metadata resolved: mark prefetched
- source already sufficient: mark prefetched
- not found by every eligible addon: mark prefetched
- request failed: leave unprefetched so the next focus retries

TMDB and external metadata are gated independently. A TMDB success no longer prevents an outstanding external request, and resolved TMDB metadata is not refetched.

## Issue or approval

Fixes #3307

## Reproduction steps

Requires separate catalog and metadata addons. If one addon provides both, the lookup returns `SOURCE_SUFFICIENT_CODE` before making the request.

1. Load Home with both addons available.
2. Stop the metadata addon, leaving the app running.
3. Focus an un-enriched item.
4. Start the metadata addon again.
5. Focus the same item.

Before this change, the second focus skipped the request. After it, the item retries and enriches.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

No layout or design change. The user-visible behavior changes because that is the bug: metadata that previously stayed missing now appears after a successful retry.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR includes:

- `_failedEnrichmentIds` was never cleared and grew for the lifetime of the ViewModel. It is now bounded to 64 entries, matching the caches beside it, and cleared when enrichment succeeds or those caches reset.
- `updateCatalogItemWithMeta` rebuilt the whole `catalogRows` tree after each enrichment. Modern Home reads `enrichedPreviews` and `lastEnrichedPreview` instead, so it now skips the rebuild, matching `updateCatalogItemWithTmdb` beside it. Classic and grid keep the existing path.

Not changed:

- No retry backoff. A failing addon is requested again whenever the user leaves and refocuses an item; `externalMetaPrefetchInFlightIds` prevents concurrent duplicates.
- TMDB failures are not retried. The external gate reopens after failure, while TMDB is marked prefetched only on success. Gating on TMDB too would refetch on every focus for items with no TMDB match.
- `updateCatalogItemImdbRating` and `updateCatalogItemArtworkOnly` still rebuild `catalogRows`; they have no enriched-preview path.
- `preloadAdjacentItemPipeline` keeps its own combined early return. Adjacent prefetch remains opportunistic; the focused path handles outstanding enrichment.

## Testing

**Unit tests:** Eighteen new tests across three classes covering repository classification, retry behaviour, TMDB/external interaction, terminal outcomes, failure-set lifecycle, and in-flight bookkeeping across a cancelled focus.

`HomeEnrichmentRepositoryBoundaryTest` runs the real `MetaRepositoryImpl` against a mocked `AddonApi`, verifying that a transport failure reaches the pipeline as retryable rather than being mocked on both sides.

Full suite on this branch: 1074 tests, 13 failures. The same 13 fail on `dev` before these changes, where the suite has 1056 tests. All are in unrelated player, Trakt/Simkl, and Matroska classes.

**On-device, Nvidia Shield Pro (2019):** outage and recovery reproduced end to end. Catalogs came from an addon declaring only a `catalog` resource, so it is not a meta candidate, and metadata from a separate addon declaring only `meta`, each in its own container so the metadata one could be stopped on demand.

With the metadata addon stopped, moving across several un-enriched items logged `Meta fetch failed ... Failed to connect` for each, and refocusing them while it was still stopped issued further requests. Before this change the first failure marks the item prefetched and no later request is made at all. Restarting the addon and refocusing produced `Meta fetch success` for every item touched during the outage, including the ones only passed over, and the metadata appeared without restarting the app.

Modern and Classic layouts were also checked after enrichment, including long-row scrolling and layout switching.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. `META_NOT_FOUND_CODE` is a new sentinel on `NetworkResult`; callers that ignore `code` are unaffected.

## Linked issues

Fixes #3307