### PR TITLE
Fix watch progress: retain episode progress and make exit completion runtime-aware

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
@@ -39,16 +39,15 @@ internal fun mergeWatchedEpisodeProjection(
 
 /**
  * Keeps a local episode position visible when the provider projection has nothing for that
- * episode.
+ * episode, which happens because Trakt and Simkl delete the resume point on a stop scrobble at
+ * 80% or more, before the watched state arrives.
  *
- * Trakt and Simkl both delete the resume point once a stop scrobble reports 80% or more, so an
- * episode left in the 80-100% band disappears from the provider projection before its watched
- * state arrives. Only in-progress local entries are retained: a local completed entry the provider
- * does not have could resurrect watched state that is no longer present remotely.
+ * Only in-progress entries are retained. A local completed entry the provider lacks could
+ * resurrect watched state removed elsewhere.
  *
- * Retention is durable, not an expiring overlay: a bounded lifetime would restore the blank card
- * it exists to prevent. A provider hole is ambiguous, so a position removed on another device
- * stays visible until the local entry is cleared.
+ * Retention is durable rather than expiring, since a bounded lifetime would restore the blank card
+ * it exists to prevent. The cost is that a provider hole is ambiguous, so a position removed on
+ * another device stays visible until the local entry is cleared.
  */
 internal fun mergeEpisodeProgressWithRetainedLocal(
     providerEntries: Map<Pair<Int, Int>, WatchProgress>,

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProjection.kt
@@ -36,3 +36,30 @@ internal fun mergeWatchedEpisodeProjection(
     }
     return merged
 }
+
+/**
+ * Keeps a local episode position visible when the provider projection has nothing for that
+ * episode.
+ *
+ * Trakt and Simkl both delete the resume point once a stop scrobble reports 80% or more, so an
+ * episode left in the 80-100% band disappears from the provider projection before its watched
+ * state arrives. Only in-progress local entries are retained: a local completed entry the provider
+ * does not have could resurrect watched state that is no longer present remotely.
+ *
+ * Retention is durable, not an expiring overlay: a bounded lifetime would restore the blank card
+ * it exists to prevent. A provider hole is ambiguous, so a position removed on another device
+ * stays visible until the local entry is cleared.
+ */
+internal fun mergeEpisodeProgressWithRetainedLocal(
+    providerEntries: Map<Pair<Int, Int>, WatchProgress>,
+    localEntries: Map<Pair<Int, Int>, WatchProgress>
+): Map<Pair<Int, Int>, WatchProgress> {
+    if (localEntries.isEmpty()) return providerEntries
+    val merged = providerEntries.toMutableMap()
+    localEntries.forEach { (key, progress) ->
+        if (key !in providerEntries && progress.isInProgress()) {
+            merged[key] = progress
+        }
+    }
+    return merged
+}

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -520,9 +520,9 @@ class WatchProgressRepositoryImpl @Inject constructor(
                                     it.season != null && it.episode != null
                             }
                         },
-                        // Seeded so the disk-backed local read cannot gate the combine. Without
-                        // this the whole projection, and the watched state derived from it, waits
-                        // on DataStore before its first emission.
+                        // Seeded so the disk-backed read cannot gate the combine, which would
+                        // make the whole projection wait on DataStore. The cost is that the first
+                        // emission can precede the local map and omit retained entries.
                         watchProgressPreferences.getAllEpisodeProgress(contentId, profileId)
                             .onStart { emit(emptyMap()) }
                     ) { remoteMap, liveEpisodes, localMap ->

--- a/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/WatchProgressRepositoryImpl.kt
@@ -20,6 +20,7 @@ import com.nuvio.tv.core.tracking.TrackingHistoryWriterRegistry
 import com.nuvio.tv.core.tracking.TrackingMediaReference
 import com.nuvio.tv.core.tracking.TrackingProgressProvider
 import com.nuvio.tv.core.tracking.TrackingProgressProviderRegistry
+import com.nuvio.tv.core.tracking.mergeEpisodeProgressWithRetainedLocal
 import com.nuvio.tv.core.tracking.mergeProgressProjectionWithRetainedLocal
 import com.nuvio.tv.core.tracking.mergeWatchedEpisodeProjection
 import com.nuvio.tv.core.tracking.TrackingProviderId
@@ -518,15 +519,23 @@ class WatchProgressRepositoryImpl @Inject constructor(
                                 it.contentId.equals(contentId, ignoreCase = true) &&
                                     it.season != null && it.episode != null
                             }
-                        }
-                    ) { remoteMap, liveEpisodes ->
+                        },
+                        // Seeded so the disk-backed local read cannot gate the combine. Without
+                        // this the whole projection, and the watched state derived from it, waits
+                        // on DataStore before its first emission.
+                        watchProgressPreferences.getAllEpisodeProgress(contentId, profileId)
+                            .onStart { emit(emptyMap()) }
+                    ) { remoteMap, liveEpisodes, localMap ->
                         val merged = remoteMap.toMutableMap()
                         liveEpisodes.forEach { episodeProgress ->
                             val seasonNum = episodeProgress.season ?: return@forEach
                             val episodeNum = episodeProgress.episode ?: return@forEach
                             merged[seasonNum to episodeNum] = episodeProgress
                         }
-                        merged
+                        mergeEpisodeProgressWithRetainedLocal(
+                            providerEntries = merged,
+                            localEntries = localMap
+                        )
                     }.distinctUntilChanged()
                 } else {
                     watchProgressPreferences.getAllEpisodeProgress(contentId, profileId)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -518,7 +518,11 @@ private fun EpisodeCard(
     val isWatched = remember(watchProgress, isMarkedWatched) { watchProgress?.isCompleted() == true || isMarkedWatched }
     val shouldBlur = remember(blurUnwatched, isWatched) { blurUnwatched && !isWatched }
     val progressPercent = remember(watchProgress) { watchProgress?.progressPercentage ?: 0f }
-    val showProgress = remember(watchProgress) { watchProgress?.isInProgress() == true }
+    // A retained local position can outlive the provider's watched flag arriving, so the
+    // completed badge wins over the progress bar rather than both showing at once.
+    val showProgress = remember(watchProgress, isWatched) {
+        !isWatched && watchProgress?.isInProgress() == true
+    }
     val showCompletedBadge = isWatched
     val showNotStartedBadge = remember(showCompletedBadge, progressPercent) { !showCompletedBadge && progressPercent < 0.02f }
     val isUnavailable = remember(episode.available) { episode.available == false }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodesSection.kt
@@ -518,8 +518,8 @@ private fun EpisodeCard(
     val isWatched = remember(watchProgress, isMarkedWatched) { watchProgress?.isCompleted() == true || isMarkedWatched }
     val shouldBlur = remember(blurUnwatched, isWatched) { blurUnwatched && !isWatched }
     val progressPercent = remember(watchProgress) { watchProgress?.progressPercentage ?: 0f }
-    // A retained local position can outlive the provider's watched flag arriving, so the
-    // completed badge wins over the progress bar rather than both showing at once.
+    // A retained local position can outlive the provider's watched flag, so the completed badge
+    // wins over the progress bar rather than both showing.
     val showProgress = remember(watchProgress, isWatched) {
         !isWatched && watchProgress?.isInProgress() == true
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodeCompletionLatch.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/EpisodeCompletionLatch.kt
@@ -1,0 +1,34 @@
+package com.nuvio.tv.ui.screens.player
+
+/**
+ * Guards against completing the current item more than once.
+ *
+ * [claim] before any suspending work. Splitting the read from the write across a suspension is
+ * what this type exists to prevent: a reset can land in that gap, so the write applies to whatever
+ * plays next and suppresses its completion. There is no API here that lets that shape be written.
+ *
+ * [reset] runs from resetLoadingOverlayForNewStream, so the lifetime is a stream rather than an
+ * episode: a same-episode source or engine switch also clears it. That is pre-existing and benign,
+ * because WatchProgressRepository.markAsCompleted is idempotent, but it means a claim guards one
+ * stream's completion write, not one episode's.
+ *
+ * Confined to the player's main-thread callbacks and its [kotlinx.coroutines.MainScope]-dispatched
+ * jobs, so a plain field is enough. An atomic would suggest cross-thread use that does not exist,
+ * and would not help: the property that matters is no suspension between the check and the
+ * mutation, not lock-free access.
+ */
+internal class EpisodeCompletionLatch {
+
+    private var claimed = false
+
+    /** True only for the caller that should write the completion. */
+    fun claim(): Boolean {
+        if (claimed) return false
+        claimed = true
+        return true
+    }
+
+    fun reset() {
+        claimed = false
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackCompletionRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlaybackCompletionRules.kt
@@ -1,0 +1,89 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.data.repository.SkipInterval
+import com.nuvio.tv.domain.model.WatchProgress
+
+/**
+ * Decides whether leaving an item counts as having finished it.
+ *
+ * Nothing below [PROVIDER_COMPLETION_PERCENT] can qualify, so local completion never precedes the
+ * provider's. Above that floor an exit qualifies on remaining time or on the credits having
+ * started, with the percentage as a fallback.
+ */
+internal object PlaybackCompletionRules {
+
+    /** Fallback for exits, not a ceiling: the rules below can qualify an exit under it. Derived
+     * from [WatchProgress.COMPLETED_THRESHOLD] so it tracks that constant. */
+    const val FALLBACK_COMPLETION_PERCENT = WatchProgress.COMPLETED_THRESHOLD * 100f
+
+    /** Remaining time that reads as "the episode is over", fixed rather than a percentage so it
+     * means the same on a 22 minute episode and a 60 minute one. Only opens a band under
+     * [FALLBACK_COMPLETION_PERCENT] between 20 and 40 minutes of runtime. */
+    const val COMPLETION_REMAINING_MS = 4 * 60_000L
+
+    /** [positionMs] is null when the player cannot report a position, which never completes. */
+    fun resolveExitCompletion(
+        leavesCurrentItem: Boolean,
+        positionMs: Long?,
+        durationMs: Long,
+        skipIntervals: List<SkipInterval> = emptyList()
+    ): Boolean {
+        if (!leavesCurrentItem) return false
+        val position = positionMs ?: return false
+        return isFinishedOnExit(position, durationMs, skipIntervals)
+    }
+
+    fun isFinishedOnExit(
+        positionMs: Long,
+        durationMs: Long,
+        skipIntervals: List<SkipInterval> = emptyList()
+    ): Boolean {
+        if (durationMs <= 0L || positionMs <= 0L) return false
+        val percent = (positionMs.toDouble() / durationMs.toDouble()) * 100.0
+        if (percent < PROVIDER_COMPLETION_PERCENT) return false
+        if (percent >= FALLBACK_COMPLETION_PERCENT) return true
+        if (durationMs - positionMs <= COMPLETION_REMAINING_MS) return true
+        return hasEnteredTerminalEnding(positionMs, durationMs, skipIntervals)
+    }
+
+    /**
+     * True once playback has crossed the start of a terminal ending. Being past the start is the
+     * signal; playback need not still be inside the segment.
+     *
+     * Segments are evaluated individually, so this does not rely on
+     * SkipIntroRepository.mergeByPriority keeping one interval per category.
+     */
+    private fun hasEnteredTerminalEnding(
+        positionMs: Long,
+        durationMs: Long,
+        skipIntervals: List<SkipInterval>
+    ): Boolean {
+        val positionSeconds = positionMs / 1_000.0
+        return skipIntervals.any { segment ->
+            isTerminalEndingSegment(segment, durationMs) && positionSeconds >= segment.startTime
+        }
+    }
+
+    /**
+     * Whether a segment is credits running to the end of the file, judged on the annotation alone.
+     *
+     * It must end within [COMPLETION_REMAINING_MS] of the file end and run no longer than that.
+     * The length is a deliberate cutoff, not something the metadata asserts: it separates credits
+     * from an arbitrary span that happens to reach the file end, at the cost of a genuinely
+     * longer ending. Open-ended animeskip intervals fail both bounds.
+     *
+     * Non-finite times are rejected explicitly. The comparisons would reject them anyway, but
+     * malformed metadata is what this guards against, so the check is visible.
+     */
+    private fun isTerminalEndingSegment(segment: SkipInterval, durationMs: Long): Boolean {
+        if (segment.type !in PlayerNextEpisodeRules.OUTRO_SEGMENT_TYPES) return false
+        if (!segment.startTime.isFinite() || !segment.endTime.isFinite()) return false
+        if (segment.startTime < 0.0 || segment.startTime > segment.endTime) return false
+
+        val fileEndSeconds = durationMs / 1_000.0
+        val windowSeconds = COMPLETION_REMAINING_MS / 1_000.0
+        if (segment.endTime - segment.startTime > windowSeconds) return false
+        return segment.endTime >= fileEndSeconds - windowSeconds &&
+            segment.endTime <= fileEndSeconds + windowSeconds
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -397,7 +397,7 @@ class PlayerRuntimeController(
 
     internal var lastSavedPosition: Long = 0L
     internal val saveThresholdMs = 5000L
-    internal var hasMarkedCurrentEpisodeCompleted: Boolean = false
+    internal val episodeCompletionLatch = EpisodeCompletionLatch()
     internal var lastKnownDuration: Long = 0L
 
     internal var playbackStartedForParentalGuide = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -224,8 +224,10 @@ class PlayerRuntimeController(
     fun getCurrentStreamUrl(): String = currentStreamUrl
     fun getCurrentHeaders(): Map<String, String> = currentHeaders
 
-    fun stopAndRelease() {
-        releasePlayer()
+    /** [leavesCurrentItem] must be false when playback continues outside the internal player, as
+     * with an external-player handoff. That is a continuation, not an exit. */
+    fun stopAndRelease(leavesCurrentItem: Boolean = true) {
+        releasePlayer(flushPlaybackState = true, leavesCurrentItem = leavesCurrentItem)
     }
 
     internal var currentVideoId: String? = videoId
@@ -664,7 +666,7 @@ class PlayerRuntimeController(
     }
 
     fun onCleared() {
-        releasePlayer()
+        releasePlayer(flushPlaybackState = true, leavesCurrentItem = true)
         stopTorrentStream()
         startupLoadingReportJob?.cancel()
         vodTelemetryJob?.cancel()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -1961,7 +1961,7 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
         progress = null
     )
     hasRenderedFirstFrame = false
-    hasMarkedCurrentEpisodeCompleted = false
+    episodeCompletionLatch.reset()
     shouldEnforceAutoplayOnFirstReady = true
     userPausedManually = false
     timeoutRecoveryAttempts = 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -4,17 +4,29 @@ import android.content.Intent
 import android.media.audiofx.AudioEffect
 import kotlinx.coroutines.flow.update
 
+/** Releases the player without treating it as leaving the item. */
 internal fun PlayerRuntimeController.releasePlayer() {
     releasePlayer(flushPlaybackState = true)
 }
 
-internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) {
-    logScrobbleDiagnostic("release_player", "flushPlaybackState=$flushPlaybackState")
+/**
+ * [leavesCurrentItem] defaults to false so a teardown that keeps the same item playing, such as an
+ * engine switch or a codec recovery reinitialize, is never recorded as finished. Only a caller
+ * that knows the user is leaving passes true.
+ */
+internal fun PlayerRuntimeController.releasePlayer(
+    flushPlaybackState: Boolean,
+    leavesCurrentItem: Boolean = false
+) {
+    logScrobbleDiagnostic(
+        "release_player",
+        "flushPlaybackState=$flushPlaybackState leavesCurrentItem=$leavesCurrentItem"
+    )
     isReleasingPlayer = true
     com.nuvio.tv.core.recommendations.TvRecommendationManager.isPlaybackActive.value = false
     if (flushPlaybackState) {
         stopTorrentStream()
-        flushPlaybackSnapshotForSwitchOrExit()
+        flushPlaybackSnapshotForSwitchOrExit(leavesCurrentItem = leavesCurrentItem)
     }
 
     notifyAudioSessionUpdate(false)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -603,12 +603,12 @@ internal fun PlayerRuntimeController.saveWatchProgressIfNeeded() {
     }
 }
 
-internal fun PlayerRuntimeController.saveWatchProgress() {
+internal fun PlayerRuntimeController.saveWatchProgress(forceCompleted: Boolean = false) {
     if (!hasRenderedFirstFrame) return
     val currentPosition = currentPlaybackPositionMs() ?: return
     val duration = getEffectiveDuration(currentPosition)
     if (isShortPlaceholderDuration(duration)) return
-    saveWatchProgressInternal(currentPosition, duration)
+    saveWatchProgressInternal(currentPosition, duration, forceCompleted = forceCompleted)
 }
 
 internal fun PlayerRuntimeController.getEffectiveDuration(position: Long): Long {
@@ -680,8 +680,15 @@ internal fun PlayerRuntimeController.cancelNextEpisodeAutoPlayOnFatalError() {
     stillWatchingPromptJob = null
 }
 
-internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, duration: Long, syncRemote: Boolean = true) {
+internal fun PlayerRuntimeController.saveWatchProgressInternal(
+    position: Long,
+    duration: Long,
+    syncRemote: Boolean = true,
+    forceCompleted: Boolean = false
+) {
     if (contentType.equals("cloud", ignoreCase = true)) {
+        // Cloud library progress has its own store and is not tracked. [forceCompleted] does not
+        // apply here; only a natural end completes a cloud item.
         saveCloudLibraryProgress(position, duration, completed = false)
         return
     }
@@ -716,7 +723,7 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(position: Long, d
             profileId = profileId
         )
         val normalizedProgress = progress.copy(contentId = effectiveContentId)
-        if (normalizedProgress.isCompleted()) {
+        if (forceCompleted || normalizedProgress.isCompleted()) {
             if (!hasMarkedCurrentEpisodeCompleted) {
                 hasMarkedCurrentEpisodeCompleted = true
                 watchProgressRepository.markAsCompleted(
@@ -807,7 +814,7 @@ internal fun PlayerRuntimeController.emitScrobbleStart() {
     // watching something already marked as watched. If the user seeks back
     // below 80%, the next progress update will re-trigger scrobble start.
     val currentProgress = currentPlaybackProgressPercent()
-    if (currentProgress >= 80f) {
+    if (currentProgress >= PROVIDER_COMPLETION_PERCENT) {
         logScrobbleDiagnostic("start_skipped", "reason=completion_threshold progress=$currentProgress")
         return
     }
@@ -861,7 +868,7 @@ internal fun PlayerRuntimeController.emitScrobbleStop(progressPercent: Float? = 
     }
 
     val provided = progressPercent
-    if (!hasRequestedScrobbleStartForCurrentItem && (provided ?: 0f) < 80f) {
+    if (!hasRequestedScrobbleStartForCurrentItem && (provided ?: 0f) < PROVIDER_COMPLETION_PERCENT) {
         logScrobbleDiagnostic("stop_skipped", "reason=no_active_scrobble providedProgress=${provided ?: "none"}")
         return
     }
@@ -918,7 +925,7 @@ internal fun PlayerRuntimeController.emitScrobblePause(progressPercent: Float? =
 }
 
 internal fun PlayerRuntimeController.emitCompletionScrobbleStop(progressPercent: Float) {
-    if (progressPercent < 80f || hasSentCompletionScrobbleForCurrentItem) return
+    if (progressPercent < PROVIDER_COMPLETION_PERCENT || hasSentCompletionScrobbleForCurrentItem) return
     hasSentCompletionScrobbleForCurrentItem = true
     emitScrobbleStop(progressPercent = progressPercent)
 }
@@ -932,7 +939,7 @@ internal fun PlayerRuntimeController.emitStopScrobbleForCurrentProgress() {
         )
         return
     }
-    if (progressPercent < 80f) {
+    if (progressPercent < PROVIDER_COMPLETION_PERCENT) {
         emitScrobbleStop(progressPercent = progressPercent)
         return
     }
@@ -944,7 +951,7 @@ internal fun PlayerRuntimeController.emitPauseScrobbleForCurrentProgress() {
 }
 
 internal fun PlayerRuntimeController.emitSeekScrobbleRestart(progressPercent: Float) {
-    if (progressPercent < 1f || progressPercent >= 80f) return
+    if (progressPercent < 1f || progressPercent >= PROVIDER_COMPLETION_PERCENT) return
     if (isShortPlaceholderStream()) return
     val item = currentScrobbleItem ?: return
     if (!hasRequestedScrobbleStartForCurrentItem) return
@@ -962,10 +969,27 @@ internal fun PlayerRuntimeController.emitSeekScrobbleRestart(progressPercent: Fl
     }
 }
 
-internal fun PlayerRuntimeController.flushPlaybackSnapshotForSwitchOrExit() {
-    logScrobbleDiagnostic("flush_switch_or_exit")
+/**
+ * Persists the final state of playback.
+ *
+ * [leavesCurrentItem] defaults to false, which is correct whenever playback continues on the same
+ * item. It suppresses exit-only local completion and nothing else. The existing
+ * [WatchProgress.COMPLETED_THRESHOLD] rule in [saveWatchProgressInternal] still applies, and stop
+ * scrobble behavior is unchanged, so a same-item switch can still complete the item remotely.
+ */
+internal fun PlayerRuntimeController.flushPlaybackSnapshotForSwitchOrExit(
+    leavesCurrentItem: Boolean = false
+) {
+    logScrobbleDiagnostic("flush_switch_or_exit", "leavesCurrentItem=$leavesCurrentItem")
+    val position = currentPlaybackPositionMs()
+    val finished = PlaybackCompletionRules.resolveExitCompletion(
+        leavesCurrentItem = leavesCurrentItem,
+        positionMs = position,
+        durationMs = position?.let { getEffectiveDuration(it) } ?: 0L,
+        skipIntervals = skipIntervals
+    )
     emitStopScrobbleForCurrentProgress()
-    saveWatchProgress()
+    saveWatchProgress(forceCompleted = finished)
 }
 
 internal fun PlayerRuntimeController.logScrobbleDiagnostic(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -603,12 +603,26 @@ internal fun PlayerRuntimeController.saveWatchProgressIfNeeded() {
     }
 }
 
+/** The position and duration behind one write, so a decision and the write it drives agree. */
+internal data class PlaybackWriteSnapshot(val positionMs: Long, val durationMs: Long)
+
+/** Null whenever there is nothing worth persisting: no rendered frame, no reportable position, or
+ * a short debrid placeholder standing in for the real stream. */
+internal fun PlayerRuntimeController.currentPlaybackWriteSnapshot(): PlaybackWriteSnapshot? {
+    if (!hasRenderedFirstFrame) return null
+    val position = currentPlaybackPositionMs() ?: return null
+    val duration = getEffectiveDuration(position)
+    if (isShortPlaceholderDuration(duration)) return null
+    return PlaybackWriteSnapshot(positionMs = position, durationMs = duration)
+}
+
 internal fun PlayerRuntimeController.saveWatchProgress(forceCompleted: Boolean = false) {
-    if (!hasRenderedFirstFrame) return
-    val currentPosition = currentPlaybackPositionMs() ?: return
-    val duration = getEffectiveDuration(currentPosition)
-    if (isShortPlaceholderDuration(duration)) return
-    saveWatchProgressInternal(currentPosition, duration, forceCompleted = forceCompleted)
+    val snapshot = currentPlaybackWriteSnapshot() ?: return
+    saveWatchProgressInternal(
+        snapshot.positionMs,
+        snapshot.durationMs,
+        forceCompleted = forceCompleted
+    )
 }
 
 internal fun PlayerRuntimeController.getEffectiveDuration(position: Long): Long {
@@ -716,6 +730,12 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(
         progressPercent = fallbackPercent
     )
 
+    // Decided and claimed before the coroutine, which suspends in normalizeParentContentId.
+    // Only contentId is normalized below, and isCompleted() does not read it, so the decision is
+    // the same either side.
+    val completesItem = forceCompleted || progress.isCompleted()
+    val claimedCompletion = completesItem && episodeCompletionLatch.claim()
+
     scope.launch(kotlinx.coroutines.NonCancellable) {
         val effectiveContentId = watchProgressRepository.normalizeParentContentId(
             parentContentId = progress.contentId,
@@ -723,9 +743,8 @@ internal fun PlayerRuntimeController.saveWatchProgressInternal(
             profileId = profileId
         )
         val normalizedProgress = progress.copy(contentId = effectiveContentId)
-        if (forceCompleted || normalizedProgress.isCompleted()) {
-            if (!hasMarkedCurrentEpisodeCompleted) {
-                hasMarkedCurrentEpisodeCompleted = true
+        if (completesItem) {
+            if (claimedCompletion) {
                 watchProgressRepository.markAsCompleted(
                     normalizedProgress,
                     profileId = profileId,
@@ -981,15 +1000,20 @@ internal fun PlayerRuntimeController.flushPlaybackSnapshotForSwitchOrExit(
     leavesCurrentItem: Boolean = false
 ) {
     logScrobbleDiagnostic("flush_switch_or_exit", "leavesCurrentItem=$leavesCurrentItem")
-    val position = currentPlaybackPositionMs()
+    // One read drives both the decision and the write. Reading again inside saveWatchProgress let
+    // playback advance across the stop scrobble, deciding completion against a position that was
+    // never persisted.
+    val snapshot = currentPlaybackWriteSnapshot()
     val finished = PlaybackCompletionRules.resolveExitCompletion(
         leavesCurrentItem = leavesCurrentItem,
-        positionMs = position,
-        durationMs = position?.let { getEffectiveDuration(it) } ?: 0L,
+        positionMs = snapshot?.positionMs,
+        durationMs = snapshot?.durationMs ?: 0L,
         skipIntervals = skipIntervals
     )
     emitStopScrobbleForCurrentProgress()
-    saveWatchProgress(forceCompleted = finished)
+    snapshot?.let {
+        saveWatchProgressInternal(it.positionMs, it.durationMs, forceCompleted = finished)
+    }
 }
 
 internal fun PlayerRuntimeController.logScrobbleDiagnostic(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1330,7 +1330,9 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     stillWatchingPromptJob?.cancel()
     stillWatchingPromptJob = null
 
-    flushPlaybackSnapshotForSwitchOrExit()
+    flushPlaybackSnapshotForSwitchOrExit(
+        leavesCurrentItem = episodeSwitchLeavesCurrentEpisode(forcedTargetVideo)
+    )
 
     // Pause current playback immediately so the old stream doesn't continue
     // playing audio/video in the background while the new episode is being prepared.
@@ -1443,6 +1445,29 @@ private fun String.safeStreamTraceHost(): String {
     }.getOrDefault("unknown")
 }
 
+
+/**
+ * A stream selection does not always target a different episode: picking another source for the
+ * episode already playing routes through the same switch. Resolves the target the same way
+ * currentVideoId is assigned below.
+ */
+private fun PlayerRuntimeController.episodeSwitchLeavesCurrentEpisode(
+    forcedTargetVideo: Video?
+): Boolean = episodeSwitchLeavesEpisode(
+    targetVideoId = forcedTargetVideo?.id ?: _uiState.value.episodeStreamsForVideoId,
+    currentVideoId = currentVideoId
+)
+
+/**
+ * True only when the target is known to be a different episode. An unresolved id means the switch
+ * is treated as staying put, which suppresses exit completion rather than applying it to an item
+ * that keeps playing.
+ */
+internal fun episodeSwitchLeavesEpisode(targetVideoId: String?, currentVideoId: String?): Boolean {
+    if (targetVideoId == null || currentVideoId == null) return false
+    return targetVideoId != currentVideoId
+}
+
 /**
  * Shared episode stream setup used by both torrent and HTTP episode switching.
  */
@@ -1458,7 +1483,9 @@ private fun PlayerRuntimeController.switchToEpisodeStreamCommon(
     stillWatchingPromptJob?.cancel()
     stillWatchingPromptJob = null
     streamRepository.setLocalPluginSearchPaused(true)
-    flushPlaybackSnapshotForSwitchOrExit()
+    flushPlaybackSnapshotForSwitchOrExit(
+        leavesCurrentItem = episodeSwitchLeavesCurrentEpisode(forcedTargetVideo)
+    )
 
     val targetVideo = forcedTargetVideo
         ?: _uiState.value.episodes.firstOrNull { it.id == _uiState.value.episodeStreamsForVideoId }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrobblePolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScrobblePolicy.kt
@@ -3,6 +3,14 @@ package com.nuvio.tv.ui.screens.player
 import androidx.media3.common.Player
 import com.nuvio.tv.core.tracking.TrackingScrobbleAction
 
+/**
+ * Progress at which a stop scrobble becomes a completion scrobble. Trakt and Simkl both document
+ * 80% as the point where a stop moves the item to history and drops the resume point. Local
+ * watched state uses it as a floor so it cannot contradict what was just published. It does not
+ * mean 80% is "watched"; PlaybackCompletionRules decides that.
+ */
+internal const val PROVIDER_COMPLETION_PERCENT = 80f
+
 internal fun trackingActionForNonPlayingState(playbackState: Int): TrackingScrobbleAction? = when (playbackState) {
     Player.STATE_BUFFERING -> null
     Player.STATE_ENDED, Player.STATE_IDLE -> TrackingScrobbleAction.STOP
@@ -17,4 +25,4 @@ internal fun shouldSendPauseScrobble(
 internal fun shouldSendStopScrobble(
     hasActiveScrobble: Boolean,
     progressPercent: Float
-): Boolean = hasActiveScrobble || progressPercent >= 80f
+): Boolean = hasActiveScrobble || progressPercent >= PROVIDER_COMPLETION_PERCENT

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerViewModel.kt
@@ -360,8 +360,10 @@ class PlayerViewModel @Inject constructor(
             }
 
             // Stop the internal player only after preparation has completed and immediately
-            // before sending the external intent.
-            controller.stopAndRelease()
+            // before sending the external intent. Playback continues in the external player, so
+            // this is not an exit: completing here would rewrite the stored position to the
+            // duration and publish a watched state the user never reached.
+            controller.stopAndRelease(leavesCurrentItem = false)
             val launched = try {
                 externalPlaybackTracker.launchPlayer(
                     metadata = metadata,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PostPlayRecommendationController.kt
@@ -766,7 +766,7 @@ internal class PostPlayRecommendationController(
         }
         postEndCountdownJob?.cancel()
         postEndCountdownJob = null
-        playbackController.releasePlayer()
+        playbackController.releasePlayer(flushPlaybackState = true, leavesCurrentItem = true)
         trailerPlayerPool.reclaim()
         _uiState.update {
             it.copy(

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
@@ -54,6 +54,42 @@ class TrackingProgressProjectionTest {
         assertEquals(null, result["tt300"])
     }
 
+    @Test
+    fun `episode projection retains a local position the provider no longer holds`() {
+        val providerEntry = progress("tt100", 1, 1, 10L, 25L)
+        val retainedLocal = progress("tt100", 1, 2, 20L, 85L)
+
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = mapOf((1 to 1) to providerEntry),
+            localEntries = mapOf((1 to 1) to progress("tt100", 1, 1, 5L, 5L), (1 to 2) to retainedLocal)
+        )
+
+        assertEquals(providerEntry, result[1 to 1])
+        assertEquals(retainedLocal, result[1 to 2])
+    }
+
+    @Test
+    fun `episode projection drops a completed local entry the provider no longer holds`() {
+        val completedLocal = progress("tt100", 1, 2, 20L, 95L)
+
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = emptyMap(),
+            localEntries = mapOf((1 to 2) to completedLocal)
+        )
+
+        assertEquals(emptyMap<Pair<Int, Int>, WatchProgress>(), result)
+    }
+
+    @Test
+    fun `episode projection drops an unstarted local entry`() {
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = emptyMap(),
+            localEntries = mapOf((1 to 2) to progress("tt100", 1, 2, 20L, 1L))
+        )
+
+        assertEquals(emptyMap<Pair<Int, Int>, WatchProgress>(), result)
+    }
+
     private fun progress(
         contentId: String,
         season: Int?,

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingProgressProjectionTest.kt
@@ -69,6 +69,62 @@ class TrackingProgressProjectionTest {
     }
 
     @Test
+    fun `episode projection prefers the provider entry when both hold the episode`() {
+        // The provider map already carries the local position through the optimistic overlay, so
+        // provider-wins is not a stale read. Retention only fills keys the provider has dropped.
+        val providerEntry = progress("tt100", 1, 1, 30L, 85L)
+        val localEntry = progress("tt100", 1, 1, 20L, 60L)
+
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = mapOf((1 to 1) to providerEntry),
+            localEntries = mapOf((1 to 1) to localEntry)
+        )
+
+        assertEquals(providerEntry, result[1 to 1])
+    }
+
+    @Test
+    fun `episode projection keeps a completed provider entry over an in-progress local one`() {
+        val providerEntry = progress("tt100", 1, 1, 30L, 100L)
+        val localEntry = progress("tt100", 1, 1, 20L, 60L)
+
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = mapOf((1 to 1) to providerEntry),
+            localEntries = mapOf((1 to 1) to localEntry)
+        )
+
+        assertEquals(providerEntry, result[1 to 1])
+    }
+
+    @Test
+    fun `episode projection retains across repeated empty provider emissions`() {
+        // Retention is durable by design. "Watched this far and never finished" does not expire,
+        // and a bounded lifetime would restore the blank card the merge exists to prevent.
+        val retained = progress("tt100", 1, 2, 20L, 85L)
+        val entries = mapOf((1 to 2) to retained)
+
+        repeat(3) {
+            val result = mergeEpisodeProgressWithRetainedLocal(
+                providerEntries = emptyMap(),
+                localEntries = entries
+            )
+            assertEquals(retained, result[1 to 2])
+        }
+    }
+
+    @Test
+    fun `episode projection shows nothing once the local entry is cleared`() {
+        // The other half of the retention contract: removeProgress deletes the local entry, and
+        // the projection then has nothing to fall back on.
+        val result = mergeEpisodeProgressWithRetainedLocal(
+            providerEntries = emptyMap(),
+            localEntries = emptyMap()
+        )
+
+        assertEquals(emptyMap<Pair<Int, Int>, WatchProgress>(), result)
+    }
+
+    @Test
     fun `episode projection drops a completed local entry the provider no longer holds`() {
         val completedLocal = progress("tt100", 1, 2, 20L, 95L)
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/EpisodeCompletionLatchTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/EpisodeCompletionLatchTest.kt
@@ -1,0 +1,42 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EpisodeCompletionLatchTest {
+
+    @Test
+    fun `the first claim wins`() {
+        assertTrue(EpisodeCompletionLatch().claim())
+    }
+
+    @Test
+    fun `a second claim without a reset does not`() {
+        val latch = EpisodeCompletionLatch()
+        assertTrue(latch.claim())
+        assertFalse(latch.claim())
+        assertFalse(latch.claim())
+    }
+
+    @Test
+    fun `a reset gives the next episode its own claim`() {
+        // The regression. An episode that completes must not consume the claim belonging to the
+        // episode that follows it.
+        val latch = EpisodeCompletionLatch()
+        assertTrue(latch.claim())
+        latch.reset()
+        assertTrue(latch.claim())
+    }
+
+    @Test
+    fun `a reset without a preceding claim changes nothing`() {
+        val latch = EpisodeCompletionLatch()
+        latch.reset()
+        assertTrue(latch.claim())
+        latch.reset()
+        latch.reset()
+        assertTrue(latch.claim())
+        assertFalse(latch.claim())
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/EpisodeSwitchTargetTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/EpisodeSwitchTargetTest.kt
@@ -1,0 +1,28 @@
+package com.nuvio.tv.ui.screens.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EpisodeSwitchTargetTest {
+
+    @Test
+    fun `selecting a different episode leaves the current one`() {
+        assertTrue(episodeSwitchLeavesEpisode(targetVideoId = "tt0944947:8:3", currentVideoId = "tt0944947:8:2"))
+    }
+
+    @Test
+    fun `selecting another source for the episode already playing does not`() {
+        assertFalse(episodeSwitchLeavesEpisode(targetVideoId = "tt0944947:8:2", currentVideoId = "tt0944947:8:2"))
+    }
+
+    @Test
+    fun `an unresolved target stays on the current episode`() {
+        assertFalse(episodeSwitchLeavesEpisode(targetVideoId = null, currentVideoId = "tt0944947:8:2"))
+    }
+
+    @Test
+    fun `an unknown current episode stays conservative`() {
+        assertFalse(episodeSwitchLeavesEpisode(targetVideoId = "tt0944947:8:3", currentVideoId = null))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlaybackCompletionRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlaybackCompletionRulesTest.kt
@@ -1,0 +1,564 @@
+package com.nuvio.tv.ui.screens.player
+
+import com.nuvio.tv.data.repository.SkipInterval
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackCompletionRulesTest {
+
+    private val shortEpisodeMs = 22 * 60_000L
+    private val longEpisodeMs = 60 * 60_000L
+
+    @Test
+    fun `exit below the provider floor is not finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (shortEpisodeMs * 0.79).toLong(),
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `short episode in the provider band is finished on remaining time`() {
+        // 85% of 22 minutes leaves 3m18s.
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (shortEpisodeMs * 0.85).toLong(),
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `long episode at the same percentage is not finished`() {
+        // 85% of 60 minutes leaves 9 minutes.
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `intro segments are ignored`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(startTime = 30.0, endTime = 90.0, type = "intro", provider = "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `just below the provider floor is not finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (shortEpisodeMs * 0.799).toLong(),
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `remaining time does not finish an item below the provider floor`() {
+        // The floor is evaluated first. A long tail of runtime already consumed must not let the
+        // remaining-time rule complete an item the provider still considers in progress.
+        val durationMs = 3 * 60 * 60_000L
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (durationMs * 0.75).toLong(),
+                durationMs = durationMs,
+                skipIntervals = listOf(
+                    SkipInterval(
+                        startTime = (durationMs * 0.74) / 1_000.0,
+                        endTime = durationMs / 1_000.0,
+                        type = "outro",
+                        provider = "introdb"
+                    )
+                )
+            )
+        )
+    }
+
+    // The remaining-time rule is only reachable below the fallback threshold, which needs a
+    // runtime under 40 minutes: at four minutes remaining a longer episode is already past 90%.
+    private val midEpisodeMs = 35 * 60_000L
+
+    @Test
+    fun `exactly the remaining time bound is finished`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = midEpisodeMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS,
+                durationMs = midEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `one millisecond short of the remaining time bound is not finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = midEpisodeMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS - 1L,
+                durationMs = midEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `exactly the provider floor with runtime left is not finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.80).toLong(),
+                durationMs = longEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `just short of the fallback threshold is not finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.8999).toLong(),
+                durationMs = longEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `exactly the fallback threshold is finished`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.90).toLong(),
+                durationMs = longEpisodeMs
+            )
+        )
+    }
+
+    /** The longest a segment may run and still read as credits. */
+    private val maxEndingSeconds = PlaybackCompletionRules.COMPLETION_REMAINING_MS / 1_000.0
+
+    /**
+     * A 90 second ED at 17:00 of a 22 minute episode, ending 2:30 before the file end.
+     *
+     * This is the shape the clause exists for. Entering it at the 80% floor leaves 4:24, so the
+     * remaining-time rule does not yet apply and only the ending qualifies the exit.
+     */
+    private fun terminalEnding(type: String = "outro") = SkipInterval(
+        startTime = 17 * 60.0,
+        endTime = 18 * 60.0 + 30.0,
+        type = type,
+        provider = "aniskip"
+    )
+
+    /** The same shape on a 60 minute file: credits at 52:30 running to 56:20. */
+    private fun longTerminalEnding(type: String = "outro") = SkipInterval(
+        startTime = 52 * 60.0 + 30.0,
+        endTime = 56 * 60.0 + 20.0,
+        type = type,
+        provider = "introdb"
+    )
+
+    @Test
+    fun `crossing into a terminal ending finishes a short episode inside the band`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (shortEpisodeMs * 0.80).toLong(),
+                durationMs = shortEpisodeMs,
+                skipIntervals = listOf(terminalEnding())
+            )
+        )
+    }
+
+    @Test
+    fun `crossing into a terminal ending finishes a long episode inside the band`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.88).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(longTerminalEnding())
+            )
+        )
+    }
+
+    @Test
+    fun `crossing a terminal ending start is enough, without reaching its end`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (shortEpisodeMs * 0.805).toLong(),
+                durationMs = shortEpisodeMs,
+                skipIntervals = listOf(terminalEnding())
+            )
+        )
+    }
+
+    @Test
+    fun `a terminal ending that has not started yet does not finish the episode`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(longTerminalEnding())
+            )
+        )
+    }
+
+    @Test
+    fun `an ending far from the end of the file does not finish the episode`() {
+        // Credits at 48:00-49:30 of a 60 minute file leave over ten minutes of runtime, so
+        // crossing them is not evidence the episode is over.
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.801).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(48 * 60.0, 49 * 60.0 + 30.0, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an ending too long to be credits does not finish the episode`() {
+        // 42:00 to the end of a 60 minute file. The end is terminal, but eighteen minutes is not
+        // a credits sequence, and entering it at 48:00 leaves twelve.
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.80).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(42 * 60.0, longEpisodeMs / 1_000.0, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an ending exactly at the maximum credits length qualifies`() {
+        // Earliest terminal end, so the segment start stays below the 90% fallback and the
+        // length bound is what decides.
+        val endSeconds = (longEpisodeMs / 1_000.0) - maxEndingSeconds
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.87).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(endSeconds - maxEndingSeconds, endSeconds, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an ending one second longer than the maximum does not qualify`() {
+        val endSeconds = (longEpisodeMs / 1_000.0) - maxEndingSeconds
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.87).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(
+                        endSeconds - maxEndingSeconds - 1.0,
+                        endSeconds,
+                        "outro",
+                        "introdb"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `ed and mixed-ed count as ending segments`() {
+        listOf("ed", "mixed-ed").forEach { type ->
+            assertTrue(
+                type,
+                PlaybackCompletionRules.isFinishedOnExit(
+                    positionMs = (shortEpisodeMs * 0.80).toLong(),
+                    durationMs = shortEpisodeMs,
+                    skipIntervals = listOf(terminalEnding(type))
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `a position beyond the duration is finished`() {
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = longEpisodeMs + 5_000L,
+                durationMs = longEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `an outro before the provider floor does not finish the episode`() {
+        // A mid-episode ED cannot promote an exit that is below the provider floor.
+        val startSeconds = (longEpisodeMs * 0.50) / 1_000.0
+
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.70).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(startSeconds, startSeconds + 90.0, "ed", "aniskip")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an ending exactly at the terminal window bound qualifies`() {
+        // Earliest end the window accepts, with a credits-length segment so the end is what
+        // decides.
+        val endSeconds = (longEpisodeMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS) / 1_000.0
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.885).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(endSeconds - 180.0, endSeconds, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an ending one millisecond outside the terminal window does not qualify`() {
+        val endSeconds =
+            (longEpisodeMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS - 1L) / 1_000.0
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.885).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(endSeconds - 180.0, endSeconds, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a non-finite segment time is ignored`() {
+        listOf(
+            Double.NaN to 18 * 60.0 + 30.0,
+            17 * 60.0 to Double.NaN,
+            Double.NEGATIVE_INFINITY to 18 * 60.0 + 30.0,
+            17 * 60.0 to Double.POSITIVE_INFINITY
+        ).forEach { (start, end) ->
+            assertFalse(
+                "$start..$end",
+                PlaybackCompletionRules.isFinishedOnExit(
+                    positionMs = (shortEpisodeMs * 0.80).toLong(),
+                    durationMs = shortEpisodeMs,
+                    skipIntervals = listOf(SkipInterval(start, end, "outro", "aniskip"))
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `a switch that keeps the current item never completes it`() {
+        assertFalse(
+            PlaybackCompletionRules.resolveExitCompletion(
+                leavesCurrentItem = false,
+                positionMs = (shortEpisodeMs * 0.99).toLong(),
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `an exit completes when the rule qualifies`() {
+        assertTrue(
+            PlaybackCompletionRules.resolveExitCompletion(
+                leavesCurrentItem = true,
+                positionMs = (shortEpisodeMs * 0.85).toLong(),
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `an unreported position never completes`() {
+        assertFalse(
+            PlaybackCompletionRules.resolveExitCompletion(
+                leavesCurrentItem = true,
+                positionMs = null,
+                durationMs = shortEpisodeMs
+            )
+        )
+    }
+
+    @Test
+    fun `the fallback tracks the existing completion threshold`() {
+        assertEquals(90f, PlaybackCompletionRules.FALLBACK_COMPLETION_PERCENT, 0.001f)
+        assertEquals(
+            WatchProgress.COMPLETED_THRESHOLD,
+            PlaybackCompletionRules.FALLBACK_COMPLETION_PERCENT / 100f,
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `at or under twenty minutes the remaining-time rule coincides with the floor`() {
+        // Four minutes is 20% of a twenty minute runtime, so at that length and below there is no
+        // 80-90% band left: clearing the floor already means four minutes or less remain.
+        val twentyMinutesMs = 20 * 60_000L
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (twentyMinutesMs * 0.80).toLong() + 1_000L,
+                durationMs = twentyMinutesMs
+            )
+        )
+
+        val fifteenMinutesMs = 15 * 60_000L
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (fifteenMinutesMs * 0.80).toLong() + 1_000L,
+                durationMs = fifteenMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `just over twenty minutes there is a band again`() {
+        val twentyOneMinutesMs = 21 * 60_000L
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (twentyOneMinutesMs * 0.80).toLong() + 1_000L,
+                durationMs = twentyOneMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `at forty minutes the remaining-time rule adds nothing`() {
+        // Four minutes remaining lands exactly on the fallback threshold here, so the two rules
+        // coincide and no band exists: 80% still leaves eight minutes.
+        val fortyMinutesMs = 40 * 60_000L
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (fortyMinutesMs * 0.80).toLong(),
+                durationMs = fortyMinutesMs
+            )
+        )
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = fortyMinutesMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS,
+                durationMs = fortyMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `just under forty minutes a band opens below the fallback`() {
+        // 39 minutes: four minutes remaining is 89.74%, so there is a narrow band under 90%.
+        val thirtyNineMinutesMs = 39 * 60_000L
+        assertTrue(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = thirtyNineMinutesMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS,
+                durationMs = thirtyNineMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `just over forty minutes no band opens below the fallback`() {
+        // 41 minutes: four minutes remaining is 90.24%, past the fallback, so nothing under 90%
+        // can qualify on remaining time.
+        val fortyOneMinutesMs = 41 * 60_000L
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (fortyOneMinutesMs * 0.899).toLong(),
+                durationMs = fortyOneMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `the floor bounds the remaining time rule on very short runtimes`() {
+        // Four minutes is most of a ten minute item. Without the floor the remaining-time rule
+        // would complete it barely past the midpoint. This holds with no tracker connected.
+        val tenMinutesMs = 10 * 60_000L
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = tenMinutesMs - PlaybackCompletionRules.COMPLETION_REMAINING_MS,
+                durationMs = tenMinutesMs
+            )
+        )
+    }
+
+    @Test
+    fun `an open-ended sentinel end does not qualify as terminal`() {
+        // SkipIntroRepository gives the last animeskip timestamp endTime = Double.MAX_VALUE. Left
+        // unguarded that passes the terminal window unconditionally, completing a mid-file ed.
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(
+                        startTime = longEpisodeMs * 0.70 / 1_000.0,
+                        endTime = Double.MAX_VALUE,
+                        type = "ed",
+                        provider = "animeskip"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a segment with a negative start is ignored`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(-30.0, longEpisodeMs / 1_000.0, "outro", "introdb")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a segment with its start after its end is ignored`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(
+                positionMs = (longEpisodeMs * 0.85).toLong(),
+                durationMs = longEpisodeMs,
+                skipIntervals = listOf(
+                    SkipInterval(
+                        startTime = longEpisodeMs * 0.84 / 1_000.0,
+                        endTime = longEpisodeMs * 0.10 / 1_000.0,
+                        type = "outro",
+                        provider = "introdb"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a negative position is never finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(positionMs = -1L, durationMs = longEpisodeMs)
+        )
+    }
+
+    @Test
+    fun `unknown duration is never finished`() {
+        assertFalse(
+            PlaybackCompletionRules.isFinishedOnExit(positionMs = 1_000L, durationMs = 0L)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fix the provider/local progress mismatch, and align local exit completion with the provider's 80% behavior when the remaining runtime allows it.

- Retain local in-progress episode positions when the active provider has no entry.
- Decide exit completion on remaining time and credits segments instead of a flat percentage.
- Keep same-item teardowns and the external-player handoff out of the new completion rule.
- Fix a race where switching episodes could suppress the next episode's completion.

**Tracker behavior is unchanged. Local completion behavior changes.**

Exit completion rule:

```
complete = progress >= 80%
           AND ( progress >= 90%
                 OR remaining <= 4 min
                 OR ( a credits segment has started
                      AND it ends within the final 4 min
                      AND it runs no longer than 4 min ) )
```

The 80% floor applies before any of the qualifications. A credits segment means `outro`, `ed` or `mixed-ed` from the skip-intro providers.

**Maintainer decision requested.** This changes local completion policy, not tracker behavior. The rule runs in the player, so it applies to every exit including movies and users without Trakt or Simkl. Please explicitly approve that scope.

This is not a fixed "less than 20% remaining" threshold. A percentage ignores runtime: 85% of a 22 minute episode leaves three minutes, 85% of a 60 minute episode leaves nine. Four minutes remaining means the same thing on both, which is what a flat threshold cannot express.

| exit | before | after |
| --- | --- | --- |
| 22 min episode at 85% | in progress | completed |
| 60 min episode at 85% | in progress | in progress |
| 60 min episode at 90% | completed | completed |
| any runtime below 80% | in progress | in progress |
| same-item teardown, any progress | unchanged | unchanged |

**What changed**

- `mergeEpisodeProgressWithRetainedLocal` retains in-progress local entries the provider has no key for. Provider entries win; completed local entries are excluded.
- `getAllEpisodeProgress` seeds its local source so the DataStore read does not gate the combined projection.
- `PlaybackCompletionRules` decides exit completion. `isTerminalEndingSegment` accepts a credits segment only when it both ends near the file end and is short enough to be credits; open-ended and malformed intervals are rejected.
- `leavesCurrentItem` distinguishes a real exit from same-item teardown, source and engine switches, and the external-player handoff.
- `EpisodeCompletionLatch` and `currentPlaybackWriteSnapshot` make the completion claim and the position it is based on resolve before the write coroutine can suspend.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Exiting an episode between 80% and 90% left it neither in progress nor watched until history synced.

Tracker completion starts at 80%, while local completion used `WatchProgress.COMPLETED_THRESHOLD` at 90%. `flushPlaybackSnapshotForSwitchOrExit` used the tracker threshold for the stop scrobble and the local 90% threshold for local completion, so an exit between the two marked watched remotely while keeping the item in progress locally.

The episode card had a second cause. `getAllEpisodeProgress` reads only provider progress when one is connected, so the locally saved position was not read back once the provider removed its resume point. Continue Watching already retained local progress; the episode path did not.

## Issue or approval

Fixes #3348

`b580d7e7a` changed `WatchProgress.COMPLETED_THRESHOLD` from 85% to 90%. This PR leaves it at 90% and adds an earlier completion path above an 80% floor for short remaining runtimes.

## Reproduction steps

Requires Trakt or Simkl connected and selected as the watch progress source.

1. Play an episode to roughly 85%, before the next-episode button appears.
2. Exit the player.
3. Check the season overview and Continue Watching.

Before this change the episode has no badge and no progress bar, and Continue Watching still offers it until history syncs. After it, the episode either shows a watched badge or a progress bar at the position reached, depending on how much runtime was left.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

No layout or design change. The existing watched/progress UI now reflects the corrected state.

A watched episode no longer renders a progress bar alongside the badge. Resume still uses the retained position, so a watched episode can offer Resume at 85% where it previously offered Play.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

| Progress source | Tracker connected | Completion rule | Retained-local merge |
| --- | --- | --- | --- |
| Trakt or Simkl | yes | applies | runs |
| Nuvio Sync | yes | applies | not reached |
| Nuvio Sync | no | applies | not reached |
| None | no | applies | not reached |

The completion rule applies to every configuration; retained-local progress applies only to the first.

**Intentionally not changed**

- What the tracker records. A stop scrobble at 85% still marks the episode watched server-side.
- Stop scrobbles on source and engine switches.
- Cloud library playback, which still completes only on a natural end.
- The next-episode card threshold.
- `WatchProgress.COMPLETED_THRESHOLD`, which stays at 90%.
- Retained-local projection for movies. A movie at 85% still shows no retained progress until history syncs.

**No extra polish.** No component, layout or design changes, and no unrelated cleanups.

**Known limitations**

- A retained local position stays visible until the local entry is cleared or the episode completes, so a position removed on another device persists locally.
- `SearchViewModel`, `HomeViewModelPresentationPipeline` and `LibraryViewModel` call `.first()` on the seeded projection and can therefore miss retained entries. Those callers received provider-only data before this PR and receive provider-only data now.
- The credits-length bound is a heuristic. Genuinely longer endings fall back to the 90% threshold.

## Testing

**Unit tests:** 55 new, in `PlaybackCompletionRulesTest` (40), `TrackingProgressProjectionTest` (7), `EpisodeSwitchTargetTest` (4) and `EpisodeCompletionLatchTest` (4), covering the decision table edges, projection merge semantics, episode-switch classification and the completion latch invariant.

**Full suite:** 1225 tests on this branch against 1170 on `dev` at `cf83131c7`, 15 failures on each with identical names. The 55-test difference is exactly the new tests.

**Device:** NVIDIA Shield TV Pro (2019), Android 11, Simkl connected and selected as progress source, both engines exercised. Percentages are `providedProgress` from the scrobble diagnostics. `flag` is `leavesCurrentItem`.

| Scenario | Progress | Flag | Result |
| --- | --- | --- | --- |
| Episodes panel, different episode (short) | 85.07% | true | episode left completed |
| Episodes panel, different episode, playing across the switch | 84.91% | true | episode left completed; next episode completed at its natural end |
| Episodes panel, different episode (long) | 84.93% | true | episode left keeps progress bar |
| Source switch, same episode | 86.27% | false | not completed |
| Engine switch, same episode | 84.66% | false | not completed, bar stable across navigation |
| Source switch, same episode | 95.32% | false | completed, via the 90% rule |
| Long episode exit | 85.08% | true | progress bar |
| Short episode exit | 84.12% | true | completed |
| Short episode exit | 85.98% | true | completed |
| Exit below the floor | 75.19% | true | progress bar |
| Exit below the floor | 73.56% | true | progress bar |
| Movie exit (26:49 runtime) | 84.12% | true | progress bar, below the band |
| Movie exit (26:49 runtime) | 87.85% | true | completed |
| Feature-length movie exit | 89.72% | true | progress bar |
| Feature-length movie exit | 91.69% | true | completed |
| External-player handoff | 87.19% | false | not completed locally |
| External-player handoff | 93.90% | false | completed, via the 90% rule |
| Profile isolation, two profiles | 84.53% / 75.01% | true | second profile shows neither entry |
| Natural end | 99.5% | true | completed, next-episode flow unchanged |

In these tests, a stop scrobble at or above 80% moved the episode into Simkl's history, so a watched badge in the table is often provider-sourced rather than local.

**Not covered:** cloud library playback, for lack of a cloud library on the test device. The credits-segment clause is only the deciding rule when credits start with more than four minutes remaining. Across 95 episodes from 16 shows the median outro is 66 s; on four episodes checked against real runtimes, credits began at 95-97% of runtime.

**Supporting evidence**, from an earlier run before the latch and credits-length changes. The 85.01% row is the reported bug; that card was blank before this change.

| Scenario | Progress | Result |
| --- | --- | --- |
| Long episode exit (57:58) | 85.01% | progress bar retained, CW agrees at 8m left |
| Short episode exit, no tracker connected | 86.34% | completed |
| Resume from the episode card after an 85% exit | 85.33% | resumes at the retained position |

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3348