### PR TITLE
Fix HLS rendition fallback after media-segment 404

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactory.kt
@@ -3,6 +3,7 @@ package com.nuvio.tv.ui.screens.player
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.datasource.DataSource
@@ -744,6 +745,32 @@ private inline fun <reified T : Throwable> Throwable.findCause(): T? {
 }
 
 private class PlayerLoadErrorHandlingPolicy : DefaultLoadErrorHandlingPolicy(6) {
+    override fun getFallbackSelectionFor(
+        fallbackOptions: LoadErrorHandlingPolicy.FallbackOptions,
+        loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo
+    ): LoadErrorHandlingPolicy.FallbackSelection? {
+        val responseCode = loadErrorInfo.exception
+            .findCause<androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException>()
+            ?.responseCode
+        if (
+            shouldPreferAlternativeHlsTrack(
+                responseCode = responseCode,
+                dataType = loadErrorInfo.mediaLoadData.dataType,
+                alternativeTrackAvailable = fallbackOptions.isFallbackAvailable(
+                    LoadErrorHandlingPolicy.FALLBACK_TYPE_TRACK
+                )
+            )
+        ) {
+            // A media-segment 404 belongs to the selected rendition. Exclude that
+            // rendition first so HLS can continue with another compatible track.
+            return LoadErrorHandlingPolicy.FallbackSelection(
+                LoadErrorHandlingPolicy.FALLBACK_TYPE_TRACK,
+                DefaultLoadErrorHandlingPolicy.DEFAULT_TRACK_EXCLUSION_MS
+            )
+        }
+        return super.getFallbackSelectionFor(fallbackOptions, loadErrorInfo)
+    }
+
     override fun getRetryDelayMsFor(loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo): Long {
         val httpException = loadErrorInfo.exception.findCause<androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException>()
         if (httpException != null) {
@@ -762,3 +789,12 @@ private class PlayerLoadErrorHandlingPolicy : DefaultLoadErrorHandlingPolicy(6) 
         } else super.getRetryDelayMsFor(loadErrorInfo)
     }
 }
+
+internal fun shouldPreferAlternativeHlsTrack(
+    responseCode: Int?,
+    dataType: Int,
+    alternativeTrackAvailable: Boolean
+): Boolean =
+    responseCode == 404 &&
+        dataType == C.DATA_TYPE_MEDIA &&
+        alternativeTrackAvailable

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerMediaSourceFactoryTest.kt
@@ -1,13 +1,44 @@
 package com.nuvio.tv.ui.screens.player
 
+import androidx.media3.common.C
 import androidx.media3.common.MimeTypes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Base64
 
 class PlayerMediaSourceFactoryTest {
+
+    @Test
+    fun `media segment 404 with an alternative prefers another HLS track`() {
+        assertTrue(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                dataType = C.DATA_TYPE_MEDIA,
+                alternativeTrackAvailable = true
+            )
+        )
+    }
+
+    @Test
+    fun `manifest errors and missing alternatives do not trigger rendition fallback`() {
+        assertFalse(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                dataType = C.DATA_TYPE_MANIFEST,
+                alternativeTrackAvailable = true
+            )
+        )
+        assertFalse(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                dataType = C.DATA_TYPE_MEDIA,
+                alternativeTrackAvailable = false
+            )
+        )
+    }
 
     @Test
     fun `inferMimeType prefers response content type for manifest urls without extension`() {


### PR DESCRIPTION
## Summary
Prefer track fallback when an HLS media segment returns HTTP 404 and another rendition is available. The policy also recognizes an HTTP response error wrapped by the data source, allowing Media3 to exclude the failing rendition instead of ending playback.

## PR type
- [x] Critical bug fix

## Why
A rendition-local segment 404 can currently become fatal even though the HLS master playlist has a playable alternative. This restores the expected recovery behavior.

## Issue or approval
Fixes #3316

## Reproduction steps
1. Start internal-player playback from an HLS master playlist with multiple compatible variants.
2. Make the active rendition return HTTP 404 for a media segment while another rendition remains available.
3. Before: playback ends with an error. After: Media3 excludes the failing rendition and selects an alternative.

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Only HLS media-segment 404 fallback selection is changed. Manifest errors and streams without an alternative rendition remain on the existing error path.

## Testing
`./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.ui.screens.player.PlayerMediaSourceFactoryTest --no-daemon` (passed: 15 tests).

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #3316