### PR TITLE
Keep FragmentActivity in ProGuard rules for CloudStream extensions (NUVIO-TV-445)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -140,5 +140,10 @@
 -keepclassmembers class org.jsoup.** { *; }
 -keep class com.fasterxml.jackson.** { *; }
 -keepclassmembers class com.fasterxml.jackson.** { *; }
+
+# AndroidX components referenced by extensions
+-keep class androidx.fragment.app.** { *; }
+-keep interface androidx.fragment.app.** { *; }
+
 -dontwarn java.beans.ConstructorProperties
 -dontwarn java.beans.Transient


### PR DESCRIPTION
## Summary

Keep `androidx.fragment.app.**` classes and interfaces in ProGuard/R8 release builds to prevent fatal `NoClassDefFoundError` crashes when dynamic CloudStream extensions (such as WitAnime) reference `FragmentActivity` at runtime.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

In release builds with R8 code shrinking enabled, `androidx.fragment.app.FragmentActivity` was stripped because NuvioTV is built entirely with Jetpack Compose (`ComponentActivity`) and does not directly reference Fragment classes in application source code. However, CloudStream DEX extensions loaded dynamically via `DexClassLoader` (such as `WitAnimeProvider`) resolve AndroidX classes from the host classloader and reference `FragmentActivity` when attempting to hook playback listeners. When these extensions run, the unresolved class causes a fatal unhandled `NoClassDefFoundError` on the main thread, immediately crashing the app for the user.

## Issue or approval


fixes NUVIO-TV-445 

## Reproduction steps

1. Build and install a release APK (`fullRelease`) where R8/ProGuard minification is enabled.
2. Install and enable the WitAnime CloudStream extension (from the Arabic providers repository).
3. Select an anime episode and initiate playback or browse content.
4. The extension attempts to hook the player via `WitAnime$PlayerAccess.getPlayerFragment()` and resolves `androidx.fragment.app.FragmentActivity`.
5. Without the keep rule, the app crashes fatally with `NoClassDefFoundError: Failed resolution of: Landroidx/fragment/app/FragmentActivity;`.
6. With this rule in place, `androidx.fragment.app.**` classes are retained, the class resolves, safe casts evaluate safely to null without crashing, and the app continues normal operation.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only adds ProGuard keep rules for `androidx.fragment.app.**` in `app/proguard-rules.pro`. Does not modify `MainActivity`, player architecture, Compose hierarchies, or any other application code.

## Testing

- Verified that `androidx.fragment:fragment` is included transitively in `fullReleaseRuntimeClasspath`.
- Inspected the CloudStream `Witanime.cs3` DEX bytecode to verify the exact call stack (`WitAnime$PlayerAccess.getPlayerFragment`) and class resolution target (`androidx/fragment/app/FragmentActivity`).
- Verified that adding `-keep class androidx.fragment.app.** { *; }` and `-keep interface androidx.fragment.app.** { *; }` instructs R8 to preserve all `androidx.fragment.app` classes in release builds.


## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues
 fixes NUVIO-TV-445
