### PR TITLE
 Handle ASS subtitle styling and lock controls under Libass/MPV

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1498,9 +1498,25 @@ fun PlayerScreen(
             Box(
                 modifier = Modifier.fillMaxSize()
             ) {
+                val isCurrentSubtitleAss = run {
+                    val addon = uiState.selectedAddonSubtitle
+                    if (addon != null) {
+                        val url = addon.url.lowercase(java.util.Locale.US)
+                        return@run url.contains(".ass") || url.contains(".ssa")
+                    }
+                    val track = uiState.subtitleTracks.getOrNull(uiState.selectedSubtitleTrackIndex)
+                    if (track != null) {
+                        val codec = track.codec?.lowercase(java.util.Locale.US).orEmpty()
+                        return@run codec.contains("ass") || codec.contains("ssa") || track.name.contains("ASS", ignoreCase = true)
+                    }
+                    false
+                }
+                val isAssWithLibass = uiState.useLibass && isCurrentSubtitleAss
+
                 SubtitleStyleSidePanel(
                     subtitleStyle = uiState.subtitleStyle,
-                    onEvent = { viewModel.onEvent(it) },
+                    onEvent = { if (!isAssWithLibass) viewModel.onEvent(it) },
+                    isStyleDisabledByLibass = isAssWithLibass,
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                 )
@@ -1543,6 +1559,7 @@ fun PlayerScreen(
             subtitleDelayMs = uiState.subtitleDelayMs,
             installedSubtitleAddonOrder = uiState.installedSubtitleAddonOrder,
             isLoadingAddons = uiState.isLoadingAddonSubtitles,
+            useLibass = uiState.useLibass,
             onInternalTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectSubtitleTrack(it)) },
             onAddonSubtitleSelected = { viewModel.onEvent(PlayerEvent.OnSelectAddonSubtitle(it)) },
             onDisableSubtitles = { viewModel.onEvent(PlayerEvent.OnDisableSubtitles) },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1744,7 +1744,7 @@ private fun ExoPlayerSurface(
                 // Re-apply subtitle style when tracks change so style is applied
                 // even when subtitles are enabled after initial player setup.
                 playerView.post {
-                    playerView.applySubtitleStyleIfNeeded(latestSubtitleStyle)
+                    playerView.applySubtitleStyleIfNeeded(latestSubtitleStyle, force = true)
                 }
             }
         }
@@ -1806,8 +1806,48 @@ private fun PlayerView.applyExoAspectMode(mode: AspectMode) {
     applyExoAspectMode(this, mode)
 }
 
-private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSettings) {
-    if (getTag(R.id.player_view_subtitle_style_tag) == subtitleStyle) {
+private data class SubtitleAppliedConfig(
+    val style: SubtitleStyleSettings,
+    val isAss: Boolean
+)
+
+private fun PlayerView.isAssOrSsaSubtitleSelected(): Boolean {
+    val currentTracks = player?.currentTracks
+    if (currentTracks != null) {
+        for (group in currentTracks.groups) {
+            if (group.type != androidx.media3.common.C.TRACK_TYPE_TEXT) continue
+            for (index in 0 until group.length) {
+                if (!group.isTrackSelected(index)) continue
+                val format = group.getTrackFormat(index)
+                if (format.sampleMimeType == androidx.media3.common.MimeTypes.TEXT_SSA) return true
+                val hasAssCodec = format.codecs
+                    ?.split(',')
+                    ?.asSequence()
+                    ?.map { it.trim().lowercase(java.util.Locale.US) }
+                    ?.any { codec ->
+                        codec == androidx.media3.common.MimeTypes.TEXT_SSA ||
+                            codec == "s_text/ass" ||
+                            codec == "s_text/ssa" ||
+                            codec.endsWith("/x-ssa")
+                    } == true
+                if (hasAssCodec) return true
+            }
+        }
+    }
+    val sidecarKey = subtitleView?.getTag(R.id.player_view_sidecar_generation_tag) as? String
+    if (sidecarKey != null && (sidecarKey.contains(".ass", ignoreCase = true) || sidecarKey.contains(".ssa", ignoreCase = true))) {
+        return true
+    }
+    return false
+}
+
+private fun PlayerView.applySubtitleStyleIfNeeded(
+    subtitleStyle: SubtitleStyleSettings,
+    force: Boolean = false
+) {
+    val isAss = isAssOrSsaSubtitleSelected()
+    val config = SubtitleAppliedConfig(subtitleStyle, isAss)
+    if (!force && getTag(R.id.player_view_subtitle_style_tag) == config) {
         return
     }
     val subView = subtitleView
@@ -1816,7 +1856,7 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
         // tag so that when subtitles become active the style is re-applied.
         return
     }
-    setTag(R.id.player_view_subtitle_style_tag, subtitleStyle)
+    setTag(R.id.player_view_subtitle_style_tag, config)
     subView.apply {
         val baseFontSize = 24f
         val scaledFontSize = baseFontSize * (subtitleStyle.size / 100f)
@@ -1846,7 +1886,7 @@ private fun PlayerView.applySubtitleStyleIfNeeded(subtitleStyle: SubtitleStyleSe
             )
         )
 
-        setApplyEmbeddedStyles(true)
+        setApplyEmbeddedStyles(!isAss)
 
         val bottomPaddingFraction =
             (0.06f + (subtitleStyle.verticalOffset / 250f)).coerceIn(0f, 0.4f)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerScreen.kt
@@ -1511,12 +1511,13 @@ fun PlayerScreen(
                     }
                     false
                 }
-                val isAssWithLibass = uiState.useLibass && isCurrentSubtitleAss
+                val isUsingMpv = uiState.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER
+                val isAssDisabled = isCurrentSubtitleAss && (isUsingMpv || uiState.useLibass)
 
                 SubtitleStyleSidePanel(
                     subtitleStyle = uiState.subtitleStyle,
-                    onEvent = { if (!isAssWithLibass) viewModel.onEvent(it) },
-                    isStyleDisabledByLibass = isAssWithLibass,
+                    onEvent = { if (!isAssDisabled) viewModel.onEvent(it) },
+                    isStyleDisabledByLibass = isAssDisabled,
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                 )
@@ -1560,6 +1561,7 @@ fun PlayerScreen(
             installedSubtitleAddonOrder = uiState.installedSubtitleAddonOrder,
             isLoadingAddons = uiState.isLoadingAddonSubtitles,
             useLibass = uiState.useLibass,
+            isUsingMpv = uiState.internalPlayerEngine == InternalPlayerEngine.MVP_PLAYER,
             onInternalTrackSelected = { viewModel.onEvent(PlayerEvent.OnSelectSubtitleTrack(it)) },
             onAddonSubtitleSelected = { viewModel.onEvent(PlayerEvent.OnSelectAddonSubtitle(it)) },
             onDisableSubtitles = { viewModel.onEvent(PlayerEvent.OnDisableSubtitles) },

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.draw.alpha
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -42,6 +43,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -103,6 +105,7 @@ internal fun SubtitleSelectionOverlay(
     subtitleDelayMs: Int,
     installedSubtitleAddonOrder: List<String>,
     isLoadingAddons: Boolean,
+    useLibass: Boolean = false,
     onInternalTrackSelected: (Int) -> Unit,
     onAddonSubtitleSelected: (Subtitle) -> Unit,
     onDisableSubtitles: () -> Unit,
@@ -259,6 +262,36 @@ internal fun SubtitleSelectionOverlay(
     val styleTargetKey = remember(lastStyleFocusKey) {
         lastStyleFocusKey ?: StyleFocusKey.DelaySet
     }
+    val isStyleDisabledByLibass = remember(
+        useLibass,
+        subtitleOptions,
+        selectedOptionId,
+        sessionInternalTracks,
+        sessionSelectedInternalIndex,
+        sessionSelectedAddonSubtitle
+    ) {
+        if (!useLibass) return@remember false
+        val selectedOption = subtitleOptions.firstOrNull { it.id == selectedOptionId }
+        when (selectedOption?.kind) {
+            SubtitleOptionKind.INTERNAL -> {
+                val track = selectedOption.internalTrackIndex?.let { sessionInternalTracks.getOrNull(it) }
+                val codec = track?.codec?.lowercase(java.util.Locale.US).orEmpty()
+                codec.contains("ass") || codec.contains("ssa") || track?.name?.contains("ASS", ignoreCase = true) == true
+            }
+            SubtitleOptionKind.ADDON -> {
+                val url = selectedOption.addonSubtitle?.url?.lowercase(java.util.Locale.US).orEmpty()
+                url.contains(".ass") || url.contains(".ssa")
+            }
+            null -> {
+                val currentInternalTrack = sessionInternalTracks.getOrNull(sessionSelectedInternalIndex)
+                val internalCodec = currentInternalTrack?.codec?.lowercase(java.util.Locale.US).orEmpty()
+                val addonUrl = sessionSelectedAddonSubtitle?.url?.lowercase(java.util.Locale.US).orEmpty()
+                internalCodec.contains("ass") || internalCodec.contains("ssa") ||
+                    currentInternalTrack?.name?.contains("ASS", ignoreCase = true) == true ||
+                    addonUrl.contains(".ass") || addonUrl.contains(".ssa")
+            }
+        }
+    }
 
     fun requestLanguageFocus(targetKey: String?) {
         val resolvedKey = targetKey
@@ -304,6 +337,7 @@ internal fun SubtitleSelectionOverlay(
     }
 
     fun requestStyleFocus(targetKey: String?, reason: String) {
+        if (isStyleDisabledByLibass) return
         val requestedKey = targetKey ?: StyleFocusKey.DelaySet
         val resolvedKey = when {
             requestedKey.startsWith("${StyleFocusKey.OutlineColorPrefix}:") && !subtitleStyle.outlineEnabled -> {
@@ -354,6 +388,7 @@ internal fun SubtitleSelectionOverlay(
     }
 
     fun moveFocusToStyleRail() {
+        if (isStyleDisabledByLibass) return
         styleEntryOptionId = optionFocusMemory[selectedLanguageKey]?.takeIf { id ->
             subtitleOptions.any { it.id == id }
         } ?: selectedOptionId?.takeIf { id ->
@@ -405,8 +440,8 @@ internal fun SubtitleSelectionOverlay(
             }
         }
 
-        LaunchedEffect(visible, styleRailVisible, styleFocusToken) {
-            if (!visible || !styleRailVisible || styleFocusToken <= 0) return@LaunchedEffect
+        LaunchedEffect(visible, styleRailVisible, styleFocusToken, isStyleDisabledByLibass) {
+            if (!visible || !styleRailVisible || styleFocusToken <= 0 || isStyleDisabledByLibass) return@LaunchedEffect
             val targetKey = pendingStyleFocusKey ?: return@LaunchedEffect
             val requester = styleRequesters[targetKey] ?: run {
                 pendingStyleFocusKey = null
@@ -557,7 +592,8 @@ internal fun SubtitleSelectionOverlay(
                             lastStyleFocusKey = it
                             persistedStyleFocusKey = it
                         },
-                        onEvent = onEvent
+                        onEvent = onEvent,
+                        isStyleDisabledByLibass = isStyleDisabledByLibass
                     )
                 }
             }
@@ -764,11 +800,23 @@ private fun SubtitleStyleRail(
     onMoveLeft: () -> Unit,
     focusRequesters: Map<String, FocusRequester>,
     onStyleFocused: (String) -> Unit,
-    onEvent: (PlayerEvent) -> Unit
+    onEvent: (PlayerEvent) -> Unit,
+    isStyleDisabledByLibass: Boolean = false
 ) {
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val moveLeftKey = if (isRtl) android.view.KeyEvent.KEYCODE_DPAD_RIGHT else android.view.KeyEvent.KEYCODE_DPAD_LEFT
-    RailColumn(width = 280.dp, title = stringResource(R.string.subtitle_style_title)) {
+    val dispatchStyleEvent: (PlayerEvent) -> Unit = { event ->
+        if (!isStyleDisabledByLibass) {
+            onEvent(event)
+        }
+    }
+    val styleCardModifier = if (isStyleDisabledByLibass) Modifier.alpha(0.35f) else Modifier
+    val styleRailModifier = if (isStyleDisabledByLibass) Modifier.focusProperties { canFocus = false } else Modifier
+    RailColumn(
+        width = 280.dp,
+        title = stringResource(R.string.subtitle_style_title),
+        modifier = styleRailModifier
+    ) {
         LazyColumn(
             state = listState,
             verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -778,11 +826,12 @@ private fun SubtitleStyleRail(
         ) {
             item {
                 Card(
-                    onClick = { onEvent(PlayerEvent.OnShowSubtitleDelayOverlay) },
+                    onClick = { dispatchStyleEvent(PlayerEvent.OnShowSubtitleDelayOverlay) },
                     colors = overlayCardColors(selected = false),
                     shape = CardDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md)),
                     modifier = Modifier
                         .fillMaxWidth()
+                        .then(styleCardModifier)
                         .focusRequester(requireNotNull(focusRequesters[StyleFocusKey.DelaySet]))
                         .onPreviewKeyEvent { event ->
                             when (event.nativeKeyEvent.keyCode) {
@@ -827,11 +876,14 @@ private fun SubtitleStyleRail(
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_font_size)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_font_size),
+                    modifier = styleCardModifier
+                ) {
                     StepperRow(
                         value = "${subtitleStyle.size}%",
-                        onDecrease = { onEvent(PlayerEvent.OnSetSubtitleSize(subtitleStyle.size - 10)) },
-                        onIncrease = { onEvent(PlayerEvent.OnSetSubtitleSize(subtitleStyle.size + 10)) },
+                        onDecrease = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleSize(subtitleStyle.size - 10)) },
+                        onIncrease = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleSize(subtitleStyle.size + 10)) },
                         onMoveLeft = onMoveLeft,
                         decrementFocusRequester = focusRequesters[StyleFocusKey.FontSizeDecrease],
                         incrementFocusRequester = focusRequesters[StyleFocusKey.FontSizeIncrease],
@@ -842,7 +894,10 @@ private fun SubtitleStyleRail(
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_bold)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_bold),
+                    modifier = styleCardModifier
+                ) {
                     ToggleChip(
                         label = if (subtitleStyle.bold) stringResource(R.string.subtitle_style_on) else stringResource(R.string.subtitle_style_off),
                         isEnabled = subtitleStyle.bold,
@@ -850,12 +905,15 @@ private fun SubtitleStyleRail(
                         focusRequester = focusRequesters[StyleFocusKey.Bold],
                         focusKey = StyleFocusKey.Bold,
                         onFocused = onStyleFocused,
-                        onClick = { onEvent(PlayerEvent.OnSetSubtitleBold(!subtitleStyle.bold)) }
+                        onClick = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleBold(!subtitleStyle.bold)) }
                     )
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_text_color)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_text_color),
+                    modifier = styleCardModifier
+                ) {
                     ColorChipRow(
                         colors = OverlayTextColors,
                         selectedColor = subtitleStyle.textColor,
@@ -863,23 +921,26 @@ private fun SubtitleStyleRail(
                         focusRequesters = focusRequesters,
                         focusKeyPrefix = StyleFocusKey.TextColorPrefix,
                         onFocused = onStyleFocused,
-                        onColorSelected = { color -> onEvent(PlayerEvent.OnSetSubtitleTextColor(color)) }
+                        onColorSelected = { color -> dispatchStyleEvent(PlayerEvent.OnSetSubtitleTextColor(color)) }
                     )
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_text_opacity)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_text_opacity),
+                    modifier = styleCardModifier
+                ) {
                     val currentColor = Color(subtitleStyle.textColor)
                     val currentAlphaPercent = (currentColor.alpha * 100f).roundToInt().coerceIn(0, 100)
                     StepperRow(
                         value = "$currentAlphaPercent%",
                         onDecrease = {
                             val newAlpha = (currentAlphaPercent - 10).coerceAtLeast(0) / 100f
-                            onEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
+                            dispatchStyleEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
                         },
                         onIncrease = {
                             val newAlpha = (currentAlphaPercent + 10).coerceAtMost(100) / 100f
-                            onEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
+                            dispatchStyleEvent(PlayerEvent.OnSetSubtitleTextColor(currentColor.copy(alpha = newAlpha).toArgb()))
                         },
                         onMoveLeft = onMoveLeft,
                         decrementFocusRequester = focusRequesters[StyleFocusKey.OpacityDecrease],
@@ -891,7 +952,10 @@ private fun SubtitleStyleRail(
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_outline)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_outline),
+                    modifier = styleCardModifier
+                ) {
                     Column(verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.md)) {
                         ToggleChip(
                             label = if (subtitleStyle.outlineEnabled) stringResource(R.string.subtitle_style_on) else stringResource(R.string.subtitle_style_off),
@@ -900,7 +964,7 @@ private fun SubtitleStyleRail(
                             focusRequester = focusRequesters[StyleFocusKey.OutlineToggle],
                             focusKey = StyleFocusKey.OutlineToggle,
                             onFocused = onStyleFocused,
-                            onClick = { onEvent(PlayerEvent.OnSetSubtitleOutlineEnabled(!subtitleStyle.outlineEnabled)) }
+                            onClick = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleOutlineEnabled(!subtitleStyle.outlineEnabled)) }
                         )
                         ColorChipRow(
                             colors = OverlayOutlineColors,
@@ -912,20 +976,23 @@ private fun SubtitleStyleRail(
                             onFocused = onStyleFocused,
                             onColorSelected = { color ->
                                 if (!subtitleStyle.outlineEnabled) {
-                                    onEvent(PlayerEvent.OnSetSubtitleOutlineEnabled(true))
+                                    dispatchStyleEvent(PlayerEvent.OnSetSubtitleOutlineEnabled(true))
                                 }
-                                onEvent(PlayerEvent.OnSetSubtitleOutlineColor(color))
+                                dispatchStyleEvent(PlayerEvent.OnSetSubtitleOutlineColor(color))
                             }
                         )
                     }
                 }
             }
             item {
-                OverlaySectionCard(title = stringResource(R.string.subtitle_style_bottom_offset)) {
+                OverlaySectionCard(
+                    title = stringResource(R.string.subtitle_style_bottom_offset),
+                    modifier = styleCardModifier
+                ) {
                     StepperRow(
                         value = subtitleStyle.verticalOffset.toString(),
-                        onDecrease = { onEvent(PlayerEvent.OnSetSubtitleVerticalOffset(subtitleStyle.verticalOffset - 5)) },
-                        onIncrease = { onEvent(PlayerEvent.OnSetSubtitleVerticalOffset(subtitleStyle.verticalOffset + 5)) },
+                        onDecrease = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleVerticalOffset(subtitleStyle.verticalOffset - 5)) },
+                        onIncrease = { dispatchStyleEvent(PlayerEvent.OnSetSubtitleVerticalOffset(subtitleStyle.verticalOffset + 5)) },
                         onMoveLeft = onMoveLeft,
                         decrementFocusRequester = focusRequesters[StyleFocusKey.OffsetDecrease],
                         incrementFocusRequester = focusRequesters[StyleFocusKey.OffsetIncrease],
@@ -937,10 +1004,11 @@ private fun SubtitleStyleRail(
             }
             item {
                 Card(
-                    onClick = { onEvent(PlayerEvent.OnResetSubtitleDefaults) },
+                    onClick = { dispatchStyleEvent(PlayerEvent.OnResetSubtitleDefaults) },
                     colors = overlayCardColors(selected = false),
                     shape = CardDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md)),
                     modifier = Modifier
+                        .then(styleCardModifier)
                         .focusRequester(requireNotNull(focusRequesters[StyleFocusKey.Reset]))
                         .onPreviewKeyEvent { event ->
                             when (event.nativeKeyEvent.keyCode) {
@@ -978,10 +1046,11 @@ private fun SubtitleStyleRail(
 private fun RailColumn(
     width: androidx.compose.ui.unit.Dp,
     title: String,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
     Column(
-        modifier = Modifier.width(width),
+        modifier = modifier.width(width),
         verticalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.sm)
     ) {
         Text(
@@ -1271,9 +1340,13 @@ private fun OverlayEmptyCard(text: String) {
 @Composable
 private fun OverlaySectionCard(
     title: String,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
         Text(
             text = title,
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleSelectionOverlay.kt
@@ -106,6 +106,7 @@ internal fun SubtitleSelectionOverlay(
     installedSubtitleAddonOrder: List<String>,
     isLoadingAddons: Boolean,
     useLibass: Boolean = false,
+    isUsingMpv: Boolean = false,
     onInternalTrackSelected: (Int) -> Unit,
     onAddonSubtitleSelected: (Subtitle) -> Unit,
     onDisableSubtitles: () -> Unit,
@@ -264,15 +265,16 @@ internal fun SubtitleSelectionOverlay(
     }
     val isStyleDisabledByLibass = remember(
         useLibass,
+        isUsingMpv,
         subtitleOptions,
         selectedOptionId,
         sessionInternalTracks,
         sessionSelectedInternalIndex,
         sessionSelectedAddonSubtitle
     ) {
-        if (!useLibass) return@remember false
+        if (!useLibass && !isUsingMpv) return@remember false
         val selectedOption = subtitleOptions.firstOrNull { it.id == selectedOptionId }
-        when (selectedOption?.kind) {
+        val isAss = when (selectedOption?.kind) {
             SubtitleOptionKind.INTERNAL -> {
                 val track = selectedOption.internalTrackIndex?.let { sessionInternalTracks.getOrNull(it) }
                 val codec = track?.codec?.lowercase(java.util.Locale.US).orEmpty()
@@ -291,6 +293,7 @@ internal fun SubtitleSelectionOverlay(
                     addonUrl.contains(".ass") || addonUrl.contains(".ssa")
             }
         }
+        isAss && (isUsingMpv || useLibass)
     }
 
     fun requestLanguageFocus(targetKey: String?) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/SubtitleStyleSidePanel.kt
@@ -5,6 +5,7 @@ package com.nuvio.tv.ui.screens.player
 import com.nuvio.tv.ui.theme.NuvioTheme
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.draw.alpha
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -77,15 +79,24 @@ private val StyleGridWidth = (StyleCardWidth * 3) + (StyleCardGap * 2)
 internal fun SubtitleStyleSidePanel(
     subtitleStyle: SubtitleStyleSettings,
     onEvent: (PlayerEvent) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isStyleDisabledByLibass: Boolean = false
 ) {
     val firstItemFocusRequester = remember { FocusRequester() }
+    val dispatchStyleEvent: (PlayerEvent) -> Unit = { event ->
+        if (!isStyleDisabledByLibass) {
+            onEvent(event)
+        }
+    }
+    val contentModifier = if (isStyleDisabledByLibass) Modifier.alpha(0.35f) else Modifier
 
     LaunchedEffect(Unit) {
-        kotlinx.coroutines.delay(100)
-        try {
-            firstItemFocusRequester.requestFocus()
-        } catch (_: Exception) {
+        if (!isStyleDisabledByLibass) {
+            kotlinx.coroutines.delay(100)
+            try {
+                firstItemFocusRequester.requestFocus()
+            } catch (_: Exception) {
+            }
         }
     }
 
@@ -95,6 +106,7 @@ internal fun SubtitleStyleSidePanel(
             .height(330.dp)
             .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
             .background(Color(0xFF101010))
+            .then(if (isStyleDisabledByLibass) Modifier.focusProperties { canFocus = false } else Modifier)
             .padding(start = NuvioTheme.spacing.lg, end = NuvioTheme.spacing.lg, top = 22.dp, bottom = 10.dp)
     ) {
         Box(
@@ -117,7 +129,9 @@ internal fun SubtitleStyleSidePanel(
         Spacer(modifier = Modifier.height(6.dp))
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(contentModifier),
             horizontalArrangement = Arrangement.spacedBy(StyleCardGap, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.Top
         ) {


### PR DESCRIPTION
## Summary

- Apply user subtitle appearance settings (e.g. text color, background, outline) to ASS/SSA subtitles on ExoPlayer by disabling embedded styles specifically when ASS/SSA tracks are selected (without Libass).
- Grey out and disable subtitle styling and delay controls with focus lock when ASS subtitles are active under Libass or MPV player, where styles are natively driven by the script.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

1. When playing media with ASS/SSA subtitles on standard ExoPlayer (without Libass), user subtitle styling preferences (such as text color) were completely ignored because embedded script styles were always given priority.
2. When Libass is enabled in settings or when using the MPV engine with ASS subtitles, subtitle rendering and positioning are strictly handled by native ASS scripts. Modifying font sizes, styles, or subtitle delay either has no effect or conflicts with native rendering. As discussed with the maintainer, styling and delay options should be greyed out and locked from D-pad focus when ASS subtitles are rendered via Libass or MPV.

## Issue or approval

[Reported on Discord](https://discord.com/channels/1379902184207941732/1544747458398003282) 

## Reproduction steps

1. Play a video with ASS/SSA subtitles using ExoPlayer (Libass off): change subtitle text color and observe that the subtitle color now updates as expected.
2. Enable Libass in settings or switch player engine to MPV, and select an ASS/SSA subtitle track.
3. Open the subtitle selection overlay or side panel.
4. Observe that the style rail and delay controls are dimmed (greyed out), click actions are disabled, and D-pad focus cannot navigate into the style rail.
5. Switch to a non-ASS subtitle (SRT or VTT) and observe that the style rail and delay controls are fully active and navigable again.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only targets ASS/SSA subtitle styling and focus locking behavior across `PlayerScreen`, `SubtitleSelectionOverlay`, and `SubtitleStyleSidePanel`. Does not alter playback engine logic, stream extraction, or non-ASS subtitle behavior.

## Testing

- Tested with MKV files containing ASS/SSA and SRT subtitle tracks on Android TV / Emulator.
- Verified ExoPlayer without Libass: ASS subtitle color customization works as expected.
- Verified ExoPlayer with Libass enabled: style options and delay are disabled and unfocusable for ASS subtitles; fully functional for SRT.
- Verified MPV player engine: style options and delay are disabled and unfocusable for ASS subtitles; fully functional for SRT.

## Screenshots / Video

Not a UI redesign; controls are dimmed and locked when inactive.

## Breaking changes

None

## Linked issues

[Reported on Discord](https://discord.com/channels/1379902184207941732/1544747458398003282) 