### PR TITLE
Exclude unavailable episodes without release dates in CW

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2300,6 +2300,9 @@ private fun resolveNextUpVideoFromMeta(
         if (!isNextUpEpisodeUnaired(releaseDate, todayLocal)) {
             return@firstOrNull true
         }
+        if (releaseDate == null && video.available == false) {
+            return@firstOrNull false
+        }
         showUnairedNextUp
     }
 


### PR DESCRIPTION
## Summary
Fixes Continue Watching sometimes showing an episode that isn't available to watch and has no release date — this mostly happens for shows currently on a mid-season break.

## PR type
- [ ] Translation/localization only
- [x] Critical bug fix

## Why
Shows often go on a break for weeks or months between episodes. During that time, some episodes are listed with no release date and marked as not available yet. Continue Watching was treating "no release date" the same as "coming soon," so it showed these placeholder episodes as upcoming in continue watching, sometimes for months before a release date is added. This fix makes it only skip an episode when it truly has no date *and* is marked unavailable, so real upcoming episodes with dates aren't affected.

These are also already being excluded for mobile.

## Issue or approval
No linked issue

## Reproduction steps
1. Watch up to the latest released episode of a show that's currently on a break, where the next episode has no release date and is marked unavailable.
2. Open Home / Continue Watching.
3. The unavailable placeholder episode shows up as "Upcoming" despite not having a release date.

## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Doesn't change how episodes with a real release date (past or future) are handled — those still show up exactly as before. Only affects episodes with no date at all that are also marked unavailable. Once a date is added to the meta for the episode it will appear in continue watching as normal.

## Testing
- Manual: show on a break with next episodes having no date and marked unavailable — before: placeholder shown as next episode; after: nothing shown until a real episode is scheduled.
- Manual: show with a real future release date — still shows correctly, unaffected.
- Manual: show with an already-released next episode — still shows correctly, unaffected.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
No linked issue