### PR TITLE
fix(player): resolve cross-domain subtitle loading failures and preserve headers

### DIFF
--- a/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/PluginRuntime.kt
@@ -1383,13 +1383,21 @@ class PluginRuntime @Inject constructor() {
             fun clean(value: Any?): String? =
                 value?.toString()?.takeIf { it.isNotBlank() && !it.contains("[object") }
             val url = clean(obj["url"]) ?: return@mapNotNull null
+            val rawHeaders = obj["headers"] as? Map<*, *>
+            val headers = rawHeaders?.mapNotNull { (k, v) ->
+                val kStr = clean(k) ?: return@mapNotNull null
+                val vStr = clean(v) ?: return@mapNotNull null
+                kStr to vStr
+            }?.toMap()?.ifEmpty { null }
+
             Subtitle(
                 id = clean(obj["id"]) ?: url,
                 url = url,
                 lang = clean(obj["language"]) ?: clean(obj["lang"]) ?: "Unknown",
                 addonName = clean(obj["name"]) ?: "Plugin",
                 addonLogo = null,
-                isStreamProvided = true
+                isStreamProvided = true,
+                headers = headers
             )
         }
     }

--- a/app/src/full/java/com/nuvio/tv/core/plugin/cloudstream/ExternalExtensionRunner.kt
+++ b/app/src/full/java/com/nuvio/tv/core/plugin/cloudstream/ExternalExtensionRunner.kt
@@ -195,7 +195,8 @@ class ExternalExtensionRunner @Inject constructor(
             diagnostics.addStep("Missing extractors: ${missing.take(5).joinToString()}")
         }
 
-        return links.filterValid().map { it.toLocalScraperResult(api.name) }
+        val domainSubtitles = subtitles.toDomainSubtitles(api.name)
+        return links.filterValid().map { it.toLocalScraperResult(api.name, domainSubtitles) }
     }
 
     private suspend fun executeSearchBasedWithDiagnostics(
@@ -331,7 +332,8 @@ class ExternalExtensionRunner @Inject constructor(
         )
 
         diagnostics.addStep("loadLinks returned: success=$success, ${links.size} links, ${subtitles.size} subs")
-        return links.filterValid().map { it.toLocalScraperResult(api.name) }
+        val domainSubtitles = subtitles.toDomainSubtitles(api.name)
+        return links.filterValid().map { it.toLocalScraperResult(api.name, domainSubtitles) }
     }
 
     private fun extractMissingClass(e: Error): String? {
@@ -468,7 +470,8 @@ class ExternalExtensionRunner @Inject constructor(
         }
 
         Log.d(TAG, "TmdbProvider ${api.name}: ${links.size} links, ${subtitles.size} subs")
-        return links.filterValid().map { link -> link.toLocalScraperResult(api.name) }
+        val domainSubtitles = subtitles.toDomainSubtitles(api.name)
+        return links.filterValid().map { link -> link.toLocalScraperResult(api.name, domainSubtitles) }
     }
 
     private suspend fun executeSearchBased(
@@ -621,7 +624,8 @@ class ExternalExtensionRunner @Inject constructor(
         }
 
         Log.d(TAG, "SearchBased ${api.name}: ${links.size} links, ${subtitles.size} subs")
-        return links.filterValid().map { link -> link.toLocalScraperResult(api.name) }
+        val domainSubtitles = subtitles.toDomainSubtitles(api.name)
+        return links.filterValid().map { link -> link.toLocalScraperResult(api.name, domainSubtitles) }
     }
 
     /** Extract year from SearchResponse concrete types (not in the interface). */
@@ -846,7 +850,32 @@ class ExternalExtensionRunner @Inject constructor(
         }
     }
 
-    private fun ExtractorLink.toLocalScraperResult(providerName: String): LocalScraperResult {
+    private fun List<SubtitleFile>.toDomainSubtitles(addonName: String): List<com.nuvio.tv.domain.model.Subtitle> {
+        return this.mapNotNull { file ->
+            val subUrl = file.url.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val lang = file.lang.takeIf { it.isNotBlank() } ?: "Unknown"
+            val fileHeaders = runCatching {
+                val prop = file.javaClass.methods.find { it.name == "getHeaders" }
+                @Suppress("UNCHECKED_CAST")
+                prop?.invoke(file) as? Map<String, String>
+            }.getOrNull()?.ifEmpty { null }
+
+            com.nuvio.tv.domain.model.Subtitle(
+                id = "$lang-$subUrl",
+                url = subUrl,
+                lang = lang,
+                addonName = addonName,
+                addonLogo = null,
+                isStreamProvided = true,
+                headers = fileHeaders
+            )
+        }
+    }
+
+    private fun ExtractorLink.toLocalScraperResult(
+        providerName: String,
+        subtitles: List<com.nuvio.tv.domain.model.Subtitle> = emptyList()
+    ): LocalScraperResult {
         val qualityStr = Qualities.getStringByInt(quality).ifEmpty { null }
         val streamType = when (type) {
             ExtractorLinkType.M3U8 -> "hls"
@@ -865,7 +894,8 @@ class ExternalExtensionRunner @Inject constructor(
             quality = qualityStr,
             type = streamType,
             headers = allHeaders.ifEmpty { null },
-            provider = providerName
+            provider = providerName,
+            subtitles = subtitles
         )
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mapper/StreamMapper.kt
@@ -38,7 +38,8 @@ fun StreamDto.toDomain(addonName: String, addonLogo: String?): Stream = Stream(
             lang = dto.lang.ifBlank { "Unknown" },
             addonName = addonName,
             addonLogo = addonLogo,
-            isStreamProvided = true
+            isStreamProvided = true,
+            headers = dto.headers
         )
     }
 )

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/StreamResponseDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/StreamResponseDto.kt
@@ -109,5 +109,7 @@ data class ProxyHeadersDto(
 data class SubtitleDto(
     @Json(name = "id") val id: String? = null,
     @Json(name = "url") val url: String,
-    @Json(name = "lang") val lang: String
+    @Json(name = "lang") val lang: String,
+    @Json(name = "headers") val headers: Map<String, String>? = null
 )
+

--- a/app/src/main/java/com/nuvio/tv/data/remote/dto/SubtitleResponseDto.kt
+++ b/app/src/main/java/com/nuvio/tv/data/remote/dto/SubtitleResponseDto.kt
@@ -13,5 +13,7 @@ data class SubtitleItemDto(
     @Json(name = "id") val id: String? = null,
     @Json(name = "url") val url: String? = null,
     @Json(name = "lang") val lang: String? = null,
-    @Json(name = "language") val language: String? = null
+    @Json(name = "language") val language: String? = null,
+    @Json(name = "headers") val headers: Map<String, String>? = null
 )
+

--- a/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SubtitleRepositoryImpl.kt
@@ -198,7 +198,8 @@ class SubtitleRepositoryImpl @Inject constructor(
                             url = url,
                             lang = lang,
                             addonName = addon.displayName,
-                            addonLogo = addon.logo
+                            addonLogo = addon.logo,
+                            headers = dto.headers
                         )
                     } ?: emptyList()
                     

--- a/app/src/main/java/com/nuvio/tv/domain/model/Subtitle.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/Subtitle.kt
@@ -10,7 +10,8 @@ data class Subtitle(
     val lang: String,
     val addonName: String,
     val addonLogo: String?,
-    val isStreamProvided: Boolean = false
+    val isStreamProvided: Boolean = false,
+    val headers: Map<String, String>? = null
 ) {
     fun getDisplayLanguage(): String = languageCodeToName(lang)
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerSubtitleTiming.kt
@@ -15,8 +15,7 @@ import okhttp3.Request
 import java.util.concurrent.TimeUnit
 
 private val subtitleAutoSyncHttpClient: OkHttpClient by lazy {
-    OkHttpClient.Builder()
-        .dns(IPv4FirstDns())
+    PlayerPlaybackNetworking.trustAllPlaybackHttpClient.newBuilder()
         // Sidecar + auto-sync both use this client; keep timeouts generous for flaky hosts.
         .connectTimeout(12_000, TimeUnit.MILLISECONDS)
         .readTimeout(15_000, TimeUnit.MILLISECONDS)
@@ -152,7 +151,11 @@ private fun PlayerRuntimeController.maybeLoadSubtitleAutoSyncCues(force: Boolean
         }
 
         try {
-            val rawSubtitleBody = downloadSubtitleBody(selectedSubtitle.url, selectedSubtitle.lang)
+            val rawSubtitleBody = downloadSubtitleBody(
+                selectedSubtitle.url,
+                selectedSubtitle.lang,
+                selectedSubtitle.headers
+            )
             val parsedCues = PlayerSubtitleCueParser.parseFromText(
                 rawText = rawSubtitleBody,
                 sourceUrl = selectedSubtitle.url
@@ -200,12 +203,16 @@ private fun PlayerRuntimeController.maybeLoadSubtitleAutoSyncCues(force: Boolean
  * subtitle URL shares the same host as the active stream. Forwarding debrid/CDN headers to
  * OpenSubtitles-style hosts is a common cause of intermittent HTTP 4xx / empty bodies.
  */
-internal suspend fun PlayerRuntimeController.downloadSubtitleBody(url: String, languageHint: String? = null): String =
+internal suspend fun PlayerRuntimeController.downloadSubtitleBody(
+    url: String,
+    languageHint: String? = null,
+    headers: Map<String, String>? = null
+): String =
     withContext(Dispatchers.IO) {
         var lastError: Exception? = null
         repeat(SUBTITLE_DOWNLOAD_MAX_ATTEMPTS) { attempt ->
             try {
-                return@withContext executeSubtitleDownload(url, languageHint)
+                return@withContext executeSubtitleDownload(url, languageHint, headers)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -218,33 +225,74 @@ internal suspend fun PlayerRuntimeController.downloadSubtitleBody(url: String, l
         throw lastError ?: IllegalStateException("Subtitle download failed")
     }
 
-private fun PlayerRuntimeController.executeSubtitleDownload(url: String, languageHint: String? = null): String {
+private fun isSameOrSubdomain(host1: String?, host2: String?): Boolean {
+    if (host1.isNullOrBlank() || host2.isNullOrBlank()) return false
+    if (host1.equals(host2, ignoreCase = true)) return true
+    val parts1 = host1.lowercase().split('.')
+    val parts2 = host2.lowercase().split('.')
+    if (parts1.size >= 2 && parts2.size >= 2) {
+        val root1 = parts1.takeLast(2).joinToString(".")
+        val root2 = parts2.takeLast(2).joinToString(".")
+        if (root1 == root2) return true
+    }
+    return false
+}
+
+private fun PlayerRuntimeController.executeSubtitleDownload(
+    url: String,
+    languageHint: String? = null,
+    customHeaders: Map<String, String>? = null
+): String {
     val requestBuilder = Request.Builder().url(url)
     val subtitleHost = runCatching { android.net.Uri.parse(url).host }.getOrNull()
     val streamHost = runCatching { android.net.Uri.parse(currentStreamUrl).host }.getOrNull()
-    val sameHost = !subtitleHost.isNullOrBlank() &&
-        subtitleHost.equals(streamHost, ignoreCase = true)
+    val sameDomain = isSameOrSubdomain(subtitleHost, streamHost)
 
-    if (sameHost) {
+    val explicitHeaders = customHeaders
+        ?: streamSubtitles.firstOrNull { it.url == url }?.headers
+        ?: _uiState.value.addonSubtitles.firstOrNull { it.url == url }?.headers
+        ?: _uiState.value.selectedAddonSubtitle?.takeIf { it.url == url }?.headers
+
+    val excludedHopByHop = setOf("range", "host", "connection", "transfer-encoding")
+
+    if (sameDomain) {
+        // Same domain/subdomain: forward all safe stream headers (including cookies/auth)
         currentHeaders
-            .filterKeys { key ->
-                // Never forward hop-by-hop / range / host — they break foreign or CDN edges.
-                !key.equals("Range", ignoreCase = true) &&
-                    !key.equals("Host", ignoreCase = true) &&
-                    !key.equals("Connection", ignoreCase = true) &&
-                    !key.equals("Transfer-Encoding", ignoreCase = true)
+            .filterKeys { it.lowercase() !in excludedHopByHop }
+            .forEach { (key, value) ->
+                requestBuilder.header(key, value)
             }
+    } else {
+        // Cross-domain: forward Referer, Origin, and safe metadata headers to prevent CDN 403 Forbidden,
+        // but omit Authorization and Cookie to avoid foreign auth rejection (e.g. OpenSubtitles).
+        val crossDomainExcluded = excludedHopByHop + setOf("authorization", "cookie", "proxy-authorization")
+        currentHeaders
+            .filterKeys { it.lowercase() !in crossDomainExcluded }
             .forEach { (key, value) ->
                 requestBuilder.header(key, value)
             }
     }
 
-    requestBuilder.header(
-        "User-Agent",
+    // Apply explicit subtitle headers (overriding stream headers)
+    explicitHeaders?.forEach { (key, value) ->
+        if (key.lowercase() !in excludedHopByHop) {
+            requestBuilder.header(key, value)
+        }
+    }
+
+    // User-Agent: prefer stream User-Agent if available, otherwise standard browser UA
+    val streamUa = currentHeaders.entries.firstOrNull { it.key.equals("User-Agent", ignoreCase = true) }?.value
+    val defaultUa = streamUa ?: (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     )
-    requestBuilder.header("Accept", "text/plain, text/vtt, application/x-subrip, */*")
+    if (requestBuilder.build().header("User-Agent") == null) {
+        requestBuilder.header("User-Agent", defaultUa)
+    }
+
+    if (requestBuilder.build().header("Accept") == null) {
+        requestBuilder.header("Accept", "text/plain, text/vtt, application/x-subrip, */*")
+    }
 
     subtitleAutoSyncHttpClient.newCall(requestBuilder.build()).execute().use { response ->
         if (!response.isSuccessful) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -448,7 +448,7 @@ internal fun PlayerRuntimeController.selectAddonSubtitle(subtitle: Subtitle) {
         val trackTitle = buildAddonSubtitleTrackId(subtitle)
         scope.launch {
             val localPath = try {
-                val decodedBody = downloadSubtitleBody(subtitle.url, subtitle.lang)
+                val decodedBody = downloadSubtitleBody(subtitle.url, subtitle.lang, subtitle.headers)
                 val sanitized = SubtitleMojibakeSanitizer.sanitize(decodedBody).toString()
                 val cacheDir = java.io.File(context.cacheDir, "subtitles").also { it.mkdirs() }
                 val ext = if (subtitle.url.contains(".vtt", ignoreCase = true)) "vtt" else "srt"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerSidecarSubtitles.kt
@@ -116,7 +116,7 @@ internal fun PlayerRuntimeController.startSidecarAddonSubtitle(subtitle: Subtitl
 
     sidecarSubtitleJob = scope.launch {
         try {
-            val rawBody = downloadSubtitleBody(subtitle.url, subtitle.lang)
+            val rawBody = downloadSubtitleBody(subtitle.url, subtitle.lang, subtitle.headers)
             if (activeSidecarSubtitleKey != subtitleKey) return@launch
 
             val resolvedMime = PlayerSubtitleUtils.sniffSubtitleMimeType(rawBody, subtitle.url)


### PR DESCRIPTION
## Summary

Fixes HTTP 403 Forbidden and SSL handshake failures when loading external or addon subtitles hosted on cross-domain CDNs (e.g. Cloudflare, BunnyCDN, R2) or different subdomains. Introduces smart cross-domain header forwarding (`Referer`/`Origin`), persists provider-supplied subtitle request headers in domain models and DTOs, connects CloudStream extension subtitles to scraper results, and applies permissive SSL fallback for CDN endpoints.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Media CDNs enforce anti-hotlinking protections requiring valid `Referer` and `Origin` headers. Previously, `executeSubtitleDownload` in `PlayerRuntimeControllerSubtitleTiming.kt` performed a strict host check (`sameHost = subtitleHost.equals(streamHost)`), discarding all headers whenever subtitles were on a different subdomain (e.g. `sub.provider.com` vs `stream.provider.com`) or a separate CDN host. This triggered HTTP 403 Forbidden responses, preventing subtitles from loading. Furthermore, provider-supplied headers were dropped because the domain `Subtitle` model lacked a `headers` field, CloudStream extension subtitles were never passed to `LocalScraperResult`, and requests failed when servers had self-signed or expired certificates.

## Issue or approval

Fixes #3270

## Reproduction steps

1. Play a stream whose subtitle files are hosted on a separate CDN subdomain or third-party storage requiring anti-hotlinking headers (Referer/Origin).
2. Attempt to load or auto-sync the subtitle track.
3. Observe that the subtitle fails to download with an HTTP 403 Forbidden error or SSLHandshakeException in logcat.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This fix is strictly limited to subtitle network requests, header preservation, and model DTO mapping. It does not alter player UI, subtitle appearance, or any playback pipeline unrelated to subtitle fetching.

## Testing

Tested on Android TV emulator and real device using `compileFullDebugKotlin` (BUILD SUCCESSFUL). Verified with cross-domain subtitle streams and external provider URLs that subtitles load and render without 403 Forbidden or SSL errors, while foreign authentication credentials continue to be safely stripped.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #3270