### PR TITLE
Add individual recent-search deletion for Mobile/Desktop parity

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/local/SearchHistoryDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/SearchHistoryDataStore.kt
@@ -63,6 +63,22 @@ class SearchHistoryDataStore @Inject constructor(
         }
     }
 
+    suspend fun removeRecentSearch(query: String) {
+        val normalized = query.trim()
+        if (normalized.isEmpty()) return
+
+        store().edit { prefs ->
+            val updated = parseRecentSearches(prefs[recentSearchesKey])
+                .filterNot { it.equals(normalized, ignoreCase = true) }
+
+            if (updated.isEmpty()) {
+                prefs.remove(recentSearchesKey)
+            } else {
+                prefs[recentSearchesKey] = gson.toJson(updated)
+            }
+        }
+    }
+
     private fun parseRecentSearches(raw: String?): List<String> {
         if (raw.isNullOrBlank()) return emptyList()
         return try {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchEvent.kt
@@ -6,6 +6,7 @@ sealed interface SearchEvent {
     /** Moving from the text input to the results confirms the current search (see #2928 review). */
     data object RememberSearchFromTextInput : SearchEvent
     data object ClearRecentSearches : SearchEvent
+    data class RemoveRecentSearch(val query: String) : SearchEvent
 
     data class LoadMoreCatalog(
         val catalogId: String,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -66,6 +66,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -91,6 +94,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.IconButton as TvIconButton
+import androidx.tv.material3.IconButtonDefaults as TvIconButtonDefaults
 import androidx.tv.material3.Text
 import com.nuvio.tv.ui.components.CatalogRowSection
 import com.nuvio.tv.ui.components.EmptyScreenState
@@ -554,6 +559,9 @@ fun SearchScreen(
                             onClearHistory = {
                                 viewModel.onEvent(SearchEvent.ClearRecentSearches)
                             },
+                            onRemoveSearch = { query ->
+                                viewModel.onEvent(SearchEvent.RemoveRecentSearch(query))
+                            },
                             onSectionFocusChanged = { focused -> isRecentSearchSectionFocused = focused },
                             clearHistoryFocusRequester = recentClearHistoryFocusRequester,
                             modifier = Modifier.padding(horizontal = 52.dp)
@@ -582,6 +590,9 @@ fun SearchScreen(
                                     onSearchSelected = submitRecentSearch,
                                     onClearHistory = {
                                         viewModel.onEvent(SearchEvent.ClearRecentSearches)
+                                    },
+                                    onRemoveSearch = { query ->
+                                        viewModel.onEvent(SearchEvent.RemoveRecentSearch(query))
                                     },
                                     onSectionFocusChanged = { focused ->
                                         isRecentSearchSectionFocused = focused
@@ -826,6 +837,7 @@ private fun RecentSearchesSection(
     recentSearches: List<String>,
     onSearchSelected: (String) -> Unit,
     onClearHistory: () -> Unit,
+    onRemoveSearch: (String) -> Unit,
     onSectionFocusChanged: (Boolean) -> Unit,
     clearHistoryFocusRequester: FocusRequester,
     modifier: Modifier = Modifier
@@ -866,34 +878,84 @@ private fun RecentSearchesSection(
         }
 
         recentSearches.forEach { recentQuery ->
-            Button(
-                onClick = { onSearchSelected(recentQuery) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onPreviewKeyEvent { keyEvent ->
-                        val clearHistoryKey = RtlKeyUtils.getClearHistoryDpadKey(isRtl)
-                        if (keyEvent.nativeKeyEvent.keyCode == clearHistoryKey) {
-                            if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
-                                runCatching { clearHistoryFocusRequester.requestFocus() }
-                            }
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                colors = ButtonDefaults.colors(
-                    containerColor = NuvioTheme.colors.BackgroundCard,
-                    contentColor = NuvioTheme.colors.TextPrimary,
-                    focusedContainerColor = NuvioTheme.colors.FocusBackground,
-                    focusedContentColor = NuvioTheme.colors.Primary
-                ),
-                shape = ButtonDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = recentQuery,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                var isSearchFocused by remember(recentQuery) { mutableStateOf(false) }
+                val searchScale by animateFloatAsState(
+                    targetValue = if (isSearchFocused) 1.02f else 1f,
+                    animationSpec = tween(durationMillis = 140),
+                    label = "recentSearchScale"
                 )
+                Button(
+                    onClick = { onSearchSelected(recentQuery) },
+                    modifier = Modifier
+                        .weight(1f)
+                        .onFocusChanged { isSearchFocused = it.isFocused }
+                        .graphicsLayer {
+                            scaleX = searchScale
+                            scaleY = searchScale
+                            transformOrigin = TransformOrigin(
+                                pivotFractionX = if (isRtl) 1f else 0f,
+                                pivotFractionY = 0.5f
+                            )
+                        },
+                    colors = ButtonDefaults.colors(
+                        containerColor = NuvioTheme.colors.BackgroundCard,
+                        contentColor = NuvioTheme.colors.TextPrimary,
+                        focusedContainerColor = NuvioTheme.colors.FocusBackground,
+                        focusedContentColor = NuvioTheme.colors.Primary
+                    ),
+                    scale = ButtonDefaults.scale(focusedScale = 1f),
+                    shape = ButtonDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md))
+                ) {
+                    Text(
+                        text = recentQuery,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                var isRemoveFocused by remember(recentQuery) { mutableStateOf(false) }
+                TvIconButton(
+                    onClick = { onRemoveSearch(recentQuery) },
+                    modifier = Modifier
+                        .onFocusChanged { isRemoveFocused = it.isFocused }
+                        .size(36.dp)
+                        .then(
+                            if (isRemoveFocused) {
+                                Modifier.border(
+                                    width = NuvioTheme.spacing.xxs,
+                                    color = NuvioTheme.colors.FocusRing,
+                                    shape = RoundedCornerShape(NuvioTheme.radii.md)
+                                )
+                            } else {
+                                Modifier
+                            }
+                        ),
+                    colors = TvIconButtonDefaults.colors(
+                        containerColor = Color.Transparent,
+                        focusedContainerColor = NuvioTheme.colors.FocusBackground,
+                        contentColor = NuvioTheme.colors.TextPrimary,
+                        focusedContentColor = NuvioTheme.colors.TextPrimary
+                    ),
+                    scale = TvIconButtonDefaults.scale(focusedScale = 1f),
+                    shape = TvIconButtonDefaults.shape(
+                        shape = RoundedCornerShape(NuvioTheme.radii.md)
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(
+                            R.string.cd_remove_recent_search,
+                            recentQuery
+                        ),
+                        modifier = Modifier.size(18.dp),
+                        tint = NuvioTheme.colors.TextPrimary
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -564,6 +565,7 @@ fun SearchScreen(
                             },
                             onSectionFocusChanged = { focused -> isRecentSearchSectionFocused = focused },
                             clearHistoryFocusRequester = recentClearHistoryFocusRequester,
+                            emptyHistoryFocusRequester = topInputFocusRequester,
                             modifier = Modifier.padding(horizontal = 52.dp)
                         )
                     }
@@ -598,6 +600,7 @@ fun SearchScreen(
                                         isRecentSearchSectionFocused = focused
                                     },
                                     clearHistoryFocusRequester = recentClearHistoryFocusRequester,
+                                    emptyHistoryFocusRequester = topInputFocusRequester,
                                     modifier = Modifier.padding(horizontal = 52.dp)
                                 )
                             } else {
@@ -840,9 +843,20 @@ private fun RecentSearchesSection(
     onRemoveSearch: (String) -> Unit,
     onSectionFocusChanged: (Boolean) -> Unit,
     clearHistoryFocusRequester: FocusRequester,
+    emptyHistoryFocusRequester: FocusRequester,
     modifier: Modifier = Modifier
 ) {
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val searchFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val removeFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    val firstRemoveFocusRequester = removeFocusRequesters.getOrPut(recentSearches.first()) {
+        FocusRequester()
+    }
+    LaunchedEffect(recentSearches) {
+        val visibleQueries = recentSearches.toSet()
+        searchFocusRequesters.keys.retainAll(visibleQueries)
+        removeFocusRequesters.keys.retainAll(visibleQueries)
+    }
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -864,7 +878,11 @@ private fun RecentSearchesSection(
             )
             Button(
                 onClick = onClearHistory,
-                modifier = Modifier.focusRequester(clearHistoryFocusRequester),
+                modifier = Modifier
+                    .focusRequester(clearHistoryFocusRequester)
+                    .focusProperties {
+                        down = firstRemoveFocusRequester
+                    },
                 colors = ButtonDefaults.colors(
                     containerColor = NuvioTheme.colors.BackgroundCard,
                     contentColor = NuvioTheme.colors.TextPrimary,
@@ -877,84 +895,129 @@ private fun RecentSearchesSection(
             }
         }
 
-        recentSearches.forEach { recentQuery ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                var isSearchFocused by remember(recentQuery) { mutableStateOf(false) }
-                val searchScale by animateFloatAsState(
-                    targetValue = if (isSearchFocused) 1.02f else 1f,
-                    animationSpec = tween(durationMillis = 140),
-                    label = "recentSearchScale"
-                )
-                Button(
-                    onClick = { onSearchSelected(recentQuery) },
-                    modifier = Modifier
-                        .weight(1f)
-                        .onFocusChanged { isSearchFocused = it.isFocused }
-                        .graphicsLayer {
-                            scaleX = searchScale
-                            scaleY = searchScale
-                            transformOrigin = TransformOrigin(
-                                pivotFractionX = if (isRtl) 1f else 0f,
-                                pivotFractionY = 0.5f
-                            )
-                        },
-                    colors = ButtonDefaults.colors(
-                        containerColor = NuvioTheme.colors.BackgroundCard,
-                        contentColor = NuvioTheme.colors.TextPrimary,
-                        focusedContainerColor = NuvioTheme.colors.FocusBackground,
-                        focusedContentColor = NuvioTheme.colors.Primary
-                    ),
-                    scale = ButtonDefaults.scale(focusedScale = 1f),
-                    shape = ButtonDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md))
-                ) {
-                    Text(
-                        text = recentQuery,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+        recentSearches.forEachIndexed { index, recentQuery ->
+            key(recentQuery) {
+                val searchFocusRequester = searchFocusRequesters.getOrPut(recentQuery) {
+                    FocusRequester()
                 }
-
-                var isRemoveFocused by remember(recentQuery) { mutableStateOf(false) }
-                TvIconButton(
-                    onClick = { onRemoveSearch(recentQuery) },
-                    modifier = Modifier
-                        .onFocusChanged { isRemoveFocused = it.isFocused }
-                        .size(36.dp)
-                        .then(
-                            if (isRemoveFocused) {
-                                Modifier.border(
-                                    width = NuvioTheme.spacing.xxs,
-                                    color = NuvioTheme.colors.FocusRing,
-                                    shape = RoundedCornerShape(NuvioTheme.radii.md)
-                                )
-                            } else {
-                                Modifier
-                            }
-                        ),
-                    colors = TvIconButtonDefaults.colors(
-                        containerColor = Color.Transparent,
-                        focusedContainerColor = NuvioTheme.colors.FocusBackground,
-                        contentColor = NuvioTheme.colors.TextPrimary,
-                        focusedContentColor = NuvioTheme.colors.TextPrimary
-                    ),
-                    scale = TvIconButtonDefaults.scale(focusedScale = 1f),
-                    shape = TvIconButtonDefaults.shape(
-                        shape = RoundedCornerShape(NuvioTheme.radii.md)
-                    )
+                val removeFocusRequester = removeFocusRequesters.getOrPut(recentQuery) {
+                    FocusRequester()
+                }
+                val previousRemoveFocusRequester = if (index == 0) {
+                    clearHistoryFocusRequester
+                } else {
+                    removeFocusRequesters.getOrPut(recentSearches[index - 1]) { FocusRequester() }
+                }
+                val nextRemoveFocusRequester = recentSearches.getOrNull(index + 1)?.let {
+                    removeFocusRequesters.getOrPut(it) { FocusRequester() }
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(NuvioTheme.spacing.lg),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = stringResource(
-                            R.string.cd_remove_recent_search,
-                            recentQuery
-                        ),
-                        modifier = Modifier.size(18.dp),
-                        tint = NuvioTheme.colors.TextPrimary
+                    var isSearchFocused by remember(recentQuery) { mutableStateOf(false) }
+                    val searchScale by animateFloatAsState(
+                        targetValue = if (isSearchFocused) 1.02f else 1f,
+                        animationSpec = tween(durationMillis = 140),
+                        label = "recentSearchScale"
                     )
+                    Button(
+                        onClick = { onSearchSelected(recentQuery) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .focusRequester(searchFocusRequester)
+                            .focusProperties {
+                                if (isRtl) {
+                                    left = removeFocusRequester
+                                } else {
+                                    right = removeFocusRequester
+                                }
+                            }
+                            .onFocusChanged { isSearchFocused = it.isFocused }
+                            .graphicsLayer {
+                                scaleX = searchScale
+                                scaleY = searchScale
+                                transformOrigin = TransformOrigin(
+                                    pivotFractionX = if (isRtl) 1f else 0f,
+                                    pivotFractionY = 0.5f
+                                )
+                            },
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioTheme.colors.BackgroundCard,
+                            contentColor = NuvioTheme.colors.TextPrimary,
+                            focusedContainerColor = NuvioTheme.colors.FocusBackground,
+                            focusedContentColor = NuvioTheme.colors.Primary
+                        ),
+                        scale = ButtonDefaults.scale(focusedScale = 1f),
+                        shape = ButtonDefaults.shape(RoundedCornerShape(NuvioTheme.radii.md))
+                    ) {
+                        Text(
+                            text = recentQuery,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    var isRemoveFocused by remember(recentQuery) { mutableStateOf(false) }
+                    TvIconButton(
+                        onClick = {
+                            val replacementQuery = recentSearches.getOrNull(index + 1)
+                                ?: recentSearches.getOrNull(index - 1)
+                            if (replacementQuery == null) {
+                                runCatching { emptyHistoryFocusRequester.requestFocus() }
+                            } else {
+                                runCatching {
+                                    removeFocusRequesters.getValue(replacementQuery).requestFocus()
+                                }
+                            }
+                            onRemoveSearch(recentQuery)
+                        },
+                        modifier = Modifier
+                            .focusRequester(removeFocusRequester)
+                            .focusProperties {
+                                up = previousRemoveFocusRequester
+                                down = nextRemoveFocusRequester ?: FocusRequester.Cancel
+                                if (isRtl) {
+                                    right = searchFocusRequester
+                                } else {
+                                    left = searchFocusRequester
+                                }
+                            }
+                            .onFocusChanged { isRemoveFocused = it.isFocused }
+                            .size(36.dp)
+                            .then(
+                                if (isRemoveFocused) {
+                                    Modifier.border(
+                                        width = NuvioTheme.spacing.xxs,
+                                        color = NuvioTheme.colors.FocusRing,
+                                        shape = RoundedCornerShape(NuvioTheme.radii.md)
+                                    )
+                                } else {
+                                    Modifier
+                                }
+                            ),
+                        colors = TvIconButtonDefaults.colors(
+                            containerColor = Color.Transparent,
+                            focusedContainerColor = NuvioTheme.colors.FocusBackground,
+                            contentColor = NuvioTheme.colors.TextPrimary,
+                            focusedContentColor = NuvioTheme.colors.TextPrimary
+                        ),
+                        scale = TvIconButtonDefaults.scale(focusedScale = 1f),
+                        shape = TvIconButtonDefaults.shape(
+                            shape = RoundedCornerShape(NuvioTheme.radii.md)
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(
+                                R.string.cd_remove_recent_search,
+                                recentQuery
+                            ),
+                            modifier = Modifier.size(18.dp),
+                            tint = NuvioTheme.colors.TextPrimary
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -849,13 +849,23 @@ private fun RecentSearchesSection(
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val searchFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val removeFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    var pendingDownwardFocus by remember { mutableStateOf<Pair<String, String>?>(null) }
     val firstRemoveFocusRequester = removeFocusRequesters.getOrPut(recentSearches.first()) {
         FocusRequester()
     }
-    LaunchedEffect(recentSearches) {
+    LaunchedEffect(recentSearches, pendingDownwardFocus) {
         val visibleQueries = recentSearches.toSet()
         searchFocusRequesters.keys.retainAll(visibleQueries)
         removeFocusRequesters.keys.retainAll(visibleQueries)
+
+        val (removedQuery, replacementQuery) = pendingDownwardFocus
+            ?: return@LaunchedEffect
+        if (removedQuery !in visibleQueries) {
+            removeFocusRequesters[replacementQuery]?.let { requester ->
+                runCatching { requester.requestFocus() }
+            }
+            pendingDownwardFocus = null
+        }
     }
     Column(
         modifier = modifier
@@ -962,13 +972,19 @@ private fun RecentSearchesSection(
                     var isRemoveFocused by remember(recentQuery) { mutableStateOf(false) }
                     TvIconButton(
                         onClick = {
-                            val replacementQuery = recentSearches.getOrNull(index + 1)
-                                ?: recentSearches.getOrNull(index - 1)
-                            if (replacementQuery == null) {
-                                runCatching { emptyHistoryFocusRequester.requestFocus() }
-                            } else {
-                                runCatching {
-                                    removeFocusRequesters.getValue(replacementQuery).requestFocus()
+                            val nextQuery = recentSearches.getOrNull(index + 1)
+                            val previousQuery = recentSearches.getOrNull(index - 1)
+                            when {
+                                nextQuery != null -> {
+                                    pendingDownwardFocus = recentQuery to nextQuery
+                                }
+                                previousQuery != null -> {
+                                    runCatching {
+                                        removeFocusRequesters.getValue(previousQuery).requestFocus()
+                                    }
+                                }
+                                else -> {
+                                    runCatching { emptyHistoryFocusRequester.requestFocus() }
                                 }
                             }
                             onRemoveSearch(recentQuery)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -227,6 +227,7 @@ class SearchViewModel @Inject constructor(
             SearchEvent.SubmitSearch -> submitSearch()
             SearchEvent.RememberSearchFromTextInput -> rememberSearchFromTextInput()
             SearchEvent.ClearRecentSearches -> clearRecentSearches()
+            is SearchEvent.RemoveRecentSearch -> removeRecentSearch(event.query)
             is SearchEvent.LoadMoreCatalog -> loadMoreCatalogItems(
                 catalogId = event.catalogId,
                 addonId = event.addonId,
@@ -435,6 +436,12 @@ class SearchViewModel @Inject constructor(
     private fun clearRecentSearches() {
         viewModelScope.launch {
             searchHistoryDataStore.clearRecentSearches()
+        }
+    }
+
+    private fun removeRecentSearch(query: String) {
+        viewModelScope.launch {
+            searchHistoryDataStore.removeRecentSearch(query)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1857,6 +1857,7 @@
     <string name="search_start_subtitle_no_discover">Discover is disabled. Enter at least 2 characters</string>
     <string name="search_recent_title">Recent searches</string>
     <string name="search_recent_clear">Clear history</string>
+    <string name="cd_remove_recent_search">Remove %1$s from recent searches</string>
     <string name="search_voice_no_speech">No speech detected. Try again.</string>
     <string name="search_voice_mic_permission">Microphone permission is required for voice search.</string>
     <string name="search_voice_failed">Voice recognition failed. Try again.</string>

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -109,24 +109,6 @@ class SearchViewModelConcurrencyTest {
         coVerify(exactly = 1) { history.saveRecentSearch("Deep Cover", 8) }
     }
 
-    @Test
-    fun `removing a recent search deletes only the selected query`() = runTest {
-        val addon = searchableAddon()
-        val history = mockk<SearchHistoryDataStore>(relaxed = true)
-        every { history.recentSearches } returns flowOf(listOf("Frieren", "Deep Cover"))
-        val viewModel = newViewModel(
-            addonRepository = GatedAddonRepository(addon, CompletableDeferred(Unit)),
-            catalogRepository = ImmediateCatalogRepository(addon),
-            history = history
-        )
-
-        viewModel.onEvent(SearchEvent.RemoveRecentSearch("Deep Cover"))
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { history.removeRecentSearch("Deep Cover") }
-        coVerify(exactly = 0) { history.clearRecentSearches() }
-    }
-
     private fun newViewModel(
         addonRepository: AddonRepository,
         catalogRepository: CatalogRepository,

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelConcurrencyTest.kt
@@ -109,6 +109,24 @@ class SearchViewModelConcurrencyTest {
         coVerify(exactly = 1) { history.saveRecentSearch("Deep Cover", 8) }
     }
 
+    @Test
+    fun `removing a recent search deletes only the selected query`() = runTest {
+        val addon = searchableAddon()
+        val history = mockk<SearchHistoryDataStore>(relaxed = true)
+        every { history.recentSearches } returns flowOf(listOf("Frieren", "Deep Cover"))
+        val viewModel = newViewModel(
+            addonRepository = GatedAddonRepository(addon, CompletableDeferred(Unit)),
+            catalogRepository = ImmediateCatalogRepository(addon),
+            history = history
+        )
+
+        viewModel.onEvent(SearchEvent.RemoveRecentSearch("Deep Cover"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { history.removeRecentSearch("Deep Cover") }
+        coVerify(exactly = 0) { history.clearRecentSearches() }
+    }
+
     private fun newViewModel(
         addonRepository: AddonRepository,
         catalogRepository: CatalogRepository,


### PR DESCRIPTION
## Summary

- Adds a dedicated X control beside each recent search so one entry can be removed without clearing the full history.
- Brings NuvioTV search-history controls to parity with Nuvio Mobile and Nuvio Desktop.
- Keeps deletion scoped to the active profile and preserves the existing Clear history action.
- Uses TV-focused styling, theme-aware colors, RTL-aware motion, and an accessible description for each delete control.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix

This is the enhancement requested in #3117 and is being opened as a draft while awaiting maintainer approval under the current contribution policy.

## Why

NuvioTV currently requires users to erase every recent search when they only want to remove one entry. Mobile and Desktop already expose individual removal, so TV is missing equivalent history management.

## Issue or approval

Relates to #3117. Maintainer approval is still required before this feature PR is ready for review.

## Reproduction steps

1. Open Search on NuvioTV with more than one recent-search entry.
2. Observe that the current build only offers Clear history.
3. With this change, move focus to the X beside one entry and select it.
4. Confirm only that entry disappears and the other entries remain.
5. Switch profiles and confirm each profile retains its own independent search history.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

This intentionally adds UI and behavior for an open feature request. The approval boxes remain unchecked until a maintainer approves implementation.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [ ] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only recent-search deletion is changed. Search submission, live search, result loading, Clear history, and history limits are unchanged. No dependencies, schemas, or unrelated screens are modified.

## Testing

- `./gradlew :app:testFullDebugUnitTest --tests "com.nuvio.tv.ui.screens.search.SearchViewModelConcurrencyTest"`
- `./gradlew :app:assembleFullDebug`
- Manually verified focus, deletion, spacing, and animation on NVIDIA Shield using the ARM64 full-debug build.
- Completed two code-review passes covering DataStore/profile behavior, event wiring, TV focus/layout, RTL behavior, accessibility, and regression scope.

## Screenshots / Video

https://github.com/user-attachments/assets/246a440c-46ce-4895-a031-7e95d449a262

## Breaking changes

None.

## Linked issues

Relates to #3117