### PR TITLE
Fix Search: tie catalog paging to the search run that created the row

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchViewModel.kt
@@ -76,6 +76,13 @@ class SearchViewModel @Inject constructor(
     private val catalogOrder = mutableListOf<String>()
 
     private var activeSearchJobs: List<Job> = emptyList()
+
+    /**
+     * Load-more jobs, tracked separately from [activeSearchJobs] because that list is replaced
+     * wholesale by each search run. Cancelled alongside it in [cancelSearchRun].
+     */
+    private val activeLoadMoreJobs: MutableSet<Job> =
+        java.util.concurrent.ConcurrentHashMap.newKeySet()
     private var searchRunJob: Job? = null
     private var activeSearchQuery: String? = null
     private var searchGeneration = 0L
@@ -458,6 +465,8 @@ class SearchViewModel @Inject constructor(
         searchRunJob = null
         activeSearchJobs.forEach { it.cancel() }
         activeSearchJobs = emptyList()
+        activeLoadMoreJobs.forEach { it.cancel() }
+        activeLoadMoreJobs.clear()
         activeSearchQuery = null
     }
 
@@ -737,6 +746,12 @@ class SearchViewModel @Inject constructor(
     private fun isCurrentSearch(generation: Long, query: String): Boolean =
         generation == searchGeneration && uiState.value.submittedQuery.trim() == query
 
+    /**
+     * Pages one row of the current search. The page belongs to the search run that created it:
+     * it is keyed on [SearchUiState.submittedQuery] rather than the live field, and every
+     * assignment back into [catalogsMap] is gated on that run still being current, so a late page
+     * cannot merge into a different query's rows.
+     */
     private fun loadMoreCatalogItems(catalogId: String, addonId: String, type: String) {
         val (key, currentRow) = catalogsMap.entries.firstOrNull { (_, row) ->
             row.addonId == addonId && row.apiType == type && row.catalogId == catalogId
@@ -746,19 +761,19 @@ class SearchViewModel @Inject constructor(
             return
         }
 
-        catalogsMap[key] = currentRow.copy(isLoading = true)
-        scheduleCatalogRowsUpdate()
-
-        val query = uiState.value.query.trim()
+        val generation = searchGeneration
+        val query = uiState.value.submittedQuery.trim()
         if (query.isBlank()) {
             return
         }
 
-        viewModelScope.launch {
+        catalogsMap[key] = currentRow.copy(isLoading = true)
+        scheduleCatalogRowsUpdate()
+
+        val job = viewModelScope.launch {
             val addon = uiState.value.installedAddons.find { it.id == addonId && it.baseUrl == currentRow.addonBaseUrl }
                 ?: uiState.value.installedAddons.find { it.id == addonId } ?: run {
-                catalogsMap[key] = currentRow.copy(isLoading = false)
-                scheduleCatalogRowsUpdate()
+                clearRowLoading(key, generation, query)
                 return@launch
             }
 
@@ -777,19 +792,29 @@ class SearchViewModel @Inject constructor(
             ).collect { result ->
                 when (result) {
                     is NetworkResult.Success -> {
-                        val latestRow = catalogsMap[key] ?: currentRow
-                        val mergedRow = latestRow.mergeCatalogPage(result.data)
-                        catalogsMap[key] = mergedRow
+                        if (!isCurrentSearch(generation, query)) return@collect
+                        val latestRow = catalogsMap[key] ?: return@collect
+                        catalogsMap[key] = latestRow.mergeCatalogPage(result.data)
                         scheduleCatalogRowsUpdate()
                     }
                     is NetworkResult.Error -> {
-                        catalogsMap[key] = currentRow.copy(isLoading = false)
-                        scheduleCatalogRowsUpdate()
+                        clearRowLoading(key, generation, query)
                     }
                     NetworkResult.Loading -> Unit
                 }
             }
         }
+        activeLoadMoreJobs.add(job)
+        job.invokeOnCompletion { activeLoadMoreJobs.remove(job) }
+    }
+
+    /** Drops the loading flag for a row, but only while its search run is still current. */
+    private fun clearRowLoading(key: String, generation: Long, query: String) {
+        if (!isCurrentSearch(generation, query)) return
+        val row = catalogsMap[key] ?: return
+        if (!row.isLoading) return
+        catalogsMap[key] = row.copy(isLoading = false)
+        scheduleCatalogRowsUpdate()
     }
 
     private fun scheduleCatalogRowsUpdate() {

--- a/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelPaginationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/search/SearchViewModelPaginationTest.kt
@@ -1,0 +1,232 @@
+package com.nuvio.tv.ui.screens.search
+
+import android.content.Context
+import com.nuvio.tv.core.network.NetworkResult
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.SearchHistoryDataStore
+import com.nuvio.tv.data.local.WatchedSeriesStateHolder
+import com.nuvio.tv.domain.model.Addon
+import com.nuvio.tv.domain.model.CatalogDescriptor
+import com.nuvio.tv.domain.model.CatalogExtra
+import com.nuvio.tv.domain.model.CatalogRow
+import com.nuvio.tv.domain.model.ContentType
+import com.nuvio.tv.domain.model.MetaPreview
+import com.nuvio.tv.domain.model.PosterShape
+import com.nuvio.tv.domain.repository.AddonRepository
+import com.nuvio.tv.domain.repository.CatalogRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import com.nuvio.tv.ui.components.posteroptions.PosterOptionsController
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private const val CATALOG_ID = "top"
+private const val ADDON_ID = "addon"
+
+/**
+ * A page belongs to the search run that requested it. These cover both ways that used to break:
+ * paging read the live text field rather than the submitted query, and a late page merged into
+ * whatever rows were current when it landed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelPaginationTest {
+
+    private val mainDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `paging asks for the submitted query, not what is currently typed`() = runTest {
+        val repository = RecordingCatalogRepository()
+        val viewModel = newViewModel(repository)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+        assertEquals("wolf", viewModel.uiState.value.submittedQuery)
+
+        // Typed after the run started and never submitted. Paging must ignore it.
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf of wall street"))
+        repository.queries.clear()
+
+        viewModel.onEvent(SearchEvent.LoadMoreCatalog(CATALOG_ID, ADDON_ID, "movie"))
+        advanceUntilIdle()
+
+        assertTrue(
+            "paging made no request",
+            repository.queries.isNotEmpty()
+        )
+        assertTrue(
+            "paged the live field instead of the submitted query: ${repository.queries}",
+            repository.queries.all { it == "wolf" }
+        )
+    }
+
+    @Test
+    fun `a page that arrives after a new search does not merge into the new rows`() = runTest {
+        val repository = RecordingCatalogRepository(pageDelayMs = 500)
+        val viewModel = newViewModel(repository)
+
+        viewModel.onEvent(SearchEvent.QueryChanged("wolf"))
+        advanceUntilIdle()
+
+        viewModel.onEvent(SearchEvent.LoadMoreCatalog(CATALOG_ID, ADDON_ID, "movie"))
+        // Start the paging job and let it suspend inside the fake's delay. Without this the
+        // dispatcher would still have it queued, and the query change below would cancel a request
+        // that never ran, which is not the case being covered.
+        runCurrent()
+
+        // A new search supersedes the run the page belongs to while it is genuinely in flight.
+        viewModel.onEvent(SearchEvent.QueryChanged("alpha"))
+        advanceUntilIdle()
+
+        assertEquals("alpha", viewModel.uiState.value.submittedQuery)
+        val titles = viewModel.uiState.value.catalogRows.flatMap { row -> row.items.map { it.name } }
+        assertFalse(
+            "a page from the previous query merged into the current rows: $titles",
+            titles.any { it.startsWith("wolf page") }
+        )
+    }
+
+    /** Answers every query, recording what it was asked for and paging indefinitely. */
+    private class RecordingCatalogRepository(
+        private val pageDelayMs: Long = 0L
+    ) : CatalogRepository {
+        val queries = mutableListOf<String>()
+
+        override fun getCatalog(
+            addonBaseUrl: String,
+            addonId: String,
+            addonName: String,
+            catalogId: String,
+            catalogName: String,
+            type: String,
+            skip: Int,
+            skipStep: Int,
+            extraArgs: Map<String, String>,
+            supportsSkip: Boolean
+        ): Flow<NetworkResult<CatalogRow>> = flow {
+            val query = extraArgs["search"].orEmpty()
+            emit(NetworkResult.Loading)
+            if (skip > 0) {
+                queries.add(query)
+                if (pageDelayMs > 0) delay(pageDelayMs)
+            }
+            emit(NetworkResult.Success(row(catalogId, query, skip)))
+        }
+
+        private fun row(catalogId: String, query: String, skip: Int): CatalogRow = CatalogRow(
+            addonId = ADDON_ID,
+            addonName = "Addon",
+            addonBaseUrl = "https://example.test",
+            catalogId = catalogId,
+            catalogName = catalogId,
+            type = ContentType.MOVIE,
+            items = listOf(
+                MetaPreview(
+                    id = "${query}_$skip",
+                    type = ContentType.MOVIE,
+                    name = if (skip > 0) "$query page $skip" else query,
+                    poster = null,
+                    posterShape = PosterShape.POSTER,
+                    background = null,
+                    logo = null,
+                    description = null,
+                    releaseInfo = null,
+                    imdbRating = null,
+                    genres = emptyList()
+                )
+            ),
+            hasMore = true,
+            nextSkip = skip + 100,
+            supportsSkip = true
+        )
+    }
+
+    private class SingleAddonRepository(private val addon: Addon) : AddonRepository {
+        override fun getInstalledAddons(): Flow<List<Addon>> = flowOf(listOf(addon))
+        override suspend fun fetchAddon(baseUrl: String): NetworkResult<Addon> = error("unused")
+        override suspend fun addAddon(url: String) = error("unused")
+        override suspend fun removeAddon(url: String) = error("unused")
+        override suspend fun setAddonOrder(urls: List<String>) = error("unused")
+        override suspend fun setAddonEnabled(url: String, enabled: Boolean) = error("unused")
+    }
+
+    private fun newViewModel(repository: CatalogRepository): SearchViewModel {
+        val addon = Addon(
+            id = ADDON_ID,
+            name = "Addon",
+            version = "1",
+            description = null,
+            logo = null,
+            baseUrl = "https://example.test",
+            catalogs = listOf(
+                CatalogDescriptor(
+                    type = ContentType.MOVIE,
+                    id = CATALOG_ID,
+                    name = CATALOG_ID,
+                    extra = listOf(CatalogExtra(name = "search"))
+                )
+            ),
+            types = listOf(ContentType.MOVIE),
+            resources = emptyList()
+        )
+
+        val layoutPreferences = mockk<LayoutPreferenceDataStore>()
+        every { layoutPreferences.discoverLocation } returns flowOf(com.nuvio.tv.domain.model.DiscoverLocation.OFF)
+        every { layoutPreferences.posterCardWidthDp } returns flowOf(126)
+        every { layoutPreferences.posterLabelsEnabled } returns flowOf(true)
+        every { layoutPreferences.catalogAddonNameEnabled } returns flowOf(true)
+        every { layoutPreferences.posterCardHeightDp } returns flowOf(189)
+        every { layoutPreferences.posterCardCornerRadiusDp } returns flowOf(12)
+        every { layoutPreferences.catalogTypeSuffixEnabled } returns flowOf(true)
+        every { layoutPreferences.hideUnreleasedContent } returns flowOf(false)
+
+        val history = mockk<SearchHistoryDataStore>(relaxed = true)
+        every { history.recentSearches } returns flowOf(emptyList())
+
+        val watchProgress = mockk<WatchProgressRepository>()
+        every { watchProgress.observeWatchedMovieIds() } returns flowOf(emptySet())
+
+        val watchedSeries = mockk<WatchedSeriesStateHolder>()
+        every { watchedSeries.fullyWatchedSeriesIds } returns MutableStateFlow(emptySet())
+
+        return SearchViewModel(
+            addonRepository = SingleAddonRepository(addon),
+            catalogRepository = repository,
+            metaRepository = mockk(relaxed = true),
+            discoverSelectionDataStore = mockk(relaxed = true),
+            layoutPreferenceDataStore = layoutPreferences,
+            searchHistoryDataStore = history,
+            watchProgressRepository = watchProgress,
+            watchedSeriesStateHolder = watchedSeries,
+            posterOptions = mockk<PosterOptionsController>(relaxed = true),
+            context = mockk<Context>(relaxed = true)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Paging a search row was not tied to the search run that produced it, so a late page could be merged into results for a newer query.

- Use `submittedQuery` instead of the live text field for paging.
- Capture the search generation and ignore results from superseded runs.
- Cancel paging jobs with the active search run.
- Do not reinsert a row that has since been removed.

This applies the pattern the main search path already uses: `loadCatalog` captures the generation, guards each result with `isCurrentSearch`, and registers its jobs in `activeSearchJobs`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Every query change calls `cancelSearchRun()`, but a paging request is launched separately into `viewModelScope` and is not in the set that cancels. Nothing checked whether the page still belonged to the current search when it completed, so a page that outlived its query was merged into whatever rows were current when it landed.

Paging also read `uiState.value.query`, the live field, while search runs are keyed on `submittedQuery`. Those differ during the 350 ms live-search debounce, so a page started in that window asked the addon for text the user had typed but not yet searched for.

## Issue or approval

Fixes #3413

## Reproduction steps

Easiest with a slow or remote addon, so the paging request is still outstanding when the query changes.

1. Search for something with enough results to fill a row and allow paging, for example `wolf`.
2. Scroll that row to its end so it starts loading another page.
3. Before the page arrives, type another letter, making it `wolfs`.
4. Before this change, results for `wolf` appear among the `wolfs` results. After it, the page is discarded.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to `loadMoreCatalogItems` and the job bookkeeping it needs. `activeLoadMoreJobs` is tracked separately from `activeSearchJobs` because that list is replaced wholesale by each search run; both are cancelled in `cancelSearchRun()`.

Two related fixes are included in the same function. A page whose row has since been removed is now dropped instead of reinserted from the stale pre-request snapshot. The blank-query guard also runs before the loading state is written, so an early return cannot leave the row marked as loading; that path is currently unreachable, because a query below `MIN_SEARCH_QUERY_LENGTH` clears `catalogsMap`.

**Intentionally not changed**

- The main search path, which already had this handling.
- Discover paging, `loadNextDiscoverResults`, which is a separate flow.
- Suggestions, history and the request-key logic.
- Whether paging should be debounced or coalesced, which is a separate question.

## Testing

**Unit tests:** adds `SearchViewModelPaginationTest` with two cases: paging asks for the submitted query rather than the live field, and a page arriving after a new search does not merge into the new rows. The second uses a repository fake that delays the page, and starts the paging job before changing the query so the request is genuinely in flight.

`:app:testFullDebugUnitTest`: 1172 tests, 15 failures. The same 15 fail by name on `dev` at `cf83131c7`, so the change introduces no new test failures.

**Device:** not performed. This is a view-model state change with deterministic unit coverage.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3413