### PR TITLE
Fix Home apply enrichment to the rows classic renders

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelPresentationPipeline.kt
@@ -739,6 +739,64 @@ internal fun HomeViewModel.preloadAdjacentItemPipeline(item: MetaPreview) {
     }
 }
 
+/**
+ * Applies enrichment to the collections consumed by the non-modern layouts.
+ *
+ * [transform] must be pure and idempotent: _uiState.update can retry, and the item is merged in
+ * each collection independently.
+ */
+private fun HomeViewModel.applyEnrichmentToDisplayedRows(
+    itemId: String,
+    transform: (MetaPreview) -> MetaPreview
+) {
+    _uiState.update { state ->
+        if (state.homeLayout == HomeLayout.MODERN) return@update state
+        var changed = false
+
+        fun patch(row: com.nuvio.tv.domain.model.CatalogRow): com.nuvio.tv.domain.model.CatalogRow {
+            val index = row.items.indexOfFirst { it.id == itemId }
+            if (index < 0) return row
+            val merged = transform(row.items[index])
+            if (merged == row.items[index]) return row
+            changed = true
+            return row.copy(items = row.items.toMutableList().apply { set(index, merged) })
+        }
+
+        val updatedCatalogRows = state.catalogRows.map(::patch)
+        val updatedHomeRows = state.homeRows.map { homeRow ->
+            if (homeRow is HomeRow.Catalog) {
+                val patched = patch(homeRow.row)
+                if (patched === homeRow.row) homeRow else HomeRow.Catalog(patched)
+            } else {
+                homeRow
+            }
+        }
+        val updatedGridItems = state.gridItems.map { gridItem ->
+            if (gridItem is GridItem.Content && gridItem.item.id == itemId) {
+                val merged = transform(gridItem.item)
+                if (merged == gridItem.item) {
+                    gridItem
+                } else {
+                    changed = true
+                    gridItem.copy(item = merged)
+                }
+            } else {
+                gridItem
+            }
+        }
+
+        if (changed) {
+            state.copy(
+                catalogRows = updatedCatalogRows,
+                homeRows = updatedHomeRows,
+                gridItems = updatedGridItems
+            )
+        } else {
+            state
+        }
+    }
+}
+
 private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: TmdbEnrichment) {
     val isModernLayout = _uiState.value.homeLayout == HomeLayout.MODERN
     fun mergeItem(currentItem: MetaPreview): MetaPreview {
@@ -774,28 +832,7 @@ private fun HomeViewModel.updateCatalogItemWithTmdb(itemId: String, enrichment: 
     updateIndexedCatalogItem(itemId, ::mergeItem)
     clearEnrichmentFailure(itemId)
 
-    // Modern layout reads enrichment via enrichedPreviews / lastEnrichedPreview.
-    // Rebuilding catalogRows here triggers a useless full-home recomposition.
-    if (!isModernLayout) {
-        _uiState.update { state ->
-            var changed = false
-            val updatedRows = state.catalogRows.map { row ->
-                val idx = row.items.indexOfFirst { it.id == itemId }
-                if (idx < 0) row
-                else {
-                    val mergedItem = mergeItem(row.items[idx])
-                    if (mergedItem == row.items[idx]) row
-                    else {
-                        changed = true
-                        val mutableItems = row.items.toMutableList()
-                        mutableItems[idx] = mergedItem
-                        row.copy(items = mutableItems)
-                    }
-                }
-            }
-            if (changed) state.copy(catalogRows = updatedRows) else state
-        }
-    }
+    applyEnrichmentToDisplayedRows(itemId, ::mergeItem)
 
     findCatalogItemById(itemId)?.let { enriched ->
         _lastEnrichedPreview.value = enriched
@@ -855,31 +892,7 @@ private fun HomeViewModel.updateCatalogItemWithMeta(itemId: String, meta: Meta) 
     updateIndexedCatalogItem(itemId, ::mergeItem)
     clearEnrichmentFailure(itemId)
 
-    _uiState.update { state ->
-        // Modern layout reads enrichment through enrichedPreviews / lastEnrichedPreview, populated
-        // just below, so rebuilding catalogRows here buys nothing and forces a full-home
-        // recomposition. The layout is read from the state being updated rather than from
-        // _uiState.value beforehand, so a concurrent layout change cannot make this stale.
-        if (state.homeLayout == HomeLayout.MODERN) return@update state
-        var changed = false
-        val updatedRows = state.catalogRows.map { row ->
-            val itemIndex = row.items.indexOfFirst { it.id == itemId }
-            if (itemIndex < 0) {
-                row
-            } else {
-                val mergedItem = mergeItem(row.items[itemIndex])
-                if (mergedItem == row.items[itemIndex]) {
-                    row
-                } else {
-                    changed = true
-                    val mutableItems = row.items.toMutableList()
-                    mutableItems[itemIndex] = mergedItem
-                    row.copy(items = mutableItems)
-                }
-            }
-        }
-        if (changed) state.copy(catalogRows = updatedRows) else state
-    }
+    applyEnrichmentToDisplayedRows(itemId, ::mergeItem)
     findCatalogItemById(itemId)?.let { enriched ->
         _lastEnrichedPreview.value = enriched
         addEnrichedPreview(itemId, enriched)


### PR DESCRIPTION
## Summary

- Update the rows consumed by classic and grid when enrichment changes an item.
- Use the same update path for TMDB and external metadata.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Enrichment updated `uiState.catalogRows`, but classic renders `uiState.homeRows`. `homeRows` is rebuilt separately, so enriched metadata did not reach the card until another operation rebuilt the rows. The same applies to `gridItems`, so the helper updates both.

Modern is unchanged and continues to read enrichment through `enrichedPreviews` and `lastEnrichedPreview`.

## Issue or approval

Fixes #3323 (as discussed in #3308)

## Reproduction steps

Requires a metadata addon returning fields the catalog does not, such as a description.

1. Set the layout to classic and enable focused poster expansion.
2. Load Home, focus an un-enriched item, and wait for enrichment.

Before this change the card keeps the catalog metadata, and the enrichment appears only after switching layout and back. After it, the enriched metadata appears without changing layout.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Both enrichment paths now update the collections consumed by the non-modern layouts. Grid is included because it consumes the same enrichment state.

Not changed:

- Modern item cards. Its presentation pipeline does not rebuild when item content changes, so that is a separate change. Modern's hero reads enrichment directly and is unaffected.
- Classic's focus gradient backdrop, which is captured once when an item takes focus.
- `updateCatalogItemImdbRating` and `updateCatalogItemArtworkOnly`.

## Testing

**Unit tests:** 1100 tests, 15 failures. The same 15 fail on `dev`, in unrelated player, Trakt/Simkl, Matroska and post-play tests.

**Device:** NVIDIA Shield Pro (2019), Android 11.

- Classic with an external metadata addon: description, logo and backdrop update without changing layout.
- Classic with TMDB, metadata addon stopped: artwork and description update from TMDB alone.
- Modern: existing enrichment behaviour unchanged.
- Grid: no visible change, as expected. Its card renders only the poster and the name, and enrichment does not overwrite the poster.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3323