### PR TITLE
Fix Player order sidecar subtitle cues before rendering them

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
@@ -184,14 +184,16 @@ internal fun PlayerRuntimeController.renderSidecarCuesAtCurrentPosition() {
             audioDelayUs.get() -
             subtitleDelayUs.get()
         ).coerceAtLeast(0L)
-    val active = collectActiveSidecarCues(cues, positionUs).let { current ->
-        val sanitized = current.map { SubtitleMojibakeSanitizer.sanitizeCue(it) }
-        if (currentPlayerSettingsForReport.subtitleStyle.stripSdh) SubtitleSdhFilter.filterCues(sanitized) else sanitized
-    }
-    val merged = PlayerSubtitleUtils.mergeOverlappingCues(active)
-    val signature = activeCueSignature(merged)
+    val active = collectActiveSidecarCues(cues, positionUs)
+    val stripSdh = currentPlayerSettingsForReport.subtitleStyle.stripSdh
+    // Sign before sanitising, filtering and merging to skip that work while cues are
+    // unchanged. stripSdh is included because it changes what filtering removes.
+    val signature = activeCueSignature(active, stripSdh)
     if (signature == lastSidecarCueSignature) return
     lastSidecarCueSignature = signature
+    val sanitized = active.map { SubtitleMojibakeSanitizer.sanitizeCue(it) }
+    val filtered = if (stripSdh) SubtitleSdhFilter.filterCues(sanitized) else sanitized
+    val merged = PlayerSubtitleUtils.mergeOverlappingCues(filtered)
     val currentKey = activeSidecarSubtitleKey ?: return
     postToSubtitleView { view ->
         if (view.getTag(R.id.player_view_sidecar_generation_tag) == currentKey) {
@@ -312,10 +314,14 @@ internal fun parseSidecarTimedCuesLenient(rawText: String, sourceUrl: String): L
         val cue = Cue.Builder().setText(syncCues[i].text).build()
         out.add(CuesWithTiming(listOf(cue), startUs, durationUs))
     }
+    // collectActiveSidecarCues stops at the first cue starting after the playhead, so the list
+    // has to be ordered. PlayerSubtitleCueParser emits cues in file order.
+    out.sortBy { it.startTimeUs }
     return out
 }
 
-private fun collectActiveSidecarCues(
+/** [cues] must be ordered by [CuesWithTiming.startTimeUs]; the scan stops at the first later cue. */
+internal fun collectActiveSidecarCues(
     cues: List<CuesWithTiming>,
     positionUs: Long
 ): List<Cue> {
@@ -335,9 +341,10 @@ private fun collectActiveSidecarCues(
     return active
 }
 
-private fun activeCueSignature(cues: List<Cue>): Long {
-    if (cues.isEmpty()) return EMPTY_CUE_SIGNATURE
+internal fun activeCueSignature(cues: List<Cue>, stripSdh: Boolean): Long {
+    if (cues.isEmpty()) return if (stripSdh) EMPTY_CUE_SIGNATURE_SDH else EMPTY_CUE_SIGNATURE
     var hash = cues.size.toLong()
+    hash = 31L * hash + if (stripSdh) 1L else 0L
     for (cue in cues) {
         hash = 31L * hash + (cue.text?.hashCode()?.toLong() ?: 0L)
         hash = 31L * hash + cue.line.toBits().toLong()
@@ -361,3 +368,4 @@ private fun normalizeSidecarCuePosition(cue: Cue): Cue {
 
 private const val SIDECAR_RENDER_INTERVAL_MS = 100L
 private const val EMPTY_CUE_SIGNATURE = 0x4E5556494FL // "NUVIO"
+private const val EMPTY_CUE_SIGNATURE_SDH = 0x4E5556494F01L

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/SidecarCueOrderingTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/SidecarCueOrderingTest.kt
@@ -1,0 +1,143 @@
+package com.nuvio.tv.ui.screens.player
+
+import androidx.media3.common.text.Cue
+import androidx.media3.extractor.text.CuesWithTiming
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * [collectActiveSidecarCues] stops at the first cue starting after the playhead, so it depends on
+ * the cue list being ordered by start time. These cover that contract and the parse path that
+ * feeds it.
+ */
+class SidecarCueOrderingTest {
+
+    private fun entry(startMs: Long, endMs: Long, text: String): CuesWithTiming {
+        val startUs = startMs * 1_000L
+        val endUs = endMs * 1_000L
+        return CuesWithTiming(
+            listOf(Cue.Builder().setText(text).build()),
+            startUs,
+            (endUs - startUs).coerceAtLeast(1L)
+        )
+    }
+
+    private fun texts(cues: List<Cue>): List<String> = cues.map { it.text.toString() }
+
+    @Test
+    fun `lenient parse orders cues that appear out of order in the file`() {
+        val srt = """
+            1
+            00:00:10,000 --> 00:00:12,000
+            third
+
+            2
+            00:00:02,000 --> 00:00:04,000
+            first
+
+            3
+            00:00:06,000 --> 00:00:08,000
+            second
+        """.trimIndent()
+
+        val parsed = parseSidecarTimedCuesLenient(srt, "https://example.test/subs.srt")
+
+        assertEquals(3, parsed.size)
+        assertEquals(listOf(2_000_000L, 6_000_000L, 10_000_000L), parsed.map { it.startTimeUs })
+        assertEquals(
+            listOf("first", "second", "third"),
+            parsed.map { it.cues.single().text.toString() }
+        )
+    }
+
+    @Test
+    fun `ordered cues are required for the early-break scan`() {
+        // What the lenient parser produced before it sorted: the 2s cue sits after the 10s one.
+        val unordered = listOf(
+            entry(10_000, 12_000, "late"),
+            entry(2_000, 4_000, "early")
+        )
+
+        // At 3s the second entry is active, but the scan stops at the first entry because it
+        // starts later, so nothing is returned.
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(unordered, 3_000_000L)))
+
+        // Sorted, the same cue is found.
+        val ordered = unordered.sortedBy { it.startTimeUs }
+        assertEquals(listOf("early"), texts(collectActiveSidecarCues(ordered, 3_000_000L)))
+    }
+
+    @Test
+    fun `ordered cues resolve by position`() {
+        val cues = listOf(
+            entry(1_000, 3_000, "a"),
+            entry(4_000, 6_000, "b"),
+            entry(7_000, 9_000, "c")
+        )
+
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(cues, 500_000L)))
+        assertEquals(listOf("a"), texts(collectActiveSidecarCues(cues, 2_000_000L)))
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(cues, 3_500_000L)))
+        assertEquals(listOf("b"), texts(collectActiveSidecarCues(cues, 5_000_000L)))
+        assertEquals(listOf("c"), texts(collectActiveSidecarCues(cues, 8_000_000L)))
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(cues, 20_000_000L)))
+    }
+
+    @Test
+    fun `a long cue stays active while later cues come and go`() {
+        // A sign or caption spanning the whole scene, with dialogue inside it.
+        val cues = listOf(
+            entry(1_000, 30_000, "sign"),
+            entry(5_000, 7_000, "dialogue")
+        )
+
+        assertEquals(listOf("sign"), texts(collectActiveSidecarCues(cues, 3_000_000L)))
+        assertEquals(listOf("sign", "dialogue"), texts(collectActiveSidecarCues(cues, 6_000_000L)))
+        assertEquals(listOf("sign"), texts(collectActiveSidecarCues(cues, 10_000_000L)))
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(cues, 31_000_000L)))
+    }
+
+    @Test
+    fun `overlapping cues out of order are all found once sorted`() {
+        // A long caption listed before a dialogue line that starts earlier. Overlap plus
+        // inversion, which is the shape a merged or hand-edited file tends to have.
+        val unordered = listOf(
+            entry(10_000, 20_000, "long"),
+            entry(5_000, 15_000, "early")
+        )
+
+        // At 7s only "early" is active, but the scan stops on "long" because it starts later,
+        // so "early" is never reached.
+        assertEquals(emptyList<String>(), texts(collectActiveSidecarCues(unordered, 7_000_000L)))
+
+        val ordered = unordered.sortedBy { it.startTimeUs }
+        assertEquals(listOf("early"), texts(collectActiveSidecarCues(ordered, 7_000_000L)))
+        // At 12s the two overlap and both have to come back.
+        assertEquals(listOf("early", "long"), texts(collectActiveSidecarCues(ordered, 12_000_000L)))
+    }
+
+    @Test
+    fun `strip sdh changes the signature so toggling it redraws`() {
+        val cues = listOf(Cue.Builder().setText("[door creaks] hello").build())
+
+        assertNotEquals(
+            activeCueSignature(cues, stripSdh = false),
+            activeCueSignature(cues, stripSdh = true)
+        )
+        assertNotEquals(
+            activeCueSignature(emptyList(), stripSdh = false),
+            activeCueSignature(emptyList(), stripSdh = true)
+        )
+    }
+
+    @Test
+    fun `cue end is exclusive so adjacent cues do not overlap`() {
+        val cues = listOf(
+            entry(1_000, 2_000, "a"),
+            entry(2_000, 3_000, "b")
+        )
+
+        assertEquals(listOf("b"), texts(collectActiveSidecarCues(cues, 2_000_000L)))
+    }
+}


### PR DESCRIPTION
## Summary

- Sort lenient sidecar subtitle cues by start time before rendering.
- Skip sanitising, SDH filtering and merging when the active cues have not changed.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`collectActiveSidecarCues` stops at the first cue starting after the playhead, so it requires cues sorted by start time. The Media3 parse path already sorts its output, but the lenient path returned cues in file order, so an out-of-order cue could cause later subtitles to be skipped silently.

The lenient parser now sorts to match the Media3 path.

The render loop also computes its signature before sanitising, filtering and merging. Those ran every 100ms even when the same cues stayed on screen. `stripSdh` is included in the signature so changing the setting still redraws.

## Issue or approval

Fixes #3335

## Reproduction steps

The failure needs a crafted subtitle file, so the regression is covered by unit tests.

1. Build a cue list with a cue at 10s to 20s followed by a cue at 5s to 15s.
2. Ask for the active cues at 7s.

Before this change nothing is returned. After it, the 5s cue is returned.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The 100ms render cadence and linear cue scan are unchanged.

## Testing

**Unit tests:** 7 new in `SidecarCueOrderingTest`, covering out-of-order parsing, inverted and overlapping cues, position resolution, long-running cues, SDH signature invalidation and cue boundaries. Run with `:app:testFullDebugUnitTest --tests '*SidecarCueOrderingTest*'`.

**Not tested on device.** The failure needs a crafted subtitle file.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3335