### PR TITLE
Fix Network: validate TLS on first-party API traffic

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -103,7 +103,8 @@ object NetworkModule {
     fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient {
         return OkHttpClient.Builder()
             .dns(IPv4FirstDns())
-            .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
+            // Keep separate from the old trust-all cache. Cached responses bypass a new TLS handshake.
+            .cache(Cache(File(context.cacheDir, "http_cache_v2"), 50L * 1024 * 1024)) // 50 MB disk cache
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .addInterceptor { chain ->
@@ -134,11 +135,10 @@ object NetworkModule {
     }
 
     /**
-     * Permissive client for addon-provided URLs, which commonly point at self-hosted servers
-     * with self-signed certificates. Do not use for first-party endpoints.
+     * Permissive client for addon-provided URLs, including self-hosted servers with self-signed
+     * certificates. Uses a separate cache from first-party traffic.
      *
-     * Uses its own cache so a response fetched without certificate validation cannot be reused
-     * by a first-party request sharing the same cache key.
+     * Do not use for first-party endpoints.
      */
     @Provides
     @Singleton

--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -97,21 +97,12 @@ object NetworkModule {
         .add(KotlinJsonAdapterFactory())
         .build()
 
+    /** Validating client for fixed first-party endpoints. Addon URLs use `addonPermissive`. */
     @Provides
     @Singleton
     fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient {
-        val trustAllManager = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
-        }
         return OkHttpClient.Builder()
             .dns(IPv4FirstDns())
-            .sslSocketFactory(sslContext.socketFactory, trustAllManager)
-            .hostnameVerifier { _, _ -> true }
             .cache(Cache(File(context.cacheDir, "http_cache"), 50L * 1024 * 1024)) // 50 MB disk cache
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
@@ -139,6 +130,35 @@ object NetworkModule {
                 level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
                         else HttpLoggingInterceptor.Level.NONE
             })
+            .build()
+    }
+
+    /**
+     * Permissive client for addon-provided URLs, which commonly point at self-hosted servers
+     * with self-signed certificates. Do not use for first-party endpoints.
+     *
+     * Uses its own cache so a response fetched without certificate validation cannot be reused
+     * by a first-party request sharing the same cache key.
+     */
+    @Provides
+    @Singleton
+    @Named("addonPermissive")
+    fun provideAddonPermissiveOkHttpClient(
+        @ApplicationContext context: Context,
+        okHttpClient: OkHttpClient
+    ): OkHttpClient {
+        val trustAllManager = object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
+        }
+        return okHttpClient.newBuilder()
+            .cache(Cache(File(context.cacheDir, "addon_http_cache"), 50L * 1024 * 1024))
+            .sslSocketFactory(sslContext.socketFactory, trustAllManager)
+            .hostnameVerifier { _, _ -> true }
             .build()
     }
 
@@ -277,7 +297,10 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit =
+    fun provideRetrofit(
+        @Named("addonPermissive") okHttpClient: OkHttpClient,
+        moshi: Moshi
+    ): Retrofit =
         Retrofit.Builder()
             .baseUrl("https://placeholder.nuvio.tv/")
             .client(okHttpClient)

--- a/app/src/main/java/com/nuvio/tv/core/player/SubtitleFileCache.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/SubtitleFileCache.kt
@@ -11,6 +11,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -20,7 +21,9 @@ import javax.inject.Singleton
 @Singleton
 class SubtitleFileCache @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val okHttpClient: OkHttpClient
+    // Callers pass addon-provided subtitle URLs, so use the permissive addon client.
+    // Keep it that way: anything routed through here inherits permissive TLS.
+    @param:Named("addonPermissive") private val okHttpClient: OkHttpClient
 ) {
     private val cacheDir: File
         get() = File(context.cacheDir, SUBTITLE_CACHE_DIR).also { it.mkdirs() }


### PR DESCRIPTION
## Summary

The shared OkHttp client accepted any server certificate and hostname. As the unnamed Hilt binding, it was also used by first-party traffic, including TMDB, Supabase auth, the updater, and Trakt.

Addon URLs still need permissive TLS because they commonly use self-signed certificates. That configuration moves to a named `@Named("addonPermissive")` client instead of being removed. It was added for addons in `000b4d68b`, fixing #1157.

- The default client now uses platform certificate and hostname verification.
- `AddonApi` and `SubtitleFileCache` use the permissive client.
- First-party and addon traffic use separate cache directories.
- The first-party cache moves from `http_cache` to `http_cache_v2`, because entries the old trust-all client wrote could be served without a new TLS connection.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A network attacker able to intercept the connection could present an arbitrary certificate for a first-party host. This could expose Trakt OAuth and Supabase session tokens and allow responses to be modified.

First-party connections now use the platform's normal certificate and hostname verification.

## Issue or approval

Fixes #3411

## Reproduction steps

1. Put the device behind an intercepting HTTPS proxy, using mitmproxy without installing its CA certificate.
2. Sign in, or let metadata load.
3. On the affected commit, the requests succeed through the proxy. With this change, first-party requests reject the untrusted certificate while addon requests continue to work.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Keep using the permissive client:

- `AddonApi` via `provideRetrofit`
- `SubtitleFileCache`

Now use the validating client:

- TMDB, GitHub, parental guide, IntroDB, AniSkip, Anime-Skip, unique contributions, supporters, playback reports, trailer, MDBList, series graph, IMDb Tapframe
- Trakt via `provideTraktOkHttpClient`
- `AuthManager`'s Supabase client
- `ApkDownloader`

Plain HTTP addons are unaffected.

These build their own networking configuration and are unchanged: `directDebrid`, `simkl`, `customServerAuth`, the Coil image loader, TorrServer and server discovery, the plugin loaders in `app/src/full`, and `PlayerPlaybackNetworking`.

## Testing

**Build:** full debug APK builds clean.

**Unit tests:** `:app:testFullDebugUnitTest` reports 1170 tests with 15 failures, run against both commits. The same 15 tests fail on `dev` at `cf83131c7`; no additional failures were introduced.

**Device:** Android 11, fresh install with data and cache cleared, on the first commit. The cache-directory change landed after this run.

| Check | Result |
| --- | --- |
| Self-signed HTTPS addon installs and catalogue loads | pass |
| Plain HTTP addon reachable | pass |
| Nuvio Sync sign-in using the validating default client | pass |
| Simkl sign-in | pass |

The self-signed HTTPS addon test confirms that addon TLS behavior is preserved.

**Not tested:**

- Rejection of an untrusted certificate
- Trakt, because this build has no Trakt client ID and the app gates locally before calling the API
- In-app update check
- Addon subtitle downloads
- Android 7 to 9 devices

There is no existing test infrastructure for an end-to-end untrusted-certificate test; the current test dependencies do not include MockWebServer or Robolectric.

## Screenshots / Video

Not a UI change.

## Breaking changes

None beyond the intended behavior change described above.

## Linked issues

Fixes #3411