### PR TITLE
Fix external player result handling on Zidoo devices

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -328,7 +328,8 @@ class ExternalPlaybackTracker @Inject constructor(
 
         Log.d(TAG, "Started tracking: content=${metadata.contentId}, video=${metadata.videoId}")
 
-        // On Zidoo devices, start REST API polling
+        // Zidoo's built-in player does not return ActivityResult data, so keep its REST monitor
+        // running as a fallback. Third-party players on the same device still use ActivityResult.
         if (ZidooPlayerMonitor.isZidooDevice()) {
             startZidooMonitor(metadata, startFromBeginning)
         }
@@ -344,7 +345,8 @@ class ExternalPlaybackTracker @Inject constructor(
      */
     /**
      * Launch external player with progress tracking.
-     * Uses the Activity-level launcher for ActivityResult, or fire-and-forget on Zidoo.
+     * Uses the Activity-level launcher for ActivityResult. Zidoo's REST monitor runs separately
+     * as a fallback for its built-in player, without bypassing results from third-party players.
      * If resumePositionMs is 0, fetches the saved position from the repository.
      *
      * @param metadata Content metadata for progress saving
@@ -509,41 +511,17 @@ class ExternalPlaybackTracker @Inject constructor(
             skipSegmentsJson = skipSegmentsJson
         )
 
-        if (ZidooPlayerMonitor.isZidooDevice()) {
-            // Zidoo doesn't return ActivityResult - use fire-and-forget
-            return ExternalPlayerLauncher.launch(
-                context = context,
-                url = url,
-                title = title,
-                headers = headers,
-                resumePositionMs = resumePositionMs,
-                startFromBeginning = startFromBeginning,
-                subtitles = subtitles,
-                skipSegmentsJson = skipSegmentsJson
-            )
-        } else {
-            // Use Activity-level launcher for ActivityResult
-            val launcher = activityLauncher
-            if (launcher != null) {
-                return try {
-                    launcher.launch(input)
-                    true
-                } catch (e: Exception) {
-                    Log.w(TAG, "ActivityResultLauncher failed, falling back to fire-and-forget", e)
-                    ExternalPlayerLauncher.launch(
-                        context = context,
-                        url = url,
-                        title = title,
-                        headers = headers,
-                        resumePositionMs = resumePositionMs,
-                        startFromBeginning = startFromBeginning,
-                        subtitles = subtitles,
-                        skipSegmentsJson = skipSegmentsJson
-                    )
-                }
-            } else {
-                Log.w(TAG, "No activityLauncher registered, using fire-and-forget")
-                return ExternalPlayerLauncher.launch(
+        // Always prefer ActivityResult, including on Zidoo hardware. A Zidoo may launch Vimu,
+        // Just Player, or another third-party player that does return progress. Treating the
+        // device itself as the player bypasses that contract and loses resume updates (#3269).
+        val launcher = activityLauncher
+        if (launcher != null) {
+            return try {
+                launcher.launch(input)
+                true
+            } catch (e: Exception) {
+                Log.w(TAG, "ActivityResultLauncher failed, falling back to fire-and-forget", e)
+                ExternalPlayerLauncher.launch(
                     context = context,
                     url = url,
                     title = title,
@@ -555,6 +533,18 @@ class ExternalPlaybackTracker @Inject constructor(
                 )
             }
         }
+
+        Log.w(TAG, "No activityLauncher registered, using fire-and-forget")
+        return ExternalPlayerLauncher.launch(
+            context = context,
+            url = url,
+            title = title,
+            headers = headers,
+            resumePositionMs = resumePositionMs,
+            startFromBeginning = startFromBeginning,
+            subtitles = subtitles,
+            skipSegmentsJson = skipSegmentsJson
+        )
     }
 
     // ===================== External-player result handling =====================

--- a/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/ExternalPlaybackTracker.kt
@@ -206,6 +206,7 @@ class ExternalPlaybackTracker @Inject constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var zidooMonitorJob: Job? = null
+    private var awaitingExternalPlayerResult = false
     // Armed only when the loader is raised on return from a persisted (process-recreated) session,
     // where onActivityResult may never fire because the external player killed us and left no
     // pending result. If the result does not arrive within STALE_RETURN_WATCHDOG_MS the session is
@@ -296,6 +297,7 @@ class ExternalPlaybackTracker @Inject constructor(
         // A fresh launch supersedes any dead-session recovery still being watched for.
         staleReturnWatchdogJob?.cancel()
         staleReturnWatchdogJob = null
+        awaitingExternalPlayerResult = true
         pendingMetadata = metadata
         pendingCloudSessionToken = cloudSessionToken
         isAutoLaunch = autoLaunch
@@ -520,6 +522,7 @@ class ExternalPlaybackTracker @Inject constructor(
                 launcher.launch(input)
                 true
             } catch (e: Exception) {
+                awaitingExternalPlayerResult = false
                 Log.w(TAG, "ActivityResultLauncher failed, falling back to fire-and-forget", e)
                 ExternalPlayerLauncher.launch(
                     context = context,
@@ -534,6 +537,7 @@ class ExternalPlaybackTracker @Inject constructor(
             }
         }
 
+        awaitingExternalPlayerResult = false
         Log.w(TAG, "No activityLauncher registered, using fire-and-forget")
         return ExternalPlayerLauncher.launch(
             context = context,
@@ -552,6 +556,7 @@ class ExternalPlaybackTracker @Inject constructor(
     /** Entry point for the player's ActivityResult: recover metadata, backfill a missing
      *  duration if needed, save progress, and auto-advance on completion. */
     fun onActivityResult(result: ExternalPlayerResult?) {
+        awaitingExternalPlayerResult = false
         // The result arrived, so this is a live session, not a dead one — stand down the watchdog
         // before it can clear the persisted copy out from under the recovery below.
         staleReturnWatchdogJob?.cancel()
@@ -575,11 +580,19 @@ class ExternalPlaybackTracker @Inject constructor(
         if (result == null) {
             Log.d(TAG, "External player returned no progress data")
             _autoNextOverlay.value = null
+            // The native Zidoo player can return before the monitor detects its final position.
+            // Keep the session until that active fallback finishes, including its persisted copy.
+            if (zidooMonitorJob?.isActive == true) {
+                return
+            }
             clearPersistedMetadata()
-            // On Zidoo, the monitor job handles progress - don't stop it prematurely.
-            if (!ZidooPlayerMonitor.isZidooDevice()) stopTracking()
+            stopTracking()
             return
         }
+
+        // A real player result takes precedence over REST polling, even during duration backfill.
+        zidooMonitorJob?.cancel()
+        zidooMonitorJob = null
 
         // Covers process recreation, where onStart could not use in-memory state. At this point
         // the result is available, so only a completion may claim the transition loader.
@@ -1260,6 +1273,7 @@ class ExternalPlaybackTracker @Inject constructor(
     fun stopTracking() {
         zidooMonitorJob?.cancel()
         zidooMonitorJob = null
+        awaitingExternalPlayerResult = false
         pendingMetadata = null
         pendingCloudSessionToken = null
         isAutoLaunch = false
@@ -1282,17 +1296,25 @@ class ExternalPlaybackTracker @Inject constructor(
         startFromBeginning: Boolean
     ) {
         zidooMonitorJob?.cancel()
-        zidooMonitorJob = scope.launch(Dispatchers.Default) {
-            val resumePosition = if (startFromBeginning) 0L else getResumePosition(metadata)
+        zidooMonitorJob = scope.launch {
+            val resumePosition = if (startFromBeginning) 0L else withContext(Dispatchers.Default) {
+                getResumePosition(metadata)
+            }
             val result = ZidooPlayerMonitor.awaitPlaybackEnd(resumePositionMs = resumePosition)
+            // State changes run on Main with ActivityResult; the monitor's HTTP requests use IO.
+            if (pendingMetadata !== metadata) return@launch
+            zidooMonitorJob = null
+            if (result == null && awaitingExternalPlayerResult) {
+                Log.d(TAG, "No Zidoo playback detected; waiting for the external player's result")
+                return@launch
+            }
             if (result != null) {
                 Log.d(TAG, "Zidoo monitor: pos=${result.positionMs}ms, dur=${result.durationMs}ms")
                 saveProgress(metadata, result.positionMs, result.durationMs)
             }
-            // Don't call stopTracking here - let the ActivityResult path handle it
-            // (on Zidoo, ActivityResult won't fire, so we stop after saving)
-            pendingMetadata = null
-            ExternalPlaybackKeepAliveService.stop(appContext)
+            clearPersistedMetadata()
+            _autoNextOverlay.value = null
+            stopTracking()
         }
     }
 


### PR DESCRIPTION
## Summary

Restore ActivityResult-based external-player launches on Zidoo devices so third-party players such as Vimu and Just Player can return playback progress. Keep the native Zidoo REST monitor as a fallback without letting an empty probe discard a third-party session.

Updated universal full-debug APK: https://gofile.io/d/U0oeVlt8

Built from commit `7416f05d6`. Replaces the earlier test APK.

SHA-256: `DAF6CE9AAB05CAB0CAC7AD5685D83A5C50E83F260CB3FB4C9522F010E8778163`

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Nuvio selected fire-and-forget mode for every external player on Zidoo hardware, bypassing the result contract supported by Vimu and Just Player. This prevents returned positions from updating resume progress as reported in #3269.

Review also identified lifecycle interactions that must be addressed when restoring results:

- An empty REST probe must retain pending metadata and keep-alive while a third-party result is expected.
- A valid ActivityResult must cancel REST polling before asynchronous duration backfill can race with it.
- A null ActivityResult must preserve the pending session until an active native monitor finishes.
- Native completion, an empty return after probe expiry, and fire-and-forget fallback must clean up without waiting for a callback that cannot arrive.

The monitor now updates session state on Main alongside ActivityResult handling; its HTTP requests still run on IO. A replaced session cannot be cleared by an older monitor.

## Issue or approval

Fixes #3269

## Reproduction steps

1. On a Zidoo device such as the reported Z9S running Android 7.1, select Vimu or Just Player as the external player.
2. Start a movie or episode, play beyond the initial position, and return to Nuvio.
3. Before this fix, the Zidoo-specific fire-and-forget launch bypasses the returned playback position.
4. With the test build, check that returning updates progress and reopening offers the saved position.
5. Leave the third-party player running for at least a minute before returning, so the native REST probe can expire. Repeat with both players, and check native Zidoo playback if available.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `ExternalPlaybackTracker.kt` changes. External-player intent extras, headers, subtitles, player selection, resume calculation, and the non-Zidoo launch route remain unchanged. Native Zidoo REST endpoints and polling behavior are unchanged; only the tracker's fallback lifecycle is corrected. No UI, dependencies, configuration migration, or test files are included.

## Testing

- Full-debug Kotlin compilation and `:app:assembleFullDebug` passed for the updated code.
- Existing external auto-next and updater unit tests: 44 passed.
- A temporary local-only MockK/coroutine harness: 12 passed. It covers probe expiry, late valid results, null callbacks before and after polling, native completion without a result, duration-backfill cancellation, replacing a session, non-Zidoo cleanup, ActivityResult routing, missing launchers, and throwing launchers. This harness lives outside the repository and is not included in the PR or APK.
- Combined run: 56 tests, zero failures, zero skipped.
- `git diff --check` passed. Both intent-building source files are unchanged from the base revision.
- The earlier broad full-debug suite run on the initial patch reported 1,064 passes, 14 failures, and one skipped test. Those failures were outside the edited tracker, including Dolby Vision, MKV probing, Trakt, collections, and performance helpers; no clean-baseline comparison was performed, so this is not a claim that the entire suite passes.
- No physical Z9S testing has been performed. This remains a draft awaiting device confirmation; successful builds and local tests do not verify vendor-specific player behavior.

## Screenshots / Video

Not a UI change.

## Breaking changes

None intended. No configuration or schema changes.

## Linked issues

Fixes #3269
