### PR TITLE
fix(profile): make Copy Settings one-directional (Primary -> non-primary)

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
+++ b/app/src/main/java/com/nuvio/tv/core/sync/ProfileSettingsSyncService.kt
@@ -264,6 +264,8 @@ class ProfileSettingsSyncService @Inject constructor(
             syncMutex.withLock {
                 try {
                     require(sourceProfileId != targetProfileId)
+                    require(sourceProfileId == 1) { "Only the primary profile can be used as a settings source" }
+                    require(targetProfileId != 1) { "Cannot copy settings onto the primary profile" }
                     require(profileManager.profiles.value.any { it.id == sourceProfileId })
                     require(profileManager.profiles.value.any { it.id == targetProfileId })
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -599,7 +599,7 @@ fun ProfileSelectionScreen(
                     Text(stringResource(R.string.profile_edit_label))
                 }
 
-                if (profiles.size > 1) {
+                if (profiles.size > 1 && !profile.isPrimary) {
                     Button(
                         onClick = {
                             longPressedProfile = null

--- a/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSettingsCopyDialogs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/profile/ProfileSettingsCopyDialogs.kt
@@ -41,6 +41,7 @@ internal fun ProfileSettingsSourceDialog(
     onDismiss: () -> Unit,
     onConfirm: (sourceProfileId: Int?, copyProviderCredentials: Boolean) -> Unit
 ) {
+    val sourceProfiles = remember(profiles) { profiles.filter { it.isPrimary } }
     var pendingSourceProfileId by remember(selectedSourceProfileId) {
         mutableStateOf(selectedSourceProfileId)
     }
@@ -49,7 +50,7 @@ internal fun ProfileSettingsSourceDialog(
     }
     val focusRequester = remember { FocusRequester() }
     val selectedIndex = selectedSourceProfileId
-        ?.let { selectedId -> profiles.indexOfFirst { it.id == selectedId }.takeIf { it >= 0 } }
+        ?.let { selectedId -> sourceProfiles.indexOfFirst { it.id == selectedId }.takeIf { it >= 0 } }
         ?.plus(1)
         ?: 0
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = selectedIndex)
@@ -90,7 +91,7 @@ internal fun ProfileSettingsSourceDialog(
                     }
                 )
             }
-            items(profiles, key = UserProfile::id) { profile ->
+            items(sourceProfiles, key = UserProfile::id) { profile ->
                 SourceProfileButton(
                     text = profile.copySourceLabel(),
                     selected = profile.id == pendingSourceProfileId,
@@ -155,7 +156,7 @@ internal fun CopyProfileSettingsDialog(
     onCopy: (sourceProfileId: Int, copyProviderCredentials: Boolean) -> Unit
 ) {
     val sourceProfiles = remember(profiles, targetProfile.id) {
-        profiles.filterNot { it.id == targetProfile.id }
+        profiles.filter { it.isPrimary && it.id != targetProfile.id }
     }
     val defaultSourceId = remember(sourceProfiles, targetProfile.id) {
         sourceProfiles.firstOrNull { it.isPrimary }?.id ?: sourceProfiles.firstOrNull()?.id


### PR DESCRIPTION
## Summary

- Restricted the Copy Settings feature on the Profile Selection screen so settings can only be copied from the Primary profile onto a non-primary profile, never the reverse.
- The Primary profile no longer offers a Copy Settings action, since it can no longer be a valid copy target.
- The source-profile picker in both the profile creation flow and the existing-profile Copy Settings dialog now only lists the Primary profile as an available source.
- Added a guard in ProfileSettingsSyncService.copyProfileSetup that requires sourceProfileId == 1 and targetProfileId != 1, enforcing the rule at the service layer regardless of which UI entry point calls it.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The Copy Settings dialogs allowed any profile to be selected as the settings source for any other profile, including copying a non-primary profile's settings onto the Primary profile. This created a confusing bidirectional relationship where both the Primary profile and a secondary profile appeared able to copy from each other, and allowed a secondary profile to overwrite Primary's settings, which was never the intended behavior.

## Issue or approval

Fixes #3334

## Reproduction steps

1. Create at least one additional profile besides Primary (for example, Profile 2).
2. Open Profile Selection and long-press the Primary profile card.
3. Select Copy Settings. The dialog allows choosing Profile 2 as the source, which overwrites Primary's settings with Profile 2's settings.
4. Separately, long-press Profile 2's card and select Copy Settings. The dialog offers Primary as the default source, giving the impression both profiles are mutually configured to copy from each other.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the profile Copy Settings flow is affected: the long-press menu entry, the profile creation source picker, and the existing-profile Copy Settings dialog.
- The usesPrimaryAddons / usesPrimaryPlugins addon and plugin sharing toggle is untouched. It was confirmed during investigation to already be one-directional (read-only from Primary) and is unrelated to this bug.
- No changes to UserProfile, the local ProfileDataStore, or any Supabase/remote schema. No new persisted state was introduced.

## Testing

- Verified by code inspection that the Copy Settings option no longer renders on the Primary profile's long-press menu.
- Verified that the source-profile list in CopyProfileSettingsDialog and ProfileSettingsSourceDialog only ever contains the Primary profile.
- Verified that ProfileSettingsSyncService.copyProfileSetup now rejects any call where sourceProfileId is not the Primary profile or targetProfileId is the Primary profile.
- Unable to run a full instrumented build or on-device test in this environment (no Android SDK configured). A gradle build and manual on-device verification of the flows above is recommended before merge.

## Screenshots / Video

Not captured. This change removes a menu entry and filters an existing picker's contents; no new screens or visual layout were introduced. See reproduction and testing steps above for the exact flows affected.

## Breaking changes

None.

## Linked issues

Fixes #3334
