### PR TITLE
feat(rating): Add episode ratings overview across all seasons

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
@@ -3,20 +3,25 @@ package com.nuvio.tv.ui.screens.detail
 import com.nuvio.tv.ui.theme.NuvioTheme
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -68,8 +73,6 @@ import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Switch
-import androidx.tv.material3.SwitchDefaults
 import androidx.tv.material3.Text
 import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
@@ -549,6 +552,109 @@ private fun RatingsCloseButton(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
+private fun RatingsLayoutToggleButton(
+    layoutMode: RatingsLayoutMode,
+    onLayoutModeChanged: (RatingsLayoutMode) -> Unit,
+    focusRequester: FocusRequester,
+    rightFocusRequester: FocusRequester?,
+    downFocusRequester: FocusRequester?,
+    modifier: Modifier = Modifier
+) {
+    val isSeasonsAcross = layoutMode == RatingsLayoutMode.SEASONS_ACROSS
+    var isFocused by remember { mutableStateOf(false) }
+
+    val trackColor by animateColorAsState(
+        targetValue = if (isFocused) Color.Black.copy(alpha = 0.10f) else Color.White.copy(alpha = 0.08f),
+        label = "ratingsToggleTrack"
+    )
+    val indicatorColor by animateColorAsState(
+        targetValue = if (isFocused) Color.Black.copy(alpha = 0.14f) else NuvioColors.Secondary.copy(alpha = 0.85f),
+        label = "ratingsToggleIndicator"
+    )
+    val activeTextColor = if (isFocused) Color.Black else Color.White
+    val inactiveTextColor = if (isFocused) Color.Black.copy(alpha = 0.45f) else NuvioColors.TextSecondary
+
+    Button(
+        onClick = {
+            onLayoutModeChanged(
+                if (isSeasonsAcross) RatingsLayoutMode.EPISODES_ACROSS else RatingsLayoutMode.SEASONS_ACROSS
+            )
+        },
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .focusProperties {
+                left = Cancel
+                right = rightFocusRequester ?: Cancel
+                down = downFocusRequester ?: Cancel
+            }
+            .onFocusChanged { isFocused = it.isFocused },
+        shape = ButtonDefaults.shape(RoundedCornerShape(999.dp)),
+        border = ButtonDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(999.dp)
+            )
+        ),
+        colors = ButtonDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard.copy(alpha = 0.92f),
+            focusedContainerColor = Color.White,
+            contentColor = NuvioColors.TextPrimary,
+            focusedContentColor = Color.Black
+        ),
+        contentPadding = PaddingValues(3.dp)
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .width(150.dp)
+                .height(28.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(trackColor)
+        ) {
+            val halfWidth = maxWidth / 2
+            val indicatorOffset by animateDpAsState(
+                targetValue = if (isSeasonsAcross) halfWidth else 0.dp,
+                label = "ratingsToggleIndicatorOffset"
+            )
+
+            Box(
+                modifier = Modifier
+                    .offset(x = indicatorOffset)
+                    .width(halfWidth)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(indicatorColor)
+            )
+
+            Row(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier.width(halfWidth).fillMaxHeight(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.ratings_layout_episodes_label),
+                        style = MaterialTheme.typography.labelLarge.copy(fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                        color = if (isSeasonsAcross) inactiveTextColor else activeTextColor,
+                        maxLines = 1
+                    )
+                }
+                Box(
+                    modifier = Modifier.width(halfWidth).fillMaxHeight(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.ratings_layout_seasons_label),
+                        style = MaterialTheme.typography.labelLarge.copy(fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                        color = if (isSeasonsAcross) activeTextColor else inactiveTextColor,
+                        maxLines = 1
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
 private fun EpisodeRatingsOverlayMessageDialog(
     title: String,
     backdropModel: Any?,
@@ -682,54 +788,13 @@ private fun EpisodeRatingsOverlay(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        var toggleFocused by rememberSaveable { mutableStateOf(false) }
-                        Row(
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.focusRequester(toggleRequester)
-                                .focusProperties {
-                                    left = Cancel
-                                    right = closeRequester
-                                    down = firstCellFocusRequester ?: Cancel
-                                }
-                                .then(
-                                    if (toggleFocused) {
-                                        Modifier.border(
-                                            width = 2.dp,
-                                            color = NuvioColors.FocusRing,
-                                            shape = RoundedCornerShape(4.dp)
-                                        )
-                                    } else {
-                                        Modifier
-                                    }
-                                )
-                                .padding(horizontal = 3.dp, vertical = 2.dp)
-                                .onFocusChanged { toggleFocused = it.isFocused }
-                        ) {
-                            Text(
-                                text = stringResource(R.string.ratings_layout_inverted),
-                                style = MaterialTheme.typography.labelLarge.copy(fontSize = 15.sp, fontWeight = FontWeight.Medium),
-                                color = NuvioColors.TextSecondary
-                            )
-                            Switch(
-                                checked = layoutMode == RatingsLayoutMode.SEASONS_ACROSS,
-                                onCheckedChange = { checked ->
-                                    onLayoutModeChanged(
-                                        if (checked) {
-                                            RatingsLayoutMode.SEASONS_ACROSS
-                                        } else {
-                                            RatingsLayoutMode.EPISODES_ACROSS
-                                        }
-                                    )
-                                },
-                                colors = SwitchDefaults.colors(
-                                    checkedThumbColor = NuvioColors.Secondary,
-                                    checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f),
-                                    uncheckedThumbColor = NuvioColors.TextSecondary,
-                                    uncheckedTrackColor = NuvioColors.BackgroundCard
-                                )
-                            )
-                        }
+                        RatingsLayoutToggleButton(
+                            layoutMode = layoutMode,
+                            onLayoutModeChanged = onLayoutModeChanged,
+                            focusRequester = toggleRequester,
+                            rightFocusRequester = closeRequester,
+                            downFocusRequester = firstCellFocusRequester
+                        )
                         RatingsCloseButton(
                             onClick = onDismiss,
                             modifier = Modifier

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSection.kt
@@ -2,45 +2,84 @@ package com.nuvio.tv.ui.screens.detail
 
 import com.nuvio.tv.ui.theme.NuvioTheme
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusRequester.Companion.Cancel
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.tv.material3.Border
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Switch
+import androidx.tv.material3.SwitchDefaults
 import androidx.tv.material3.Text
 import androidx.compose.ui.res.stringResource
+import coil3.compose.AsyncImage
 import com.nuvio.tv.R
+import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.Video
+import com.nuvio.tv.ui.theme.NuvioColors
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -316,3 +355,1106 @@ private data class EpisodeRatingChipUi(
     val chipColor: Color,
     val chipTextColor: Color
 )
+
+// ---------------------------------------------------------------------------------------------
+// Chart-style ratings overlay (grid of all seasons/episodes), opened from a button on the Hero.
+// ---------------------------------------------------------------------------------------------
+
+private val PanelShape = RoundedCornerShape(10.dp)
+private val CellShape = RoundedCornerShape(4.dp)
+private val OverlayShape = RoundedCornerShape(12.dp)
+private val CellWidth = 46.dp
+private val CellHeight = 34.dp
+private val RowHeaderWidth = 60.dp
+private val GridContentPadding = 10.dp
+private const val AverageRowLabel = "Avg"
+
+private val ColorAwesome = Color(0xFF186A3B)
+private val ColorGreat = Color(0xFF28B463)
+private val ColorGood = Color(0xFFF4D03F)
+private val ColorRegular = Color(0xFFF39C12)
+private val ColorBad = Color(0xFFE74C3C)
+private val ColorGarbage = Color(0xFF633974)
+private val ColorMutedCell = Color(0xFF111111)
+
+internal enum class RatingsLayoutMode {
+    EPISODES_ACROSS,
+    SEASONS_ACROSS
+}
+
+private data class RatingsGridMetrics(
+    val cellWidth: androidx.compose.ui.unit.Dp,
+    val cellHeight: androidx.compose.ui.unit.Dp,
+    val rowHeaderWidth: androidx.compose.ui.unit.Dp,
+    val leadingHeaderWidth: androidx.compose.ui.unit.Dp,
+    val gridSpacing: androidx.compose.ui.unit.Dp,
+    val cellPadding: androidx.compose.ui.unit.Dp,
+    val summaryBarWidth: androidx.compose.ui.unit.Dp,
+    val summaryBarWidthEpisodesAcross: androidx.compose.ui.unit.Dp,
+    val summaryBarHeight: androidx.compose.ui.unit.Dp,
+    val unreleasedIconBoxSize: androidx.compose.ui.unit.Dp,
+    val unreleasedIconSize: androidx.compose.ui.unit.Dp
+)
+
+private fun rememberRatingsGridMetrics(displayModel: RatingsDisplayModel): RatingsGridMetrics {
+    val rowCount = displayModel.rows.size
+    val columnCount = displayModel.columnHeaders.size
+    val scale = when {
+        rowCount <= 2 || columnCount <= 2 -> 1.80f
+        rowCount <= 3 || columnCount <= 3 -> 1.55f
+        rowCount <= 4 || columnCount <= 4 -> 1.32f
+        rowCount <= 6 && columnCount <= 6 -> 1.16f
+        else -> 1f
+    }
+    return RatingsGridMetrics(
+        cellWidth = CellWidth * scale,
+        cellHeight = CellHeight * scale,
+        rowHeaderWidth = RowHeaderWidth * scale.coerceAtMost(1.35f),
+        leadingHeaderWidth = (RowHeaderWidth * scale.coerceAtMost(1.35f)).coerceAtLeast(78.dp),
+        gridSpacing = if (scale > 1.6f) 8.dp else if (scale > 1.3f) 7.dp else if (scale > 1f) 5.dp else 4.dp,
+        cellPadding = if (scale > 1.3f) 5.dp else if (scale > 1f) 4.dp else 3.dp,
+        summaryBarWidth = if (scale > 1.6f) 20.dp else if (scale > 1.3f) 18.dp else if (scale > 1f) 14.dp else 12.dp,
+        summaryBarWidthEpisodesAcross = if (scale > 1.6f) 22.dp else if (scale > 1.3f) 20.dp else if (scale > 1f) 16.dp else 14.dp,
+        summaryBarHeight = if (scale > 1.3f) 4.dp else if (scale > 1f) 3.dp else 2.dp,
+        unreleasedIconBoxSize = if (scale > 1.6f) 24.dp else if (scale > 1.3f) 22.dp else 18.dp,
+        unreleasedIconSize = if (scale > 1.6f) 16.dp else if (scale > 1.3f) 14.dp else 12.dp
+    )
+}
+
+@Composable
+fun EpisodeRatingsOverlayDialog(
+    meta: Meta,
+    episodes: List<Video>,
+    ratings: Map<Pair<Int, Int>, Double>,
+    isLoading: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    backdropModel: Any? = meta.backdropUrl
+) {
+    val chartData = remember(episodes, ratings) {
+        buildEpisodeRatingsChartData(episodes = episodes, ratings = ratings)
+    }
+    var layoutMode by rememberSaveable(meta.id) { mutableStateOf(RatingsLayoutMode.EPISODES_ACROSS) }
+
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+        when {
+            isLoading -> {
+                EpisodeRatingsOverlayMessageDialog(
+                    title = meta.name,
+                    backdropModel = backdropModel,
+                    message = stringResource(R.string.ratings_loading),
+                    onDismiss = onDismiss
+                )
+            }
+            error != null -> {
+                EpisodeRatingsOverlayMessageDialog(
+                    title = meta.name,
+                    backdropModel = backdropModel,
+                    message = error,
+                    onDismiss = onDismiss
+                )
+            }
+            chartData.displaySeasonNumbers.isEmpty() -> {
+                EpisodeRatingsOverlayMessageDialog(
+                    title = meta.name,
+                    backdropModel = backdropModel,
+                    message = stringResource(R.string.ratings_unavailable),
+                    onDismiss = onDismiss
+                )
+            }
+            else -> {
+                EpisodeRatingsOverlay(
+                    meta = meta,
+                    chartData = chartData,
+                    backdropModel = backdropModel,
+                    layoutMode = layoutMode,
+                    onLayoutModeChanged = { layoutMode = it },
+                    onDismiss = onDismiss
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeRatingsBackdrop(backdropModel: Any?) {
+    if (backdropModel != null) {
+        AsyncImage(
+            model = backdropModel,
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            alignment = Alignment.TopEnd
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.58f))
+    )
+}
+
+@Composable
+private fun OverlayHeaderBar(
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(OverlayShape)
+            .background(NuvioColors.Surface.copy(alpha = 0.60f))
+            .border(1.dp, Color.White.copy(alpha = 0.10f), OverlayShape)
+            .padding(start = 14.dp, end = 14.dp, top = 8.dp, bottom = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        content = content
+    )
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun RatingsCloseButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        shape = ButtonDefaults.shape(RoundedCornerShape(999.dp)),
+        border = ButtonDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                shape = RoundedCornerShape(999.dp)
+            )
+        ),
+        colors = ButtonDefaults.colors(
+            containerColor = NuvioColors.BackgroundCard.copy(alpha = 0.92f),
+            focusedContainerColor = Color.White,
+            contentColor = NuvioColors.TextPrimary,
+            focusedContentColor = Color.Black
+        ),
+        contentPadding = PaddingValues(
+            horizontal = 16.dp,
+            vertical = 3.dp
+        )
+    ) {
+        Text(
+            text = stringResource(R.string.ratings_close_overlay),
+            style = MaterialTheme.typography.labelLarge.copy(fontSize = 14.sp, fontWeight = FontWeight.Bold),
+            maxLines = 1
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun EpisodeRatingsOverlayMessageDialog(
+    title: String,
+    backdropModel: Any?,
+    message: String,
+    onDismiss: () -> Unit
+) {
+    BackHandler(onBack = onDismiss)
+    val closeRequester = remember { FocusRequester() }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            EpisodeRatingsBackdrop(backdropModel = backdropModel)
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                OverlayHeaderBar {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 17.sp),
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    RatingsCloseButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.focusRequester(closeRequester)
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(OverlayShape)
+                        .background(NuvioColors.Surface.copy(alpha = 0.60f))
+                        .border(1.dp, Color.White.copy(alpha = 0.10f), OverlayShape)
+                        .padding(12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp),
+                        color = NuvioColors.TextPrimary,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun EpisodeRatingsOverlay(
+    meta: Meta,
+    chartData: EpisodeRatingsChartData,
+    backdropModel: Any?,
+    layoutMode: RatingsLayoutMode,
+    onLayoutModeChanged: (RatingsLayoutMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    BackHandler(onBack = onDismiss)
+    val displayModel = remember(chartData, layoutMode) {
+        chartData.toDisplayModel(layoutMode)
+    }
+    var focusedEpisodeId by rememberSaveable(meta.id, displayModel.signature) {
+        mutableStateOf(displayModel.firstEpisodeId)
+    }
+    val focusRequesters = remember(displayModel) {
+        buildMap {
+            displayModel.rows.flatMap { it.cells }
+                .mapNotNull { it.episodeId }
+                .forEach { episodeId ->
+                    put(episodeId, FocusRequester())
+                }
+        }
+    }
+    val firstCellFocusRequester = focusRequesters.values.firstOrNull()
+    val closeRequester = remember { FocusRequester() }
+    val toggleRequester = remember { FocusRequester() }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            EpisodeRatingsBackdrop(backdropModel = backdropModel)
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                OverlayHeaderBar {
+                    Text(
+                        text = meta.name,
+                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 17.sp),
+                        color = NuvioColors.TextPrimary,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .wrapContentWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        RatingLegendStrip(modifier = Modifier.wrapContentWidth())
+                    }
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        var toggleFocused by rememberSaveable { mutableStateOf(false) }
+                        Row(
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.focusRequester(toggleRequester)
+                                .focusProperties {
+                                    left = Cancel
+                                    right = closeRequester
+                                    down = firstCellFocusRequester ?: Cancel
+                                }
+                                .then(
+                                    if (toggleFocused) {
+                                        Modifier.border(
+                                            width = 2.dp,
+                                            color = NuvioColors.FocusRing,
+                                            shape = RoundedCornerShape(4.dp)
+                                        )
+                                    } else {
+                                        Modifier
+                                    }
+                                )
+                                .padding(horizontal = 3.dp, vertical = 2.dp)
+                                .onFocusChanged { toggleFocused = it.isFocused }
+                        ) {
+                            Text(
+                                text = stringResource(R.string.ratings_layout_inverted),
+                                style = MaterialTheme.typography.labelLarge.copy(fontSize = 15.sp, fontWeight = FontWeight.Medium),
+                                color = NuvioColors.TextSecondary
+                            )
+                            Switch(
+                                checked = layoutMode == RatingsLayoutMode.SEASONS_ACROSS,
+                                onCheckedChange = { checked ->
+                                    onLayoutModeChanged(
+                                        if (checked) {
+                                            RatingsLayoutMode.SEASONS_ACROSS
+                                        } else {
+                                            RatingsLayoutMode.EPISODES_ACROSS
+                                        }
+                                    )
+                                },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = NuvioColors.Secondary,
+                                    checkedTrackColor = NuvioColors.Secondary.copy(alpha = 0.3f),
+                                    uncheckedThumbColor = NuvioColors.TextSecondary,
+                                    uncheckedTrackColor = NuvioColors.BackgroundCard
+                                )
+                            )
+                        }
+                        RatingsCloseButton(
+                            onClick = onDismiss,
+                            modifier = Modifier
+                                .focusRequester(closeRequester)
+                                .focusProperties {
+                                    left = toggleRequester
+                                    down = firstCellFocusRequester ?: Cancel
+                                }
+                        )
+                    }
+                }
+
+                RatingsGridPanel(
+                    displayModel = displayModel,
+                    layoutMode = layoutMode,
+                    focusedEpisodeId = focusedEpisodeId,
+                    onEpisodeFocused = { focusedEpisodeId = it },
+                    focusRequesters = focusRequesters,
+                    upFocusRequester = closeRequester,
+                    downFocusRequester = closeRequester,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RatingLegendStrip(modifier: Modifier = Modifier) {
+    val scrollState = rememberScrollState()
+
+    Row(
+        modifier = modifier
+            .horizontalScroll(scrollState)
+            .padding(horizontal = 2.dp),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        listOf(
+            LegendItem(color = ColorAwesome, label = "9+"),
+            LegendItem(color = ColorGreat, label = "8+"),
+            LegendItem(color = ColorGood, label = "7.5+"),
+            LegendItem(color = ColorRegular, label = "7+"),
+            LegendItem(color = ColorBad, label = "6+"),
+            LegendItem(color = ColorGarbage, label = "<6")
+        ).forEachIndexed { index, item ->
+            if (index > 0) Spacer(modifier = Modifier.width(5.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(item.color!!)
+                )
+                Text(
+                    text = item.label,
+                    style = MaterialTheme.typography.labelMedium.copy(fontSize = 15.sp, fontWeight = FontWeight.Medium),
+                    color = NuvioColors.TextSecondary
+                )
+            }
+            if (index < 5) Spacer(modifier = Modifier.width(4.dp))
+        }
+        Spacer(modifier = Modifier.width(6.dp))
+    }
+}
+
+@Composable
+private fun HeaderBadge(
+    label: String,
+    modifier: Modifier = Modifier,
+    color: Color = NuvioColors.TextPrimary,
+    fontSize: androidx.compose.ui.unit.TextUnit = 18.sp,
+    contentPadding: androidx.compose.ui.unit.Dp = 3.dp
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = contentPadding, vertical = 2.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold, fontSize = fontSize),
+                color = color,
+                textAlign = TextAlign.Center,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusClockBadge(
+    iconTint: Color,
+    containerColor: Color,
+    modifier: Modifier = Modifier,
+    iconSize: androidx.compose.ui.unit.Dp = 10.dp
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(3.dp))
+            .background(containerColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.AccessTime,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(iconSize)
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SummaryCell(
+    cell: RatingsDisplayCell,
+    metrics: RatingsGridMetrics,
+    isEpisodesAcross: Boolean = false
+) {
+    Box(
+        modifier = Modifier
+            .size(width = metrics.cellWidth, height = metrics.cellHeight)
+            .padding(horizontal = metrics.cellPadding, vertical = 2.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
+        ) {
+            Text(
+                text = cell.ratingLabel,
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold, fontSize = 15.sp),
+                color = NuvioColors.TextSecondary,
+                maxLines = 1,
+                textAlign = TextAlign.Center
+            )
+            Box(
+                modifier = Modifier
+                    .width(
+                        if (isEpisodesAcross) {
+                            metrics.summaryBarWidthEpisodesAcross
+                        } else {
+                            metrics.summaryBarWidth
+                        }
+                    )
+                    .height(metrics.summaryBarHeight.coerceAtLeast(3.dp))
+                    .clip(RoundedCornerShape(99.dp))
+                    .background(cell.backgroundColor)
+            )
+        }
+    }
+}
+
+private fun List<RatingsDisplayCell>.findHorizontalNeighbor(
+    startIndex: Int,
+    offset: Int
+): RatingsDisplayCell? {
+    var targetIndex = startIndex + offset
+    while (targetIndex in indices) {
+        val cell = this[targetIndex]
+        if (cell.episodeId != null) return cell
+        targetIndex += offset
+    }
+    return null
+}
+
+private fun RatingsDisplayModel.findHorizontalNeighborInColumn(
+    rowIndex: Int,
+    columnIndex: Int,
+    offset: Int
+): RatingsDisplayCell? {
+    var targetColumnIndex = columnIndex + offset
+    while (rows.isNotEmpty() && targetColumnIndex in rows.first().cells.indices) {
+        for (searchRowIndex in rowIndex downTo 0) {
+            val candidate = rows[searchRowIndex].cells.getOrNull(targetColumnIndex)
+            if (candidate?.episodeId != null) return candidate
+        }
+        for (searchRowIndex in (rowIndex + 1)..rows.lastIndex) {
+            val candidate = rows[searchRowIndex].cells.getOrNull(targetColumnIndex)
+            if (candidate?.episodeId != null) return candidate
+        }
+        targetColumnIndex += offset
+    }
+    return null
+}
+
+private fun RatingsDisplayModel.findStrictVerticalNeighbor(
+    rowIndex: Int,
+    columnIndex: Int,
+    offset: Int
+): RatingsDisplayCell? {
+    var targetRowIndex = rowIndex + offset
+    while (targetRowIndex in rows.indices) {
+        val candidate = rows[targetRowIndex].cells.getOrNull(columnIndex)
+        if (candidate?.episodeId != null) return candidate
+        targetRowIndex += offset
+    }
+    return null
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun RatingsGridPanel(
+    displayModel: RatingsDisplayModel,
+    layoutMode: RatingsLayoutMode,
+    focusedEpisodeId: String?,
+    onEpisodeFocused: (String) -> Unit,
+    focusRequesters: Map<String, FocusRequester>,
+    upFocusRequester: FocusRequester?,
+    downFocusRequester: FocusRequester?,
+    modifier: Modifier = Modifier
+) {
+    val horizontalScrollState = rememberScrollState()
+    val verticalScrollState = rememberScrollState()
+    val metrics = remember(displayModel) { rememberRatingsGridMetrics(displayModel) }
+
+    Column(
+        modifier = modifier
+            .background(NuvioColors.Surface.copy(alpha = 0.60f), PanelShape)
+            .border(1.dp, Color.White.copy(alpha = 0.10f), PanelShape)
+            .padding(8.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(start = GridContentPadding, end = GridContentPadding, top = GridContentPadding, bottom = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HeaderBadge(
+                label = displayModel.leadingHeader,
+                modifier = Modifier
+                    .width(metrics.leadingHeaderWidth)
+                    .height(metrics.cellHeight),
+                fontSize = 14.sp,
+                contentPadding = metrics.cellPadding
+            )
+            Spacer(modifier = Modifier.width(metrics.gridSpacing))
+
+            Row(
+                modifier = Modifier.horizontalScroll(horizontalScrollState),
+                horizontalArrangement = Arrangement.spacedBy(metrics.gridSpacing)
+            ) {
+                displayModel.columnHeaders.forEach { header ->
+                    HeaderBadge(
+                        label = header.label,
+                        modifier = Modifier
+                            .width(metrics.cellWidth)
+                            .height(metrics.cellHeight),
+                        fontSize = 16.sp,
+                        contentPadding = metrics.cellPadding
+                    )
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = GridContentPadding, end = GridContentPadding, bottom = GridContentPadding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .width(metrics.leadingHeaderWidth)
+                    .verticalScroll(verticalScrollState)
+                    .padding(end = metrics.gridSpacing)
+            ) {
+                Column(modifier = Modifier.padding(vertical = metrics.gridSpacing)) {
+                    displayModel.rows.forEachIndexed { rowIndex, row ->
+                        Box(
+                            modifier = Modifier
+                                .width(metrics.leadingHeaderWidth)
+                                .height(metrics.cellHeight)
+                                .padding(bottom = if (rowIndex == displayModel.rows.lastIndex) 0.dp else metrics.gridSpacing),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            HeaderBadge(
+                                label = row.label,
+                                modifier = Modifier.fillMaxSize(),
+                                color = NuvioColors.TextSecondary,
+                                fontSize = 16.sp,
+                                contentPadding = metrics.cellPadding
+                            )
+                        }
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .horizontalScroll(horizontalScrollState)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(verticalScrollState)
+                        .padding(vertical = metrics.gridSpacing)
+                ) {
+                    displayModel.rows.forEachIndexed { rowIndex, row ->
+                        Row(
+                            modifier = Modifier
+                                .height(metrics.cellHeight)
+                                .padding(bottom = if (rowIndex == displayModel.rows.lastIndex) 0.dp else metrics.gridSpacing),
+                            horizontalArrangement = Arrangement.spacedBy(metrics.gridSpacing)
+                        ) {
+                            row.cells.forEachIndexed { columnIndex, cell ->
+                                when {
+                                    cell.state == EpisodeRatingCellState.SUMMARY -> {
+                                        SummaryCell(
+                                            cell = cell,
+                                            metrics = metrics,
+                                            isEpisodesAcross = layoutMode == RatingsLayoutMode.EPISODES_ACROSS
+                                        )
+                                    }
+                                    cell.episodeId == null -> {
+                                        Box(modifier = Modifier.size(width = metrics.cellWidth, height = metrics.cellHeight))
+                                    }
+                                    else -> {
+                                        val episodeId = cell.episodeId
+                                        val bringIntoViewRequester = remember(episodeId) { BringIntoViewRequester() }
+                                        val upCell = if (layoutMode == RatingsLayoutMode.SEASONS_ACROSS) {
+                                            displayModel.findStrictVerticalNeighbor(rowIndex, columnIndex, -1)
+                                        } else {
+                                            displayModel.findNeighbor(rowIndex, columnIndex, -1)
+                                        }
+                                        val downCell = if (layoutMode == RatingsLayoutMode.SEASONS_ACROSS) {
+                                            displayModel.findStrictVerticalNeighbor(rowIndex, columnIndex, 1)
+                                        } else {
+                                            displayModel.findNeighbor(rowIndex, columnIndex, 1)
+                                        }
+                                        val leftCell = if (layoutMode == RatingsLayoutMode.SEASONS_ACROSS) {
+                                            displayModel.findHorizontalNeighborInColumn(rowIndex, columnIndex, -1)
+                                        } else {
+                                            row.cells.findHorizontalNeighbor(columnIndex, -1)
+                                        }
+                                        val rightCell = if (layoutMode == RatingsLayoutMode.SEASONS_ACROSS) {
+                                            displayModel.findHorizontalNeighborInColumn(rowIndex, columnIndex, 1)
+                                        } else {
+                                            row.cells.findHorizontalNeighbor(columnIndex, 1)
+                                        }
+
+                                        Card(
+                                            onClick = {},
+                                            modifier = Modifier
+                                                .focusRequester(focusRequesters.getValue(episodeId))
+                                                .bringIntoViewRequester(bringIntoViewRequester)
+                                                .focusProperties {
+                                                    left = leftCell?.episodeId?.let(focusRequesters::get) ?: Cancel
+                                                    right = rightCell?.episodeId?.let(focusRequesters::get) ?: Cancel
+                                                    val resolvedUp =
+                                                        upCell?.episodeId?.let(focusRequesters::get)
+                                                            ?: upFocusRequester
+                                                    up = resolvedUp ?: Cancel
+                                                    val resolvedDown = if (rowIndex == displayModel.rows.lastIndex) {
+                                                        Cancel
+                                                    } else {
+                                                        downCell?.episodeId?.let(focusRequesters::get)
+                                                    }
+                                                    down = resolvedDown ?: Cancel
+                                                }
+                                                .onFocusChanged {
+                                                    if (it.isFocused) onEpisodeFocused(episodeId)
+                                                },
+                                            shape = CardDefaults.shape(CellShape),
+                                            colors = CardDefaults.colors(
+                                                containerColor = cell.backgroundColor,
+                                                focusedContainerColor = cell.backgroundColor
+                                            ),
+                                            border = CardDefaults.border(
+                                                focusedBorder = Border(
+                                                    border = BorderStroke(2.dp, NuvioColors.FocusRing),
+                                                    shape = CellShape
+                                                )
+                                            ),
+                                            scale = CardDefaults.scale(focusedScale = 1f)
+                                        ) {
+                                            if (focusedEpisodeId == episodeId) {
+                                                LaunchedEffect(episodeId) {
+                                                    bringIntoViewRequester.bringIntoView()
+                                                }
+                                            }
+                                            Box(
+                                                modifier = Modifier
+                                                    .size(width = metrics.cellWidth, height = metrics.cellHeight)
+                                                    .padding(metrics.cellPadding),
+                                                contentAlignment = Alignment.Center
+                                            ) {
+                                                when (cell.state) {
+                                                    EpisodeRatingCellState.RATED -> {
+                                                        Text(
+                                                            text = cell.ratingLabel,
+                                                            style = MaterialTheme.typography.titleSmall.copy(
+                                                                fontWeight = FontWeight.Bold,
+                                                                fontSize = 18.sp
+                                                            ),
+                                                            color = if (cell.useDarkText) Color(0xFF1D1D1F) else Color.White,
+                                                            textAlign = TextAlign.Center
+                                                        )
+                                                    }
+                                                    EpisodeRatingCellState.UNRATED -> {
+                                                        Text(
+                                                            text = "—",
+                                                            style = MaterialTheme.typography.titleSmall.copy(
+                                                                fontWeight = FontWeight.Bold,
+                                                                fontSize = 18.sp
+                                                            ),
+                                                            color = NuvioColors.TextSecondary,
+                                                            textAlign = TextAlign.Center
+                                                        )
+                                                    }
+                                                    EpisodeRatingCellState.UNAIRED -> {
+                                                        StatusClockBadge(
+                                                            iconTint = Color.White,
+                                                            containerColor = ColorMutedCell,
+                                                            modifier = Modifier.size(metrics.unreleasedIconBoxSize),
+                                                            iconSize = metrics.unreleasedIconSize
+                                                        )
+                                                    }
+                                                    EpisodeRatingCellState.SUMMARY -> Unit
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun buildEpisodeRatingsChartData(
+    episodes: List<Video>,
+    ratings: Map<Pair<Int, Int>, Double>
+): EpisodeRatingsChartData {
+    val normalizedEpisodes = episodes
+        .filter { (it.season ?: 0) > 0 && (it.episode ?: 0) > 0 }
+        .sortedWith(compareBy<Video>({ it.season ?: Int.MAX_VALUE }, { it.episode ?: Int.MAX_VALUE }))
+
+    if (normalizedEpisodes.isEmpty()) return EpisodeRatingsChartData()
+
+    val seasonNumbers = normalizedEpisodes.mapNotNull { it.season }.distinct().sorted()
+    val maxEpisodeNumber = normalizedEpisodes.maxOfOrNull { it.episode ?: 0 } ?: 0
+    val episodeLookup = normalizedEpisodes.associateBy { requireNotNull(it.season) to requireNotNull(it.episode) }
+
+    val seasonAverages = seasonNumbers.mapNotNull { seasonNumber ->
+        val seasonRatings = (1..maxEpisodeNumber).mapNotNull { episodeNumber ->
+            ratings[seasonNumber to episodeNumber]
+        }
+        if (seasonRatings.isEmpty()) null else SeasonAverage(seasonNumber, seasonRatings.average())
+    }
+
+    return EpisodeRatingsChartData(
+        displaySeasonNumbers = seasonNumbers,
+        maxEpisodeNumber = maxEpisodeNumber,
+        episodeLookup = episodeLookup,
+        ratings = ratings,
+        seasonAverages = seasonAverages,
+        seasonAverageBySeasonNumber = seasonAverages.associate { it.seasonNumber to it.average }
+    )
+}
+
+internal data class EpisodeRatingsChartData(
+    val displaySeasonNumbers: List<Int> = emptyList(),
+    val maxEpisodeNumber: Int = 0,
+    val episodeLookup: Map<Pair<Int, Int>, Video> = emptyMap(),
+    val ratings: Map<Pair<Int, Int>, Double> = emptyMap(),
+    val seasonAverages: List<SeasonAverage> = emptyList(),
+    val seasonAverageBySeasonNumber: Map<Int, Double> = emptyMap()
+) {
+    fun toDisplayModel(layoutMode: RatingsLayoutMode): RatingsDisplayModel {
+        return when (layoutMode) {
+            RatingsLayoutMode.EPISODES_ACROSS -> {
+                val columnHeaders = buildList {
+                    add(RatingsDisplayHeader(label = "Avg"))
+                    (1..maxEpisodeNumber).forEach { episodeNumber ->
+                        add(RatingsDisplayHeader(label = "E$episodeNumber"))
+                    }
+                }
+                val rows = displaySeasonNumbers.map { seasonNumber ->
+                    RatingsDisplayRow(
+                        label = "S$seasonNumber",
+                        cells = buildList {
+                            val average = seasonAverageBySeasonNumber[seasonNumber]
+                            add(
+                                if (average == null) {
+                                    RatingsDisplayCell.summary(
+                                        seasonNumber = seasonNumber,
+                                        ratingLabel = "—",
+                                        backgroundColor = ColorMutedCell,
+                                        useDarkText = false
+                                    )
+                                } else {
+                                    RatingsDisplayCell.summary(
+                                        seasonNumber = seasonNumber,
+                                        ratingLabel = String.format("%.1f", average),
+                                        backgroundColor = getRatingColor(average),
+                                        useDarkText = average >= 7.0 && average < 8.0
+                                    )
+                                }
+                            )
+                            (1..maxEpisodeNumber).forEach { episodeNumber ->
+                                add(buildDisplayCell(seasonNumber, episodeNumber))
+                            }
+                        }
+                    )
+                }
+                RatingsDisplayModel(
+                    leadingHeader = "Season",
+                    columnHeaders = columnHeaders,
+                    rows = rows
+                )
+            }
+            RatingsLayoutMode.SEASONS_ACROSS -> {
+                val columnHeaders = displaySeasonNumbers.map { seasonNumber ->
+                    RatingsDisplayHeader(label = "S$seasonNumber")
+                }
+                val rows = buildList {
+                    add(
+                        RatingsDisplayRow(
+                            label = AverageRowLabel,
+                            cells = displaySeasonNumbers.map { seasonNumber ->
+                                buildAverageDisplayCell(seasonNumber)
+                            }
+                        )
+                    )
+                    addAll(
+                        (1..maxEpisodeNumber).map { episodeNumber ->
+                            RatingsDisplayRow(
+                                label = "E$episodeNumber",
+                                cells = displaySeasonNumbers.map { seasonNumber ->
+                                    buildDisplayCell(seasonNumber, episodeNumber)
+                                }
+                            )
+                        }
+                    )
+                }
+                RatingsDisplayModel(
+                    leadingHeader = "Episode",
+                    columnHeaders = columnHeaders,
+                    rows = rows
+                )
+            }
+        }
+    }
+
+    private fun buildAverageDisplayCell(seasonNumber: Int): RatingsDisplayCell {
+        val average = seasonAverageBySeasonNumber[seasonNumber]
+        return if (average == null) {
+            RatingsDisplayCell.summary(
+                seasonNumber = seasonNumber,
+                ratingLabel = "—",
+                backgroundColor = ColorMutedCell,
+                useDarkText = false
+            )
+        } else {
+            RatingsDisplayCell.summary(
+                seasonNumber = seasonNumber,
+                ratingLabel = String.format("%.1f", average),
+                backgroundColor = getRatingColor(average),
+                useDarkText = average >= 7.0 && average < 8.0
+            )
+        }
+    }
+
+    private fun buildDisplayCell(seasonNumber: Int, episodeNumber: Int): RatingsDisplayCell {
+        val episode = episodeLookup[seasonNumber to episodeNumber]
+            ?: return RatingsDisplayCell.placeholder(seasonNumber, episodeNumber)
+        val rating = ratings[seasonNumber to episodeNumber]
+        val isUnaired = isFutureEpisode(episode)
+        return RatingsDisplayCell(
+            episodeId = episode.id,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            ratingLabel = rating?.let { String.format("%.1f", it) }.orEmpty(),
+            state = when {
+                rating != null -> EpisodeRatingCellState.RATED
+                isUnaired -> EpisodeRatingCellState.UNAIRED
+                else -> EpisodeRatingCellState.UNRATED
+            },
+            backgroundColor = rating?.let(::getRatingColor) ?: ColorMutedCell,
+            useDarkText = rating != null && rating >= 7.0 && rating < 8.0
+        )
+    }
+}
+
+internal data class RatingsDisplayModel(
+    val leadingHeader: String,
+    val columnHeaders: List<RatingsDisplayHeader>,
+    val rows: List<RatingsDisplayRow>
+) {
+    val signature: String = buildString {
+        append(leadingHeader)
+        columnHeaders.forEach { header ->
+            append('|').append(header.label)
+        }
+        rows.forEach { row ->
+            append('#').append(row.label).append(':').append(row.average ?: "x")
+            row.cells.forEach { append(':').append(it.episodeId ?: "x") }
+        }
+    }
+
+    val firstEpisodeId: String?
+        get() = rows.flatMap { it.cells }.firstOrNull { it.episodeId != null }?.episodeId
+
+    fun findNeighbor(rowIndex: Int, columnIndex: Int, offset: Int): RatingsDisplayCell? {
+        var targetIndex = rowIndex + offset
+        while (targetIndex in rows.indices) {
+            val cells = rows[targetIndex].cells
+            val preferredIndex = columnIndex.coerceIn(0, cells.lastIndex)
+
+            for (searchIndex in preferredIndex downTo 0) {
+                val candidate = cells[searchIndex]
+                if (candidate.episodeId != null) return candidate
+            }
+
+            for (searchIndex in (preferredIndex + 1)..cells.lastIndex) {
+                val candidate = cells[searchIndex]
+                if (candidate.episodeId != null) return candidate
+            }
+
+            targetIndex += offset
+        }
+        return null
+    }
+}
+
+internal data class RatingsDisplayHeader(
+    val label: String
+)
+
+internal data class RatingsDisplayRow(
+    val label: String,
+    val average: Double? = null,
+    val cells: List<RatingsDisplayCell>
+)
+
+internal data class SeasonAverage(
+    val seasonNumber: Int,
+    val average: Double
+)
+
+internal enum class EpisodeRatingCellState {
+    RATED,
+    UNRATED,
+    UNAIRED,
+    SUMMARY
+}
+
+internal data class RatingsDisplayCell(
+    val episodeId: String?,
+    val seasonNumber: Int,
+    val episodeNumber: Int,
+    val ratingLabel: String,
+    val state: EpisodeRatingCellState,
+    val backgroundColor: Color,
+    val useDarkText: Boolean
+) {
+    companion object {
+        fun placeholder(seasonNumber: Int, episodeNumber: Int) = RatingsDisplayCell(
+            episodeId = null,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            ratingLabel = "",
+            state = EpisodeRatingCellState.UNRATED,
+            backgroundColor = Color.Transparent,
+            useDarkText = false
+        )
+
+        fun summary(
+            seasonNumber: Int,
+            ratingLabel: String,
+            backgroundColor: Color,
+            useDarkText: Boolean
+        ) = RatingsDisplayCell(
+            episodeId = null,
+            seasonNumber = seasonNumber,
+            episodeNumber = 0,
+            ratingLabel = ratingLabel,
+            state = EpisodeRatingCellState.SUMMARY,
+            backgroundColor = backgroundColor,
+            useDarkText = useDarkText
+        )
+    }
+}
+
+private data class LegendItem(
+    val color: Color? = null,
+    val label: String,
+    val iconColor: Color? = null,
+    val iconContainerColor: Color? = null
+)
+
+private fun getRatingColor(rating: Double): Color {
+    return when {
+        rating >= 9.0 -> ColorAwesome
+        rating >= 8.0 -> ColorGreat
+        rating >= 7.5 -> ColorGood
+        rating >= 7.0 -> ColorRegular
+        rating >= 6.0 -> ColorBad
+        else -> ColorGarbage
+    }
+}
+
+private fun isFutureEpisode(video: Video): Boolean {
+    val releaseDate = parseReleaseDate(video.released) ?: return false
+    return releaseDate.isAfter(LocalDate.now())
+}
+
+private fun parseReleaseDate(value: String?): LocalDate? {
+    val normalized = value?.substringBefore('T')?.trim().orEmpty()
+    if (normalized.isBlank()) return null
+    return try {
+        LocalDate.parse(normalized, DateTimeFormatter.ISO_LOCAL_DATE)
+    } catch (_: DateTimeParseException) {
+        null
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/HeroSection.kt
@@ -109,7 +109,12 @@ fun HeroContentSection(
     restorePlayFocusToken: Int = 0,
     onHeroActionFocused: () -> Unit = {},
     onPlayFocusRestored: () -> Unit = {},
-    onShowFullDescription: () -> Unit = {}
+    onShowFullDescription: () -> Unit = {},
+    ratingsAvailable: Boolean = false,
+    onRatingsClick: () -> Unit = {},
+    ratingsButtonFocusRequester: FocusRequester? = null,
+    restoreRatingsFocusToken: Int = 0,
+    onRatingsFocusRestored: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val isSeriesApi = remember(meta.apiType) {
@@ -289,6 +294,20 @@ fun HeroContentSection(
                                 contentDescription = stringResource(R.string.hero_play_trailer),
                                 onClick = onTrailerClick,
                                 onFocused = onHeroActionFocused
+                            )
+                        }
+
+                        if (ratingsAvailable) {
+                            RatingsActionButton(
+                                contentDescription = stringResource(R.string.ratings_open_overlay),
+                                onClick = onRatingsClick,
+                                onFocused = onHeroActionFocused,
+                                focusRequester = ratingsButtonFocusRequester,
+                                restoreFocusToken = restoreRatingsFocusToken,
+                                onFocusRestored = {
+                                    onHeroActionFocused()
+                                    onRatingsFocusRestored()
+                                }
                             )
                         }
                     }
@@ -583,6 +602,96 @@ private fun ActionIconButton(
                 modifier = Modifier.size(NuvioTheme.spacing.xl)
             )
         }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+private fun RatingsActionButton(
+    contentDescription: String,
+    onClick: () -> Unit,
+    onFocused: () -> Unit = {},
+    focusRequester: FocusRequester? = null,
+    restoreFocusToken: Int = 0,
+    onFocusRestored: () -> Unit = {}
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    var pendingRestore by remember { mutableStateOf(false) }
+
+    LaunchedEffect(restoreFocusToken) {
+        if (restoreFocusToken > 0 && focusRequester != null) {
+            pendingRestore = true
+            focusRequester.requestFocusAfterFrames()
+        }
+    }
+
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier
+            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+            .size(NuvioTheme.spacing.xxxl)
+            .onFocusChanged { state ->
+                isFocused = state.isFocused
+                if (state.isFocused) {
+                    onFocused()
+                    if (pendingRestore) {
+                        pendingRestore = false
+                        onFocusRestored()
+                    }
+                }
+            }
+            .focusProperties { up = FocusRequester.Cancel },
+        colors = IconButtonDefaults.colors(
+            containerColor = NuvioTheme.colors.BackgroundCard,
+            focusedContainerColor = NuvioTheme.colors.Secondary,
+            contentColor = NuvioTheme.colors.TextPrimary,
+            focusedContentColor = NuvioTheme.colors.OnSecondary
+        ),
+        border = IconButtonDefaults.border(
+            focusedBorder = Border(
+                border = NuvioTheme.focusRing.border(NuvioTheme.spacing.xxs),
+                shape = CircleShape
+            )
+        ),
+        shape = IconButtonDefaults.shape(shape = CircleShape)
+    ) {
+        ChartGlyph(
+            modifier = Modifier
+                .size(22.dp)
+                .padding(horizontal = 1.dp, vertical = 2.dp),
+            color = if (isFocused) NuvioTheme.colors.OnSecondary else NuvioTheme.colors.TextPrimary
+        )
+    }
+}
+
+@Composable
+private fun ChartGlyph(
+    modifier: Modifier = Modifier,
+    color: Color
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Box(
+            modifier = Modifier
+                .width(4.dp)
+                .height(8.dp)
+                .background(color, RoundedCornerShape(99.dp))
+        )
+        Box(
+            modifier = Modifier
+                .width(4.dp)
+                .height(14.dp)
+                .background(color, RoundedCornerShape(99.dp))
+        )
+        Box(
+            modifier = Modifier
+                .width(4.dp)
+                .height(11.dp)
+                .background(color, RoundedCornerShape(99.dp))
+        )
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -1094,6 +1094,7 @@ private fun MetaDetailsContent(
     val ratingsTabFocusRequester = remember { FocusRequester() }
     val ratingsContentFocusRequester = remember { FocusRequester() }
     val ratingsGridFocusRequester = remember { FocusRequester() }
+    val heroRatingsFocusRequester = remember { FocusRequester() }
     val castSectionFocusRequester = remember { FocusRequester() }
     val moreLikeSectionFocusRequester = remember { FocusRequester() }
     val trailerSectionFocusRequester = remember { FocusRequester() }
@@ -1114,6 +1115,8 @@ private fun MetaDetailsContent(
     var initialHeroFocusRequested by rememberSaveable(meta.id) { mutableStateOf(false) }
     var showHeroPlayOptionsDialog by rememberSaveable(meta.id) { mutableStateOf(false) }
     var showSynopsisOverlay by rememberSaveable(meta.id) { mutableStateOf(false) }
+    var showRatingsOverlay by rememberSaveable(meta.id) { mutableStateOf(false) }
+    var restoreRatingsFocusToken by rememberSaveable { mutableIntStateOf(0) }
     var initialDetailReturnFocusHandled by rememberSaveable(
         meta.id,
         detailReturnEpisodeFocusRequest?.season,
@@ -1822,7 +1825,16 @@ private fun MetaDetailsContent(
                             initialHeroFocusRequested = true
                             clearPendingRestore()
                         },
-                        onShowFullDescription = { showSynopsisOverlay = true }
+                        onShowFullDescription = { showSynopsisOverlay = true },
+                        ratingsAvailable = hasRatingsSection,
+                        onRatingsClick = {
+                            showRatingsOverlay = true
+                        },
+                        ratingsButtonFocusRequester = heroRatingsFocusRequester,
+                        restoreRatingsFocusToken = restoreRatingsFocusToken,
+                        onRatingsFocusRestored = {
+                            initialHeroFocusRequested = true
+                        }
                     )
                 }
             }
@@ -2274,6 +2286,21 @@ private fun MetaDetailsContent(
                 title = meta.name,
                 description = synopsis,
                 onDismiss = { showSynopsisOverlay = false }
+            )
+        }
+
+        if (showRatingsOverlay) {
+            EpisodeRatingsOverlayDialog(
+                meta = meta,
+                episodes = meta.videos,
+                ratings = visibleEpisodeImdbRatings,
+                isLoading = isEpisodeRatingsLoading,
+                error = episodeRatingsError,
+                onDismiss = {
+                    restoreRatingsFocusToken += 1
+                    showRatingsOverlay = false
+                },
+                backdropModel = backdropRequest
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2216,6 +2216,9 @@
     <!-- EpisodeRatingsSection -->
     <string name="ratings_loading">Loading episode ratings...</string>
     <string name="ratings_unavailable">Episode ratings are unavailable.</string>
+    <string name="ratings_open_overlay">Open ratings grid</string>
+    <string name="ratings_close_overlay">Close</string>
+    <string name="ratings_layout_inverted">Inverted</string>
     <string name="ratings_load_error">Unable to load episode ratings.</string>
     <string name="ratings_season_summary">Season %1$d - %2$d episodes</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2218,7 +2218,8 @@
     <string name="ratings_unavailable">Episode ratings are unavailable.</string>
     <string name="ratings_open_overlay">Open ratings grid</string>
     <string name="ratings_close_overlay">Close</string>
-    <string name="ratings_layout_inverted">Inverted</string>
+    <string name="ratings_layout_episodes_label">Episodes</string>
+    <string name="ratings_layout_seasons_label">Seasons</string>
     <string name="ratings_load_error">Unable to load episode ratings.</string>
     <string name="ratings_season_summary">Season %1$d - %2$d episodes</string>
 

--- a/app/src/test/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSectionTest.kt‎
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/detail/EpisodeRatingsSectionTest.kt‎
@@ -1,0 +1,100 @@
+package com.nuvio.tv.ui.screens.detail
+
+import com.nuvio.tv.domain.model.Video
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EpisodeRatingsSectionTest {
+
+    @Test
+    fun `episodes across layout remains available for inverted mode`() {
+        val chart = buildEpisodeRatingsChartData(
+            episodes = listOf(
+                episode(id = "s1e1", season = 1, episode = 1),
+                episode(id = "s1e2", season = 1, episode = 2),
+                episode(id = "s2e1", season = 2, episode = 1),
+                episode(id = "s2e3", season = 2, episode = 3)
+            ),
+            ratings = mapOf(
+                (1 to 1) to 8.4,
+                (2 to 3) to 9.3
+            )
+        )
+
+        val display = chart.toDisplayModel(RatingsLayoutMode.EPISODES_ACROSS)
+
+        assertEquals(listOf(1, 2), chart.displaySeasonNumbers)
+        assertEquals(3, chart.maxEpisodeNumber)
+        assertEquals("Season", display.leadingHeader)
+        assertEquals(listOf("Avg", "E1", "E2", "E3"), display.columnHeaders.map { it.label })
+        assertEquals("S1", display.rows[0].label)
+        assertEquals("8.4", display.rows[0].cells[0].ratingLabel)
+        assertEquals("s1e1", display.rows[0].cells[1].episodeId)
+        assertEquals("s2e3", display.rows[1].cells[3].episodeId)
+        assertEquals("9.3", display.rows[1].cells[3].ratingLabel)
+    }
+
+    @Test
+    fun `seasons across layout keeps mobile style orientation available`() {
+        val chart = buildEpisodeRatingsChartData(
+            episodes = listOf(
+                episode(id = "s1e1", season = 1, episode = 1),
+                episode(id = "s1e2", season = 1, episode = 2),
+                episode(id = "s2e1", season = 2, episode = 1),
+                episode(id = "s2e2", season = 2, episode = 2)
+            ),
+            ratings = emptyMap()
+        )
+
+        val display = chart.toDisplayModel(RatingsLayoutMode.SEASONS_ACROSS)
+
+        assertEquals("Episode", display.leadingHeader)
+        assertEquals(listOf("S1", "S2"), display.columnHeaders.map { it.label })
+        assertEquals("Avg", display.rows[0].label)
+        assertEquals(3, display.rows.size)
+        assertEquals(EpisodeRatingCellState.SUMMARY, display.rows[0].cells[0].state)
+        assertEquals("—", display.rows[0].cells[0].ratingLabel)
+        assertEquals("E1", display.rows[1].label)
+        assertEquals("s1e1", display.rows[1].cells[0].episodeId)
+        assertEquals("s2e2", display.rows[2].cells[1].episodeId)
+    }
+
+    @Test
+    fun `season averages are computed from available ratings only`() {
+        val chart = buildEpisodeRatingsChartData(
+            episodes = listOf(
+                episode(id = "s1e1", season = 1, episode = 1),
+                episode(id = "s1e2", season = 1, episode = 2),
+                episode(id = "s2e1", season = 2, episode = 1)
+            ),
+            ratings = mapOf(
+                (1 to 1) to 8.0,
+                (1 to 2) to 6.0,
+                (2 to 1) to 9.0
+            )
+        )
+
+        assertEquals(2, chart.seasonAverages.size)
+        assertEquals(7.0, chart.seasonAverages.first { it.seasonNumber == 1 }.average, 0.001)
+        assertEquals(9.0, chart.seasonAverages.first { it.seasonNumber == 2 }.average, 0.001)
+        val display = chart.toDisplayModel(RatingsLayoutMode.SEASONS_ACROSS)
+        assertEquals("Avg", display.rows.first().label)
+        assertEquals(EpisodeRatingCellState.SUMMARY, display.rows.first().cells[0].state)
+        assertEquals("7.0", display.rows.first().cells[0].ratingLabel)
+        assertEquals("9.0", display.rows.first().cells[1].ratingLabel)
+        assertNotNull(chart.toDisplayModel(RatingsLayoutMode.EPISODES_ACROSS).firstEpisodeId)
+        assertTrue(display.rows.isNotEmpty())
+    }
+
+    private fun episode(id: String, season: Int?, episode: Int?) = Video(
+        id = id,
+        title = id,
+        released = null,
+        thumbnail = null,
+        season = season,
+        episode = episode,
+        overview = null
+    )
+}


### PR DESCRIPTION
## Summary

Add a dedicated episode ratings overview to TV series pages, showing the ratings of all episodes organized by season. The existing Rating tab and its functionality will remain unchanged.

NuvioTV already exposes ratings at the episode, season, and series levels. This feature brings that existing information together into a single, easy-to-browse view.

Credit: @EzzatBoukhary
Based on: `feature/ratings-chart`
Original Issue: https://github.com/NuvioMedia/NuvioTV/issues/1689

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Currently, users can see an episode's rating only when viewing that specific episode, while the series page provides only the overall series rating. There is no convenient way to compare episode ratings across a season or understand how ratings change throughout an entire series.

As a result, users have to open episodes individually to find highly rated episodes, compare seasons, or identify lower-rated episodes. This becomes especially inconvenient for series with many seasons and episodes.

An episode ratings overview makes the existing rating data much more useful by giving users a clear picture of episode performance at a glance, making it easier to compare episodes, discover standout entries, and see rating trends across seasons.

## Issue or approval

#1689

## Reproduction steps

1. Open a TV series with multiple seasons and episodes.
2. Try to compare episode ratings across the series.
3. Notice that ratings are only available when viewing individual episodes or seasons.
4. Open the new episode ratings overview.
5. Verify that episodes and their ratings are displayed by seasons.
6. No need to switch between seasons.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy.
- [x] This PR does not include unrelated refactors or cleanup.
- [x] This PR is focused on #1689.
- [x] Testing has been performed.
- [x] The linked issue is included.

## Scope boundaries

Intentionally unchanged:

* Existing Rating tab and functionality.
* Rating calculations and data sources.
* Series-level ratings.
* Playback and episode selection.
* Watch history and progress.
* Unrelated UI or feature work.

## Testing

Tested the ratings overview with TV series containing:

* Multiple seasons.
* Different numbers of episodes per season.
* Short and long seasons.
* Episodes with available ratings.
* RTL and LTR layouts.

Verified:

* Correct ratings are shown for each episode.
* Seasons with different episode counts work correctly.
* Focus navigation works with a TV remote.
* The chart can be opened and closed using normal TV navigation.
* Existing rating functionality remains unaffected.

## Screenshots / Video

<img width="1821" height="914" alt="IMG_3780" src="https://github.com/user-attachments/assets/bccf7563-0f01-43f8-9714-2e57e7bfd3cc" />


https://github.com/user-attachments/assets/7d9743db-9fe3-458f-910f-5b235ce958a2



## Breaking changes

None.

## Linked issues

Fixes #1689, Fixes #3493, Fixes #3517

## Credit

Implementation based on @EzzatBoukhary's work:

`https://github.com/EzzatBoukhary/NuvioTV/tree/feature/ratings-chart`
