### PR TITLE
fix(player): add opt-in Hi10P software fallback

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/PlayerSettingsDataStore.kt
@@ -257,6 +257,7 @@ data class PlayerSettings(
     // Only honored when dv7HandlingMode is OFF or DV81_LIBDOVI.
     val dv7LibdoviModeOverride: Int = -1,
     val stripHdr10PlusSei: Boolean = false,
+    val mpvHi10pGnextSoftwareFallbackEnabled: Boolean = false,
     val mpvHardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE,
     // Display settings
     val frameRateMatchingMode: FrameRateMatchingMode = FrameRateMatchingMode.OFF,
@@ -520,6 +521,8 @@ class PlayerSettingsDataStore @Inject constructor(
     private val legacyMapDv7ToHevcKey = booleanPreferencesKey("map_dv7_to_hevc")
     private val dv7LibdoviModeOverrideKey = intPreferencesKey("dv7_libdovi_mode_override")
     private val stripHdr10PlusSeiKey = booleanPreferencesKey("strip_hdr10plus_sei")
+    private val mpvHi10pGnextSoftwareFallbackEnabledKey =
+        booleanPreferencesKey("mpv_hi10p_gnext_software_fallback_enabled")
     private val mpvHardwareDecodeModeKey = stringPreferencesKey("mpv_hardware_decode_mode")
     private val frameRateMatchingKey = booleanPreferencesKey("frame_rate_matching")
     private val frameRateMatchingModeKey = stringPreferencesKey("frame_rate_matching_mode")
@@ -871,6 +874,8 @@ class PlayerSettingsDataStore @Inject constructor(
                 },
                 dv7LibdoviModeOverride = (prefs[dv7LibdoviModeOverrideKey] ?: -1).coerceIn(-1, 4),
                 stripHdr10PlusSei = prefs[stripHdr10PlusSeiKey] ?: false,
+                mpvHi10pGnextSoftwareFallbackEnabled =
+                    prefs[mpvHi10pGnextSoftwareFallbackEnabledKey] ?: false,
                 mpvHardwareDecodeMode = parseMpvHardwareDecodeMode(prefs[mpvHardwareDecodeModeKey]),
                 frameRateMatchingMode = prefs[frameRateMatchingModeKey]?.let {
                     runCatching { FrameRateMatchingMode.valueOf(it) }.getOrNull()
@@ -1466,6 +1471,12 @@ class PlayerSettingsDataStore @Inject constructor(
     suspend fun setMpvHardwareDecodeMode(mode: MpvHardwareDecodeMode) {
         store().edit { prefs ->
             prefs[mpvHardwareDecodeModeKey] = mode.name
+        }
+    }
+
+    suspend fun setMpvHi10pGnextSoftwareFallbackEnabled(enabled: Boolean) {
+        store().edit { prefs ->
+            prefs[mpvHi10pGnextSoftwareFallbackEnabledKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/MpvHi10pFallback.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/MpvHi10pFallback.kt
@@ -1,0 +1,26 @@
+package com.nuvio.tv.ui.screens.player
+
+import java.util.Locale
+
+internal fun PlayerRuntimeController.shouldUseMpvHi10pGnextSoftwareFallback(): Boolean {
+    if (!mpvHi10pGnextSoftwareFallbackEnabledSetting) return false
+    return mpvPlaybackHintsIndicateHi10p(
+        currentFilename,
+        currentStreamDescription,
+        _uiState.value.currentStreamName,
+        currentStreamUrl,
+    )
+}
+
+internal fun mpvPlaybackHintsIndicateHi10p(vararg hints: String?): Boolean =
+    hints.filterNotNull().any(String::indicatesH264Hi10p)
+
+private fun String.indicatesH264Hi10p(): Boolean {
+    val value = lowercase(Locale.US)
+    val tenBit = value.contains("10bit") || value.contains("10-bit") || value.contains("10 bit")
+    val h264 = value.contains("x264") || value.contains("h264") ||
+        value.contains("h.264") || value.contains("avc")
+    val hevc = value.contains("x265") || value.contains("h265") ||
+        value.contains("h.265") || value.contains("hevc")
+    return value.contains("hi10") || (tenBit && h264 && !hevc)
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/NuvioMpvSurfaceView.kt
@@ -23,6 +23,8 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
     private var pendingInitialMediaUrl: String? = null
     private var pendingInitialStartOption: String? = null
     private var hardwareDecodeMode: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE
+    private var hi10pGnextSoftwareFallbackActive = false
+    private var appliedHi10pGnextSoftwareFallback: Boolean? = null
     private var currentAspectMode: AspectMode = AspectMode.ORIGINAL
     private var pendingAspectRetryCount = 0
     private val aspectReapplyRunnable = Runnable {
@@ -49,7 +51,13 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         applyHeaders(headers)
         val startOption = startPositionMs
             .takeIf { it > 0L }
-            ?.let { String.format(Locale.US, "start=+%.3f", it / 1000.0) }
+            ?.let {
+                buildList {
+                    add(String.format(Locale.US, "start=+%.3f", it / 1000.0))
+                    // Avoid decoding forward from a distant keyframe before showing resumed Hi10P video.
+                    if (hi10pGnextSoftwareFallbackActive) add("hr-seek=no")
+                }.joinToString(",")
+            }
         if (startOption != null && holder.surface?.isValid == true) {
             ensureSurfaceAttachedIfAlreadyAvailable()
             loadFileWithOptions(url, startOption)
@@ -244,11 +252,26 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     fun applyHardwareDecodeMode(mode: MpvHardwareDecodeMode) {
         hardwareDecodeMode = mode
-        if (!initialized) return
+        if (!initialized || hi10pGnextSoftwareFallbackActive) return
         runCatching {
             mpv.setPropertyString("hwdec", mode.toMpvHwdecValue())
         }.onFailure {
             Log.w(TAG, "Failed to apply mpv hardware decode mode ($mode): ${it.message}")
+        }
+    }
+
+    fun applyHi10pGnextSoftwareFallback(active: Boolean) {
+        hi10pGnextSoftwareFallbackActive = active
+        if (!initialized || appliedHi10pGnextSoftwareFallback == active) return
+        runCatching {
+            val videoOutput = if (active) MPV_VIDEO_OUTPUT_GPU_NEXT else MPV_VIDEO_OUTPUT_GPU
+            val hardwareDecoder = if (active) MPV_HWDEC_DISABLED else hardwareDecodeMode.toMpvHwdecValue()
+            setVo(videoOutput)
+            mpv.setPropertyString("vo", videoOutput)
+            mpv.setPropertyString("hwdec", hardwareDecoder)
+            appliedHi10pGnextSoftwareFallback = active
+        }.onFailure {
+            Log.w(TAG, "Failed to apply mpv Hi10P G-NEXT SW fallback (active=$active): ${it.message}")
         }
     }
 
@@ -590,11 +613,12 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         lastMediaRequestKey = null
         pendingInitialMediaUrl = null
         pendingInitialStartOption = null
+        appliedHi10pGnextSoftwareFallback = null
     }
 
     override fun initOptions() {
         mpv.setOptionString("profile", "fast")
-        setVo("gpu")
+        setVo(if (hi10pGnextSoftwareFallbackActive) MPV_VIDEO_OUTPUT_GPU_NEXT else MPV_VIDEO_OUTPUT_GPU)
         mpv.setOptionString("gpu-context", "android")
         mpv.setOptionString("opengl-es", "yes")
         mpv.setOptionString("user-agent", PlayerMediaSourceFactory.DEFAULT_USER_AGENT)
@@ -604,7 +628,11 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
         mpv.setOptionString("sub-font", "Roboto")
         mpv.setOptionString("sub-use-margins", "yes")
         mpv.setOptionString("sub-ass-force-margins", "yes")
-        mpv.setOptionString("hwdec", hardwareDecodeMode.toMpvHwdecValue())
+        mpv.setOptionString(
+            "hwdec",
+            if (hi10pGnextSoftwareFallbackActive) MPV_HWDEC_DISABLED else hardwareDecodeMode.toMpvHwdecValue()
+        )
+        appliedHi10pGnextSoftwareFallback = hi10pGnextSoftwareFallbackActive
         mpv.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
         mpv.setOptionString("ao", "audiotrack,opensles")
         mpv.setOptionString("audio-set-media-role", "yes")
@@ -715,6 +743,9 @@ class NuvioMpvSurfaceView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "NuvioMpvSurfaceView"
+        private const val MPV_VIDEO_OUTPUT_GPU = "gpu"
+        private const val MPV_VIDEO_OUTPUT_GPU_NEXT = "gpu-next"
+        private const val MPV_HWDEC_DISABLED = "no"
         /** `loadfile` insertion index; only meaningful for insert-at flags, -1 is mpv's default. */
         private const val LOADFILE_DEFAULT_INDEX = "-1"
         private const val MPV_COVER_FALLBACK_SCALE = 1.15f

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -466,6 +466,7 @@ class PlayerRuntimeController(
     internal var stillWatchingEnabledSetting: Boolean = false
     internal var stillWatchingEpisodeThresholdSetting: Int =
         PlayerSettings.DEFAULT_STILL_WATCHING_EPISODE_THRESHOLD
+    internal var mpvHi10pGnextSoftwareFallbackEnabledSetting: Boolean = false
     internal var mpvHardwareDecodeModeSetting: MpvHardwareDecodeMode = MpvHardwareDecodeMode.AUTO_SAFE
     internal var mpvPreferredAudioLanguages: List<String> = emptyList()
     internal var currentStreamBingeGroup: String? = navigationArgs.bingeGroup
@@ -499,6 +500,7 @@ class PlayerRuntimeController(
     internal var ffmpegAudioRenderer: FfmpegAudioRenderer? = null
     internal var mpvView: NuvioMpvSurfaceView? = null
     internal var mpvInitializationInProgress: Boolean = false
+    internal var mpvMediaLoadPrepared: Boolean = false
     internal var mpvTrackRefreshJob: Job? = null
     internal var mpvTrackRefreshInProgress: Boolean = false
     internal var pendingMpvHardRestartOnNextAttach: Boolean = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -159,6 +159,7 @@ internal fun PlayerRuntimeController.initializePlayer(
         _uiState.update { it.copy(error = context.getString(R.string.player_error_no_stream_url), showLoadingOverlay = false) }
         return
     }
+    mpvMediaLoadPrepared = false
 
     scope.launch {
         try {
@@ -215,6 +216,8 @@ internal fun PlayerRuntimeController.initializePlayer(
                 contentOriginalLanguage = contentLanguage
             )
             mpvPreferredAudioLanguages = preferredAudioLanguages
+            mpvHi10pGnextSoftwareFallbackEnabledSetting =
+                playerSettings.mpvHi10pGnextSoftwareFallbackEnabled
             mpvHardwareDecodeModeSetting = playerSettings.mpvHardwareDecodeMode
             var effectiveInternalPlayerEngine = overrideInternalPlayerEngine ?: playerSettings.internalPlayerEngine
             if (effectiveInternalPlayerEngine == InternalPlayerEngine.AUTO) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerLifecycle.kt
@@ -50,6 +50,7 @@ internal fun PlayerRuntimeController.releasePlayer(flushPlaybackState: Boolean) 
     traktMappingJob?.cancel()
     traktMappingJob = null
     delayMpvResumeSeekUntilVideoTrack = false
+    mpvMediaLoadPrepared = false
     nextEpisodeAutoPlayJob?.cancel()
     nextEpisodeAutoPlayJob = null
     debridResolveJob?.cancel()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -18,10 +18,12 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
     if (view == null) return
     if (!isUsingMpvEngine()) return
     if (currentStreamUrl.isBlank()) return
+    if (!mpvMediaLoadPrepared) return
     if (mpvInitializationInProgress) return
 
     runCatching {
         performPendingMpvHardRestartIfNeeded(view)
+        view.applyHi10pGnextSoftwareFallback(shouldUseMpvHi10pGnextSoftwareFallback())
         view.applyHardwareDecodeMode(mpvHardwareDecodeModeSetting)
         view.setMedia(currentStreamUrl, currentHeaders)
         view.setPlaybackSpeed(_uiState.value.playbackSpeed)
@@ -80,6 +82,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
     headers: Map<String, String>,
     allowEngineFailover: Boolean = true
 ) {
+    mpvMediaLoadPrepared = true
     _exoPlayer?.release()
     _exoPlayer = null
     trackSelector = null
@@ -115,6 +118,7 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
             showOverlay = true
         )
         performPendingMpvHardRestartIfNeeded(view)
+        view.applyHi10pGnextSoftwareFallback(shouldUseMpvHi10pGnextSoftwareFallback())
         view.applyHardwareDecodeMode(mpvHardwareDecodeModeSetting)
         val initialResumePosition = resolvePendingInitialResumePosition()
             .takeIf { it > 0L }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -352,18 +352,6 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     }
 
     if (isMpvEngine) {
-        item(key = "audio_mpv_hi10p_gnext_software_fallback") {
-            ToggleSettingsItem(
-                icon = Icons.Default.Tune,
-                title = stringResource(R.string.audio_mpv_hi10p_gnext_sw_title),
-                subtitle = stringResource(R.string.audio_mpv_hi10p_gnext_sw_subtitle),
-                isChecked = playerSettings.mpvHi10pGnextSoftwareFallbackEnabled,
-                onCheckedChange = onSetMpvHi10pGnextSoftwareFallbackEnabled,
-                onFocused = onItemFocused,
-                enabled = enabled
-            )
-        }
-
         item(key = "audio_mpv_hardware_decode_mode") {
             val hwDecodeModeName = when (playerSettings.mpvHardwareDecodeMode) {
                 MpvHardwareDecodeMode.LEGACY_DIRECT_COPY -> stringResource(R.string.audio_mpv_hwdec_legacy_direct_copy)
@@ -378,6 +366,18 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
                 title = stringResource(R.string.audio_mpv_hwdec_title),
                 subtitle = hwDecodeModeName,
                 onClick = onShowMpvHardwareDecodeModeDialog,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
+        }
+
+        item(key = "audio_mpv_hi10p_gnext_software_fallback") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_mpv_hi10p_gnext_sw_title),
+                subtitle = stringResource(R.string.audio_mpv_hi10p_gnext_sw_subtitle),
+                isChecked = playerSettings.mpvHi10pGnextSoftwareFallbackEnabled,
+                onCheckedChange = onSetMpvHi10pGnextSoftwareFallbackEnabled,
                 onFocused = onItemFocused,
                 enabled = enabled
             )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackAudioSettings.kt
@@ -78,6 +78,7 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     onSetDv5ToDv81Enabled: (Boolean) -> Unit,
     onSetDv7ToDv81PreserveMappingEnabled: (Boolean) -> Unit,
     onSetStripHdr10PlusSei: (Boolean) -> Unit,
+    onSetMpvHi10pGnextSoftwareFallbackEnabled: (Boolean) -> Unit,
     onItemFocused: () -> Unit = {},
     enabled: Boolean = true,
     videoExtraItems: (LazyListScope.() -> Unit)? = null
@@ -351,23 +352,35 @@ internal fun LazyListScope.trailerAndAudioSettingsItems(
     }
 
     if (isMpvEngine) {
-        item(key = "audio_mpv_hardware_decode_mode") {
-        val hwDecodeModeName = when (playerSettings.mpvHardwareDecodeMode) {
-            MpvHardwareDecodeMode.LEGACY_DIRECT_COPY -> stringResource(R.string.audio_mpv_hwdec_legacy_direct_copy)
-            MpvHardwareDecodeMode.AUTO_SAFE -> stringResource(R.string.audio_mpv_hwdec_auto_safe)
-            MpvHardwareDecodeMode.HARDWARE_COPY -> stringResource(R.string.audio_mpv_hwdec_hardware_copy)
-            MpvHardwareDecodeMode.HARDWARE_DIRECT -> stringResource(R.string.audio_mpv_hwdec_hardware_direct)
-            MpvHardwareDecodeMode.DISABLED -> stringResource(R.string.audio_mpv_hwdec_disabled)
+        item(key = "audio_mpv_hi10p_gnext_software_fallback") {
+            ToggleSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_mpv_hi10p_gnext_sw_title),
+                subtitle = stringResource(R.string.audio_mpv_hi10p_gnext_sw_subtitle),
+                isChecked = playerSettings.mpvHi10pGnextSoftwareFallbackEnabled,
+                onCheckedChange = onSetMpvHi10pGnextSoftwareFallbackEnabled,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
         }
 
-        NavigationSettingsItem(
-            icon = Icons.Default.Tune,
-            title = stringResource(R.string.audio_mpv_hwdec_title),
-            subtitle = hwDecodeModeName,
-            onClick = onShowMpvHardwareDecodeModeDialog,
-            onFocused = onItemFocused,
-            enabled = enabled
-        )
+        item(key = "audio_mpv_hardware_decode_mode") {
+            val hwDecodeModeName = when (playerSettings.mpvHardwareDecodeMode) {
+                MpvHardwareDecodeMode.LEGACY_DIRECT_COPY -> stringResource(R.string.audio_mpv_hwdec_legacy_direct_copy)
+                MpvHardwareDecodeMode.AUTO_SAFE -> stringResource(R.string.audio_mpv_hwdec_auto_safe)
+                MpvHardwareDecodeMode.HARDWARE_COPY -> stringResource(R.string.audio_mpv_hwdec_hardware_copy)
+                MpvHardwareDecodeMode.HARDWARE_DIRECT -> stringResource(R.string.audio_mpv_hwdec_hardware_direct)
+                MpvHardwareDecodeMode.DISABLED -> stringResource(R.string.audio_mpv_hwdec_disabled)
+            }
+
+            NavigationSettingsItem(
+                icon = Icons.Default.Tune,
+                title = stringResource(R.string.audio_mpv_hwdec_title),
+                subtitle = hwDecodeModeName,
+                onClick = onShowMpvHardwareDecodeModeDialog,
+                onFocused = onItemFocused,
+                enabled = enabled
+            )
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsScreen.kt
@@ -316,6 +316,11 @@ fun PlaybackSettingsContent(
                 onSetStripHdr10PlusSei = { enabled ->
                     coroutineScope.launch { viewModel.setStripHdr10PlusSei(enabled) }
                 },
+                onSetMpvHi10pGnextSoftwareFallbackEnabled = { enabled ->
+                    coroutineScope.launch {
+                        viewModel.setMpvHi10pGnextSoftwareFallbackEnabled(enabled)
+                    }
+                },
                 onSetBufferEngineEnabled = { enabled ->
                     coroutineScope.launch { viewModel.setBufferEngineEnabled(enabled) }
                     if (enabled) memoryUsageTrigger++

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsSections.kt
@@ -165,6 +165,7 @@ internal fun PlaybackSettingsSections(
     onSetDv5ToDv81Enabled: (Boolean) -> Unit,
     onSetDv7ToDv81PreserveMappingEnabled: (Boolean) -> Unit,
     onSetStripHdr10PlusSei: (Boolean) -> Unit,
+    onSetMpvHi10pGnextSoftwareFallbackEnabled: (Boolean) -> Unit,
     onSetSubtitleSize: (Int) -> Unit,
     onSetSubtitleVerticalOffset: (Int) -> Unit,
     onSetSubtitleBold: (Boolean) -> Unit,
@@ -586,6 +587,8 @@ internal fun PlaybackSettingsSections(
                 onSetDv5ToDv81Enabled = onSetDv5ToDv81Enabled,
                 onSetDv7ToDv81PreserveMappingEnabled = onSetDv7ToDv81PreserveMappingEnabled,
                 onSetStripHdr10PlusSei = onSetStripHdr10PlusSei,
+                onSetMpvHi10pGnextSoftwareFallbackEnabled =
+                    onSetMpvHi10pGnextSoftwareFallbackEnabled,
                 onItemFocused = { focusedSection = PlaybackSection.AUDIO_TRAILER },
                 enabled = !generalUi.isExternalPlayer,
                 videoExtraItems = {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/PlaybackSettingsViewModel.kt
@@ -187,6 +187,10 @@ class PlaybackSettingsViewModel @Inject constructor(
         playerSettingsDataStore.setMpvHardwareDecodeMode(mode)
     }
 
+    suspend fun setMpvHi10pGnextSoftwareFallbackEnabled(enabled: Boolean) {
+        playerSettingsDataStore.setMpvHi10pGnextSoftwareFallbackEnabled(enabled)
+    }
+
 
     suspend fun setDv5ToDv81Enabled(enabled: Boolean) {
         playerSettingsDataStore.setDv5ToDv81Enabled(enabled)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -809,6 +809,8 @@
     <string name="dv7_libdovi_mode_3_sub" translatable="false">Convert Profile 5 (DV5) streams to Profile 8.1. Same conversion the Convert DV5 to DV8.1 toggle uses.</string>
     <string name="dv7_libdovi_mode_4_title" translatable="false">Mode 4 — 8.4 (static)</string>
     <string name="dv7_libdovi_mode_4_sub" translatable="false">Convert to static profile 8.4.</string>
+    <string name="audio_mpv_hi10p_gnext_sw_title">Hi10P G-NEXT SW fallback (MPV-only)</string>
+    <string name="audio_mpv_hi10p_gnext_sw_subtitle">Use G-NEXT software decoding when stream details identify H.264 Hi10P. Off by default; enable only if Hi10P playback freezes or fails.</string>
     <string name="audio_mpv_hwdec_title">Hardware Decoding (MPV-only)</string>
     <string name="audio_mpv_hwdec_dialog_subtitle">Select how libmpv should use hardware decoders.</string>
     <string name="audio_mpv_hwdec_legacy_direct_copy">Legacy (direct -&gt; copy)</string>


### PR DESCRIPTION
## Summary

- Adds a default-off `Hi10P G-NEXT SW fallback (MPV-only)` setting under Audio & Video for devices whose hardware decoder cannot play H.264 Hi10P.
- Detects H.264 Hi10P from the selected stream metadata before MPV opens the file, then starts the matching stream directly with `gpu-next` and software decoding.
- Prepares MPV settings and media metadata before surface attachment so MPV does not open the stream once with the normal decoder, switch decoders, and reopen it for the fallback. This avoids the otherwise substantial Hi10P startup delay.
- Uses a fast keyframe resume only for streams matched by this fallback.
- Leaves normal non-Hi10P streams, the existing Auto behavior, hardware-decoding preferences, ExoPlayer, and external players unchanged.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

On devices without working H.264 Hi10P hardware decoding, internal MPV may fail to start or may spend a long time opening the stream while trying an unsuitable decoder path. The fallback must be selected during file-load preparation, before MPV receives the media URL. Opening first and switching decoders afterward causes duplicate network opens and noticeably longer startup.

The option is disabled by default. When enabled, it applies only when the selected stream is positively identified as H.264 Hi10P. It does not alter ordinary H.264, HEVC 10-bit, or other non-Hi10P playback.

## Issue or approval

Fixes #3370

## Reproduction steps

1. On a device that cannot hardware-decode H.264 Hi10P, select internal MPV or Auto when Auto resolves to MPV.
2. Play a stream identified as H.264 Hi10P.
3. Observe failed playback or delayed startup while the normal decoder path is attempted.
4. Enable `Hi10P G-NEXT SW fallback (MPV-only)` and open the same stream.
5. Confirm the stream is prepared before file load and opens directly through G-NEXT software decoding without first cycling through other decoders.
6. Play a normal non-Hi10P stream and confirm Auto and the configured decoder mode behave exactly as before.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

- No changes to ExoPlayer or external-player launch, tracking, or auto-next behavior.
- No changes to normal non-Hi10P streams or the existing Auto selection behavior.
- No Lua updates, native-library updates, or unrelated playback changes.
- No test fixtures or generated build files are included.

## Testing

- `./gradlew :app:compileFullDebugKotlin`
- `./gradlew :app:assembleFullDebug`
- Installed the Full debug APK on an NVIDIA Shield and manually checked internal-MPV Hi10P playback and startup behavior.
- Confirmed through MPV logs that the matched stream uses software H.264 decoding with `gpu-next` and that preparation occurs before the media URL is opened.
- Confirmed normal non-Hi10P playback remains on the user's configured decoder path.
- Ran `:app:testFullDebugUnitTest`: 1,121 tests ran; 17 existing failures remain in unrelated data-source, allocator, Dolby Vision, frame-rate probe, migration, tracking, post-play, and track-selection suites.
- Completed two code-review passes covering state/lifecycle correctness, persistence/default behavior, detection boundaries, startup performance, and regression isolation.

## Screenshots / Video

https://github.com/user-attachments/assets/b46114a5-9780-4172-bf7c-390b21f8218b

## Breaking changes

None.

## Linked issues

Fixes #3370


