### PR TITLE
Fix Search drop suggestions that do not match the query

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -102,6 +102,8 @@ class SearchViewModel @Inject constructor(
         const val LIVE_SEARCH_DEBOUNCE_MS = 350L
 
         const val MAX_SUGGESTIONS = 8
+        /** Splits titles and queries into words. */
+        private val WORD_SEPARATOR = Regex("[^\\p{L}\\p{N}]+")
         const val MAX_RECENT_SEARCHES = 8
     }
 
@@ -280,6 +282,26 @@ class SearchViewModel @Inject constructor(
         fetchSuggestions(trimmed)
     }
 
+    /** Match rank for [title], lower being better, or null when it does not match [queryLower]. */
+    private fun suggestionRank(title: String, queryLower: String): Int? {
+        val titleLower = title.lowercase()
+        if (titleLower == queryLower) return 0
+        if (titleLower.startsWith(queryLower)) return 1
+        if (titleLower.contains(queryLower)) return 2
+
+        // Allow multi-word matches such as "wolf wall" -> "The Wolf of Wall Street".
+        // Each query word must consume a different title word.
+        val queryWords = queryLower.split(WORD_SEPARATOR).filter { it.isNotEmpty() }
+        if (queryWords.size < 2) return null
+        val unmatchedTitleWords = titleLower.split(WORD_SEPARATOR).filterTo(mutableListOf()) { it.isNotEmpty() }
+        val everyWordMatches = queryWords.all { word ->
+            val index = unmatchedTitleWords.indexOfFirst { it.startsWith(word) }
+            if (index >= 0) unmatchedTitleWords.removeAt(index)
+            index >= 0
+        }
+        return if (everyWordMatches) 3 else null
+    }
+
     private fun fetchSuggestions(query: String) {
         suggestionJob?.cancel()
 
@@ -336,10 +358,11 @@ class SearchViewModel @Inject constructor(
                                 // Push updated suggestions immediately as each addon responds
                                 if (added) {
                                     val sorted = collectedNames
-                                        .sortedWith(
-                                            compareByDescending<String> { it.lowercase().startsWith(queryLower) }
-                                                .thenBy { it.lowercase() }
-                                        )
+                                        .mapNotNull { name ->
+                                            suggestionRank(name, queryLower)?.let { name to it }
+                                        }
+                                        .sortedWith(compareBy({ it.second }, { it.first.lowercase() }))
+                                        .map { it.first }
                                         .take(MAX_SUGGESTIONS)
                                     _uiState.update { it.copy(suggestions = sorted) }
                                 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelSuggestionsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelSuggestionsTest.kt
@@ -38,6 +38,11 @@ import org.junit.Before
 import org.junit.Test
 
 private const val TITLE = "The Wolf of Wall Street"
+private const val SHORT_TITLE = "Wolf"
+
+/** Alphabetically ahead of the wolf titles, so an unfiltered strip shows these first. */
+private const val HYPHENATED_TITLE = "Spider-Man"
+private val CATALOG = listOf("Alpha", "Beasts of No Nation", HYPHENATED_TITLE, SHORT_TITLE, TITLE)
 
 /**
  * Suggestions are pushed to the keyboard's own suggestion strip while the user types, so they
@@ -166,7 +171,70 @@ class SearchViewModelSuggestionsTest {
         assertEquals(emptyList<String>(), viewModel.uiState.value.suggestions)
     }
 
-    private fun newViewModel(): SearchViewModel {
+    // The catalog here ignores the search argument, so every title comes back for every query.
+    @Test
+    fun `titles that do not match the query never reach the strip`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf o"))
+        advanceUntilIdle()
+
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `a query nothing matches leaves the strip empty rather than alphabetical`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("zzz"))
+        advanceUntilIdle()
+
+        assertEquals(emptyList<String>(), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `prefix matches are offered before substring matches`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        // "wolf" is a prefix of one title and appears mid-string in the other.
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+
+        assertEquals(listOf(SHORT_TITLE, TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `words of the query can match separate words of the title`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        // Not a substring of the title, so this only matches word by word.
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf wall"))
+        advanceUntilIdle()
+
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `two query words cannot both match the same title word`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("a al"))
+        advanceUntilIdle()
+
+        assertEquals(emptyList<String>(), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `punctuation in a title does not hide it from a spaced query`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("spider man"))
+        advanceUntilIdle()
+
+        assertEquals(listOf(HYPHENATED_TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    private fun newViewModel(catalogIgnoresQuery: Boolean = false): SearchViewModel {
         val addon = searchableAddon()
 
         val layoutPreferences = mockk<LayoutPreferenceDataStore>()
@@ -190,7 +258,7 @@ class SearchViewModelSuggestionsTest {
 
         return SearchViewModel(
             addonRepository = SingleAddonRepository(addon),
-            catalogRepository = TitleCatalogRepository(addon),
+            catalogRepository = TitleCatalogRepository(addon, catalogIgnoresQuery),
             metaRepository = mockk(relaxed = true),
             discoverSelectionDataStore = mockk(relaxed = true),
             layoutPreferenceDataStore = layoutPreferences,
@@ -213,7 +281,12 @@ class SearchViewModelSuggestionsTest {
 
     /** Answers with one title, and only for queries that title contains, so both the filled
      *  and the empty strip are reachable from a test. */
-    private class TitleCatalogRepository(private val addon: Addon) : CatalogRepository {
+    private class TitleCatalogRepository(
+        private val addon: Addon,
+        /** Answers with everything whatever the query is, the way an addon that ignores the
+         *  search argument does. */
+        private val ignoresQuery: Boolean = false
+    ) : CatalogRepository {
         override fun getCatalog(
             addonBaseUrl: String,
             addonId: String,
@@ -227,7 +300,7 @@ class SearchViewModelSuggestionsTest {
             supportsSkip: Boolean
         ): Flow<NetworkResult<CatalogRow>> = flow {
             val query = extraArgs["search"].orEmpty()
-            val matches = query.isNotBlank() && TITLE.contains(query, ignoreCase = true)
+            val matches = ignoresQuery || (query.isNotBlank() && TITLE.contains(query, ignoreCase = true))
             emit(NetworkResult.Loading)
             emit(NetworkResult.Success(row(matches)))
         }
@@ -239,11 +312,11 @@ class SearchViewModelSuggestionsTest {
             catalogId = addon.catalogs.single().id,
             catalogName = addon.catalogs.single().name,
             type = ContentType.MOVIE,
-            items = if (!matches) emptyList() else listOf(
+            items = if (!matches) emptyList() else (if (ignoresQuery) CATALOG else listOf(TITLE)).map { title ->
                 MetaPreview(
-                    id = "tt0993846",
+                    id = "id_${title.hashCode()}",
                     type = ContentType.MOVIE,
-                    name = TITLE,
+                    name = title,
                     poster = null,
                     posterShape = PosterShape.POSTER,
                     background = null,
@@ -253,7 +326,7 @@ class SearchViewModelSuggestionsTest {
                     imdbRating = null,
                     genres = emptyList()
                 )
-            )
+            }
         )
     }
 


### PR DESCRIPTION
## Summary

Filter out addon titles that do not match the search query, and rank the matching ones by match type.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The suggestion strip sorted addon results but did not filter them. If an addon ignores the search argument and answers with its whole catalog, unrelated titles appear alphabetically once the query stops matching. Typing "wolf o" showed "Alpha" and "Beasts of No Nation".

The match order is now exact, prefix, substring, then multi-word prefix matching, with titles of the same rank ordered alphabetically.

Multi-word matching requires each query word to match a different title word, so "wolf wall" still matches "The Wolf of Wall Street" without letting "a al" match "Alpha". Words are split on non-letter and non-digit characters, so "spider man" also matches "Spider-Man".

## Issue or approval

Fixes #3325

## Reproduction steps

1. Open search and type a word that matches something, such as "wolf".
2. Continue typing a second word, such as "wolf o".

Before this change the strip fills with unrelated titles in alphabetical order.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the suggestion strip changes. Search results and the existing first-addon behaviour are unchanged.

## Testing

**Unit tests:** 6 new in `SearchViewModelSuggestionsTest`, covering non-matching titles being filtered, no matches leaving the strip empty, prefix ranking ahead of substring, multi-word queries matching separate title words, one title word not satisfying two query words, and punctuation not preventing a word match. The existing 7 lifecycle tests still pass.

**Device:** NVIDIA Shield Pro (2019), Android 11, with real addons. "wolf o" no longer shows unrelated catalog titles, and a query with no matches leaves the strip empty.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3325