### PR TITLE
Fix MPV player stuck at EOF + profile selection gradient jank

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -171,6 +171,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         return mpv.getPropertyBoolean("core-idle") == true
     }
 
+    fun isEofReached(): Boolean {
+        if (!initialized) return false
+        return mpv.getPropertyBoolean("eof-reached") == true
+    }
+
     fun seekToMs(positionMs: Long) {
         if (!initialized) return
         val seconds = (positionMs.coerceAtLeast(0L) / 1000.0)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -227,7 +227,8 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         isPlaying = playingForWatchClock
                     )
                     val nearEnd = playerDuration > 0L && pos >= (playerDuration - 500L)
-                    val naturalEnded = !view.isLiveStreamNow() && nearEnd && shouldTreatAsNaturalPlaybackCompletion(
+                    val mpvEofReached = view.isEofReached()
+                    val naturalEnded = !view.isLiveStreamNow() && (nearEnd || mpvEofReached) && shouldTreatAsNaturalPlaybackCompletion(
                         hasRenderedFirstFrame = firstFrameReady,
                         hasFatalError = !_uiState.value.error.isNullOrBlank(),
                         durationMs = playerDuration
@@ -236,7 +237,7 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     _uiState.update { state ->
                         state.copy(
                             isPlaying = playingNow,
-                            isBuffering = !firstFrameReady || cacheBuffering,
+                            isBuffering = if (naturalEnded) false else (!firstFrameReady || cacheBuffering),
                             showLoadingOverlay = if (state.loadingOverlayEnabled) !firstFrameReady else false,
                             // Snap the loading-logo fill to 100% once playback is
                             // ready so the logo finishes filling on dismissal.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationState.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationState.kt
@@ -60,7 +60,7 @@ data class PostPlayRecommendationUiState(
         get() = isVisible && !isTrailerPlaying && !hasAutoPlayedTrailer
 
     val blocksNaturalCompletion: Boolean
-        get() = recommendation != null || isVisible || hasReturnedToPlayer || isLoadingRecommendation
+        get() = isVisible || (isLoadingRecommendation && !hasReturnedToPlayer)
 }
 
 internal fun PostPlayRecommendationUiState.returnToPlayer(): PostPlayRecommendationUiState {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalContext
@@ -792,6 +793,7 @@ private fun ProfileSelectionBackground(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
                         .background(
                             brush = Brush.verticalGradient(
                                 colorStops = arrayOf(


### PR DESCRIPTION
## Summary

Two fixes:
1. Profile selection background gradient caused jank when opening profile options -> added offscreen compositing.
2. MPV player stuck on last frame after playback ended -> player never closed.

MPV fix has three parts:
- Added `eof-reached` property read from MPV. With `keep-open=yes`, position can stop ~38ms before duration, so `nearEnd` heuristic alone missed EOF. `eof-reached` is a reliable signal.
- Force `isBuffering = false` when `naturalEnded` is true. MPV reports `paused-for-cache=true` at EOF (demuxer waiting for data that never comes), which made the UI show a spinner.
- `PostPlayRecommendationState.blocksNaturalCompletion` no longer blocks after user returned to player from post-play overlay. Previously `hasReturnedToPlayer` and `recommendation != null` kept blocking, so the player never dispatched natural completion.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

- Profile options dialog had poor frame rate on low-end Android TV due to full-screen animated gradient without offscreen compositing -> overdraw on every animation frame.
- MPV player hung indefinitely at the end of playback. User had to force-close. The combination of `keep-open=yes`, position not reaching the `duration - 500ms` threshold, and post-play state blocking natural completion meant the player never exited.

## Issue or approval

No linked issue - found during internal testing.

## Reproduction steps

Bug 1 (profile jank):
1. Open profile selection screen
2. Click on a profile avatar to open options
3. Observe dropped frames / sluggish animation

Bug 2 (MPV stuck):
1. Play any content using the MPV engine
2. Let playback reach the end naturally
3. If post-play recommendation appears, press back to return to player
4. Let the remaining seconds play out
5. Player hangs on the last frame, never closes

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only MPV engine affected. ExoPlayer end-of-playback path untouched - `eof-reached` read is inside the `isUsingMpvEngine()` branch.
- `keep-open=yes` option left as is - it's needed for other functionality.
- Post-play `blocksNaturalCompletion` change: only removes `hasReturnedToPlayer` and `recommendation != null` from the blocking condition. `isVisible` still blocks (user must interact with visible overlay). `isLoadingRecommendation` still blocks on first load but not after return.
- Profile gradient: only the null-background (no custom image) branch gets offscreen compositing. Catalog/custom background images unaffected.

## Testing

- TCL Android TV
- MPV engine: played content to natural end -> player closed correctly
- MPV engine: post-play appeared -> pressed back -> let remaining seconds finish -> player closed correctly
- MPV engine: post-play appeared -> selected recommendation -> navigated correctly
- ExoPlayer engine: played to end -> no regression, closes as before
- Profile selection: opened profile options dialog -> smooth animation, no jank

## Screenshots / Video

Not a UI change - fixes performance glitch and stuck player behavior.

## Breaking changes

None.

## Linked issues

No linked issue - found during internal testing.
