### PR TITLE
Fix Player stop counting paused time as watched on live streams

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -323,6 +323,24 @@ class PlayerRuntimeController(
         )
     }
 
+    /**
+     * Closes the live watch clock's open segment and publishes the result.
+     *
+     * Call whenever playback observation stops. The clock accumulates only when it is told
+     * playback is no longer running, so an open segment left behind by a cancelled observer
+     * keeps counting wall-clock time.
+     */
+    internal fun closeLiveWatchClockSegment() {
+        if (!_playbackTimeline.value.isLive) return
+        updatePlaybackTimeline(
+            watchedDurationMs = liveWatchClock.watchedDurationMs(
+                isLive = true,
+                isPlaying = false,
+                nowElapsedMs = android.os.SystemClock.elapsedRealtime()
+            )
+        )
+    }
+
     internal fun resetPlaybackTimeline() {
         livePlaybackLatched = false
         liveWatchClock.reset()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -358,6 +358,10 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
 internal fun PlayerRuntimeController.stopProgressUpdates() {
     progressJob?.cancel()
     progressJob = null
+    // The live watch clock only closes its open segment when it is told playback stopped.
+    // Once the loop is cancelled nothing tells it, so the segment has to be closed here or
+    // the wall-clock time until the loop restarts is counted as watched.
+    closeLiveWatchClockSegment()
 }
 
 internal fun PlayerRuntimeController.startWatchProgressSaving() {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -135,6 +135,8 @@ import java.util.concurrent.TimeUnit
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.foundation.lazy.rememberLazyListState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.media3.exoplayer.ExoPlayer
@@ -153,6 +155,14 @@ fun PlayerScreen(
     val uiState by viewModel.uiState.collectAsState()
     val postPlayRecommendationState by viewModel.postPlayRecommendationUiState.collectAsState()
     val effectiveAutoplayEnabled by viewModel.effectiveAutoplayEnabled.collectAsState(initial = false)
+    // Collect only the isLive field: playbackTimeline emits every 500ms as the position
+    // advances, while isLive changes only when the stream's live status does. Subscribing to
+    // the whole timeline here invalidated PlayerScreen at the position's rate.
+    val isLivePlayback by remember(viewModel) {
+        viewModel.playbackTimeline
+            .map { it.isLive }
+            .distinctUntilChanged()
+    }.collectAsState(initial = viewModel.playbackTimeline.value.isLive)
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
@@ -995,7 +1005,7 @@ fun PlayerScreen(
             type = uiState.contentType,
             description = uiState.description,
             cast = uiState.castMembers,
-            showClock = !viewModel.playbackTimeline.collectAsState().value.isLive,
+            showClock = !isLivePlayback,
             modifier = Modifier
                 .fillMaxSize()
                 .zIndex(2.5f)
@@ -1375,7 +1385,7 @@ fun PlayerScreen(
                 !uiState.showLoadingOverlay && !uiState.showPauseOverlay &&
                 !uiState.showSubtitleDelayOverlay && !uiState.showSubtitleTimingDialog &&
                 !uiState.showMoreDialog &&
-                !viewModel.playbackTimeline.collectAsState().value.isLive,
+                !isLivePlayback,
             enter = fadeIn(animationSpec = tween(150)),
             exit = fadeOut(animationSpec = tween(150)),
             modifier = Modifier.align(Alignment.BottomCenter)


### PR DESCRIPTION
## Summary

- Close the live watch clock's open interval when progress observation stops.
- Collect only `isLive` in `PlayerScreen` instead of the whole playback timeline.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On MPV, pausing cancels the 500ms progress loop. That loop was the only place reporting `isPlaying = false` to `LivePlaybackWatchClock`, so its open interval survived the pause and the paused time was counted as watched on resume.

`stopProgressUpdates()` is the common teardown point for progress observation, so the interval is closed there rather than only in the pause handler. ExoPlayer keeps its loop running while paused and already reported `isPlaying = false`, so it was unaffected and now matches.

`LivePlaybackWatchClock` is unchanged and already covered by `LivePlaybackUiPolicyTest`. The regression was in the controller lifecycle, not the clock.

`PlayerScreen` collected the full `playbackTimeline` at two call sites just to read `isLive`, which invalidated the screen every 500ms as the position advanced. It now collects only `isLive` with `distinctUntilChanged()`. Same values, fewer invalidations.

## Issue or approval

Fixes #3330

## Reproduction steps

1. Set the internal player engine to Libmpv (Beta) in playback settings.
2. Play a live stream and wait for the controls to show `LIVE` with a readable time.
3. Note the time, then pause.
4. Wait two minutes.
5. Resume and read the time again.

Before this change the counter includes the pause. After it, only the time played.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the live watch clock and the two `isLive` reads in `PlayerScreen` change. The progress loop cadence, the ExoPlayer pause path, and the one-way live latch in `LivePlaybackUiPolicy.nextLiveLatch` are unchanged. That latch can mark a non-live MPV stream as live for a whole session, which is a separate bug needing its own issue.

## Testing

**Unit tests:** `LivePlaybackUiPolicyTest` passes on `dev` and on this branch, with no new warnings. It already covers the clock's interval transitions, including a pause spanning two ticks and repeated stop calls. The clock is unchanged, so no new test was added.

**Device:** NVIDIA Shield Pro (2019), Android 11, libmpv engine, live stream. Same journey on both builds: play ~31s, pause ~2m10s, resume, play ~11s, exit. Both builds carried the same temporary log inside the watch clock, which is not part of this PR.

Before, on `dev`: watched read 31309ms at the pause and 161254ms on resume, an increase of 129945ms across a measured 129945ms pause. Final 172368ms against 42423ms actually played, so the controls read `LIVE 2:52`.

After: watched read 31013ms on both sides of the pause. Final 42586ms against 42586ms actually played, so the controls read `LIVE 0:42`. The trace also shows the interval closing at the pause and a fresh one opening on resume, where on `dev` the pre-pause interval was still open afterwards.

Also checked: exiting while playing does not crash, which covers the new call reached through `releasePlayer`, and non-live content never opens an interval.

Not covered: repeated pause and resume cycles, pausing immediately after start, ExoPlayer live playback, VOD playback, and the `PlayerScreen` overlay behaviour on live and non-live.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3330