### PR TITLE
Fix Search: keep matching titles in the keyboard suggestion bar

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -445,8 +445,10 @@ fun SearchScreen(
         runCatching { topInputFocusRequester.requestFocus() }
     }
 
-    // Push search suggestions to the native keyboard suggestion bar
-    LaunchedEffect(uiState.suggestions) {
+    // Push search suggestions to the native keyboard suggestion bar. Keyed on the query as well
+    // as the list: the keyboard rebuilds its strip as the query changes, so completions have to
+    // be pushed again even when the list is unchanged.
+    LaunchedEffect(uiState.query, uiState.suggestions) {
         val imm = context.getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as? InputMethodManager
             ?: return@LaunchedEffect
         val completions = uiState.suggestions.mapIndexed { index, name ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -249,8 +249,14 @@ class SearchViewModel @Inject constructor(
     private fun onQueryChanged(query: String) {
         _uiState.update {
             val trimmedInput = query.trim()
+            // Narrow the strip to what still matches before anything is fetched, so a letter
+            // that rules a title out drops it on that keystroke rather than a fetch later.
+            // Narrowing does not clear the strip when every current title stops matching. The
+            // fetch stays authoritative for an empty result.
+            val narrowed = rankedSuggestions(it.suggestions, trimmedInput.lowercase())
             it.copy(
                 query = query,
+                suggestions = if (narrowed.isEmpty()) it.suggestions else narrowed,
                 error = null,
                 isSearching = false,
                 // Keep whatever is on screen while a keystroke waits to run. Clearing here flashed
@@ -302,6 +308,14 @@ class SearchViewModel @Inject constructor(
         return if (everyWordMatches) 3 else null
     }
 
+    /** The strip contents for [names], best match first, capped at [MAX_SUGGESTIONS]. */
+    private fun rankedSuggestions(names: Collection<String>, queryLower: String): List<String> =
+        names
+            .mapNotNull { name -> suggestionRank(name, queryLower)?.let { name to it } }
+            .sortedWith(compareBy({ it.second }, { it.first.lowercase() }))
+            .map { it.first }
+            .take(MAX_SUGGESTIONS)
+
     private fun fetchSuggestions(query: String) {
         suggestionJob?.cancel()
 
@@ -310,9 +324,10 @@ class SearchViewModel @Inject constructor(
             return
         }
 
-        // Don't show suggestions if the query already matches the submitted search
+        // Already searched, so a fetch would repeat itself and the strip is current. Leave it
+        // standing: live search submits as the user types, so typing a space between words
+        // trims back to the submitted query and lands here mid-query.
         if (query == _uiState.value.submittedQuery.trim() && _uiState.value.catalogRows.isNotEmpty()) {
-            _uiState.update { it.copy(suggestions = emptyList()) }
             return
         }
 
@@ -355,19 +370,23 @@ class SearchViewModel @Inject constructor(
                                 result.data.items.forEach { item ->
                                     if (collectedNames.add(item.name)) added = true
                                 }
-                                // Push updated suggestions immediately as each addon responds
+                                // Catalog results arrive independently and accumulate into one
+                                // shared set, so a batch whose titles all fail the filter ranks
+                                // to nothing while the batch holding the match is still in
+                                // flight. Only the settle below may empty the strip: an empty
+                                // push tells the keyboard there are no completions, and it does
+                                // not always take them back when the next batch lands.
                                 if (added) {
-                                    val sorted = collectedNames
-                                        .mapNotNull { name ->
-                                            suggestionRank(name, queryLower)?.let { name to it }
-                                        }
-                                        .sortedWith(compareBy({ it.second }, { it.first.lowercase() }))
-                                        .map { it.first }
-                                        .take(MAX_SUGGESTIONS)
-                                    _uiState.update { it.copy(suggestions = sorted) }
+                                    val ranked = rankedSuggestions(collectedNames, queryLower)
+                                    if (ranked.isNotEmpty()) {
+                                        _uiState.update { it.copy(suggestions = ranked) }
+                                    }
                                 }
                             }
                         }
+                    } catch (e: CancellationException) {
+                        // The settle below treats joinAll() as "collection is over".
+                        throw e
                     } catch (_: Exception) {
                         // Ignore per-catalog errors for suggestions
                     }
@@ -376,12 +395,12 @@ class SearchViewModel @Inject constructor(
 
             suggestionJobs.joinAll()
 
-            // Nothing came back for this query. The strip keeps the previous query's titles
-            // while a fetch is in flight, to avoid blinking on every keystroke, so without this
-            // it would keep captioning text the field no longer contains. Live search used to
-            // clear it as a side effect; it no longer does.
-            if (collectedNames.isEmpty() && _uiState.value.query.trim() == query) {
-                _uiState.update { it.copy(suggestions = emptyList()) }
+            // Every catalog job has completed, so this is the first point the query is known
+            // to have no suggestions. Until here the strip keeps the previous query's titles
+            // rather than blinking on every keystroke. It must be cleared here or it would go
+            // on captioning text the field no longer contains.
+            if (_uiState.value.query.trim() == query) {
+                _uiState.update { it.copy(suggestions = rankedSuggestions(collectedNames, queryLower)) }
             }
         }
     }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelSuggestionsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelSuggestionsTest.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
@@ -43,6 +44,11 @@ private const val SHORT_TITLE = "Wolf"
 /** Alphabetically ahead of the wolf titles, so an unfiltered strip shows these first. */
 private const val HYPHENATED_TITLE = "Spider-Man"
 private val CATALOG = listOf("Alpha", "Beasts of No Nation", HYPHENATED_TITLE, SHORT_TITLE, TITLE)
+
+/** Answered by the catalog that holds nothing useful, and matching nothing typed here. */
+private val UNRELATED = listOf("Alpha", "Beasts of No Nation")
+private const val UNRELATED_CATALOG = "unrelated"
+private const val MATCHING_CATALOG = "matching"
 
 /**
  * Suggestions are pushed to the keyboard's own suggestion strip while the user types, so they
@@ -234,8 +240,107 @@ class SearchViewModelSuggestionsTest {
         assertEquals(listOf(HYPHENATED_TITLE), viewModel.uiState.value.suggestions)
     }
 
-    private fun newViewModel(catalogIgnoresQuery: Boolean = false): SearchViewModel {
-        val addon = searchableAddon()
+    /** Narrowing only removes, so a broader query has to wait for the fetch to fill it back in. */
+    @Test
+    fun `a fetch puts back a title that narrowing had removed`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf o"))
+        advanceUntilIdle()
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceTimeBy(50)
+        runCurrent()
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+
+        advanceUntilIdle()
+        assertEquals(listOf(SHORT_TITLE, TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    /** SUGGESTION_DEBOUNCE_MS has not elapsed, so nothing has been fetched for the new query. */
+    @Test
+    fun `a keystroke that rules a title out drops it before the fetch runs`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+        assertEquals(listOf(SHORT_TITLE, TITLE), viewModel.uiState.value.suggestions)
+
+        // "Wolf" no longer matches the two word query.
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf o"))
+        advanceTimeBy(50)
+        runCurrent()
+
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `a keystroke that rules every title out leaves the strip standing`() = runTest {
+        val viewModel = newViewModel(catalogIgnoresQuery = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolfx"))
+        advanceTimeBy(50)
+        runCurrent()
+
+        assertEquals(listOf(SHORT_TITLE, TITLE), viewModel.uiState.value.suggestions)
+
+        // The fetch is what may empty it, once it has answered.
+        advanceUntilIdle()
+        assertEquals(emptyList<String>(), viewModel.uiState.value.suggestions)
+    }
+
+    /**
+     * One catalog answers with titles that all fail the filter while the catalog holding the
+     * match is still fetching, which used to push an empty strip for as long as that took.
+     */
+    @Test
+    fun `an intermediate batch that ranks to nothing leaves the strip standing`() = runTest {
+        val viewModel = newViewModel(staged = true)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wol"))
+        advanceUntilIdle()
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+
+        // Past SUGGESTION_DEBOUNCE_MS, so the unrelated batch has landed and the matching one
+        // has not. The strip should still be showing what it had.
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceTimeBy(200)
+        runCurrent()
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+
+        advanceUntilIdle()
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    /** Live search submits as the user types, so a space trims back to the submitted query. */
+    @Test
+    fun `typing a space between words leaves the strip standing`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+        assertEquals("wolf", viewModel.uiState.value.submittedQuery)
+        assertTrue(viewModel.uiState.value.catalogRows.isNotEmpty())
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf "))
+        advanceUntilIdle()
+
+        assertEquals(listOf(TITLE), viewModel.uiState.value.suggestions)
+    }
+
+    private fun newViewModel(
+        catalogIgnoresQuery: Boolean = false,
+        staged: Boolean = false
+    ): SearchViewModel {
+        val addon = if (staged) {
+            searchableAddon(listOf(UNRELATED_CATALOG, MATCHING_CATALOG))
+        } else {
+            searchableAddon()
+        }
 
         val layoutPreferences = mockk<LayoutPreferenceDataStore>()
         every { layoutPreferences.discoverLocation } returns flowOf(com.nuvio.tv.domain.model.DiscoverLocation.OFF)
@@ -258,7 +363,11 @@ class SearchViewModelSuggestionsTest {
 
         return SearchViewModel(
             addonRepository = SingleAddonRepository(addon),
-            catalogRepository = TitleCatalogRepository(addon, catalogIgnoresQuery),
+            catalogRepository = if (staged) {
+                StagedCatalogRepository(addon)
+            } else {
+                TitleCatalogRepository(addon, catalogIgnoresQuery)
+            },
             metaRepository = mockk(relaxed = true),
             discoverSelectionDataStore = mockk(relaxed = true),
             layoutPreferenceDataStore = layoutPreferences,
@@ -330,13 +439,64 @@ class SearchViewModelSuggestionsTest {
         )
     }
 
-    private fun searchableAddon(): Addon {
-        val catalog = CatalogDescriptor(
+    /** Two catalogs of one addon answering out of order: the one with no usable titles first,
+     *  the one holding the match after a pause. */
+    private class StagedCatalogRepository(private val addon: Addon) : CatalogRepository {
+        override fun getCatalog(
+            addonBaseUrl: String,
+            addonId: String,
+            addonName: String,
+            catalogId: String,
+            catalogName: String,
+            type: String,
+            skip: Int,
+            skipStep: Int,
+            extraArgs: Map<String, String>,
+            supportsSkip: Boolean
+        ): Flow<NetworkResult<CatalogRow>> = flow {
+            emit(NetworkResult.Loading)
+            if (catalogId == MATCHING_CATALOG) {
+                delay(100)
+                emit(NetworkResult.Success(row(catalogId, listOf(TITLE))))
+            } else {
+                emit(NetworkResult.Success(row(catalogId, UNRELATED)))
+            }
+        }
+
+        private fun row(catalogId: String, titles: List<String>): CatalogRow = CatalogRow(
+            addonId = addon.id,
+            addonName = addon.displayName,
+            addonBaseUrl = addon.baseUrl,
+            catalogId = catalogId,
+            catalogName = catalogId,
             type = ContentType.MOVIE,
-            id = "top",
-            name = "Top",
-            extra = listOf(CatalogExtra(name = "search"))
+            items = titles.map { title ->
+                MetaPreview(
+                    id = "id_${title.hashCode()}",
+                    type = ContentType.MOVIE,
+                    name = title,
+                    poster = null,
+                    posterShape = PosterShape.POSTER,
+                    background = null,
+                    logo = null,
+                    description = null,
+                    releaseInfo = null,
+                    imdbRating = null,
+                    genres = emptyList()
+                )
+            }
         )
+    }
+
+    private fun searchableAddon(catalogIds: List<String> = listOf("top")): Addon {
+        val catalogs = catalogIds.map { id ->
+            CatalogDescriptor(
+                type = ContentType.MOVIE,
+                id = id,
+                name = id,
+                extra = listOf(CatalogExtra(name = "search"))
+            )
+        }
         return Addon(
             id = "addon",
             name = "Addon",
@@ -344,7 +504,7 @@ class SearchViewModelSuggestionsTest {
             description = null,
             logo = null,
             baseUrl = "https://example.test",
-            catalogs = listOf(catalog),
+            catalogs = catalogs,
             types = listOf(ContentType.MOVIE),
             resources = emptyList()
         )


### PR DESCRIPTION
## Summary

Push search completions to the keyboard on every query change instead of only when the suggestion list changes, and stop the list being emptied while catalog requests are still in flight.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

The suggestion bar loses a matching title partway through typing it:

- "wake up de" offers "Wake Up Dead Man: A Knives Out Mystery"
- "wake up dea" ranks to the same two titles, the effect does not run, and the keyboard shows its dictionary words
- "wake up dead ma" narrows the list, the effect runs, and the title is back

Completions were pushed from a `LaunchedEffect` keyed on the suggestion list alone. The keyboard rebuilds its strip on each keystroke, so they have to be pushed again even when the list has not moved.

Two existing state transitions could also clear the strip, and both can blank the bar now that every keystroke pushes:

Live search submits as the user types, so a space between words trims the query back to the submitted one and hits the guard against re-fetching. That guard no longer clears the suggestions.

Catalog results arrive independently and accumulate into one shared set of names. An early result can hold only titles the filter rejects while the one holding the match is still in flight, so the list may now only empty once every catalog job has completed. Those jobs caught `CancellationException` along with everything else, so a cancelled catalog could be treated as having completed normally. They now rethrow it, matching `performSearch` in the same file.

The list is also narrowed locally on each keystroke, so a title that stops matching is removed immediately rather than when the fetch completes. Narrowing only removes, and it may not empty the strip.

This became reproducible after #3326, because filtering made consecutive queries far more likely to produce the same list.

## Issue or approval

Fixes #3366

## Reproduction steps

1. Open search and type "wake up de". The title appears in the suggestion bar.
2. Type one more letter, "wake up dea".
3. Continue to "wake up dead ma".

Before this change the title disappears at step 2 and comes back at step 3. Typing a space blanks the bar as well.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This changes when completions are pushed and when the list is allowed to empty. The matching and ranking rules are unchanged. Catalog selection and catalog fetch behaviour are unchanged, as is everything about search results.

The ranking logic moved into a named function so the incremental and final updates use the same path.

#3197 flagged that guard as worth revisiting with the rest of the suggestion flow, which is what this does.

## Testing

**Unit tests:** 5 new in `SearchViewModelSuggestionsTest`, covering a title removed by narrowing, every title ruled out while a fetch is pending, a fetch putting back a title narrowing had removed, one catalog ranking to nothing while another still holds the match, and a space back to an already submitted query. 13 existing tests are unchanged.

`:app:testFullDebugUnitTest` ran 1126 tests on this branch with 15 failures. All 5 new tests pass. The same 15 failures, an identical list, ran on dev at 1121 tests before this branch was rebased onto it. None of them are in search.

The ViewModel tests cover the state transitions the fix exposes. The `InputMethodManager` push is a Compose effect and is verified on device instead.

**Device:** NVIDIA Shield Pro (2019), Android 11, against a self-hosted AIOMetadata addon with three search catalogs including an LLM-backed one. Typing through to "wake up dea" keeps the title in the bar, where it used to disappear, and spaces no longer blank it. The narrowing was checked in a second run on the same device and addon.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3366, found through comments on #3197
