### PR TITLE
Add Custom User-Agent Setting

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -100,10 +100,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(
-        @ApplicationContext context: Context,
-        userAgentProvider: UserAgentProvider
-    ): OkHttpClient {
+    fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient {
         val trustAllManager = object : X509TrustManager {
             override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
             override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
@@ -121,9 +118,8 @@ object NetworkModule {
             .readTimeout(60, TimeUnit.SECONDS)
             .addInterceptor { chain ->
                 val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
-                val defaultUa = "Nuvio/$version"
                 val request = chain.request().newBuilder()
-                    .header("User-Agent", userAgentProvider.currentOrDefault(defaultUa))
+                    .header("User-Agent", "Nuvio/$version")
                     .header("Accept-Language", buildAcceptLanguageHeader())
                     .build()
                 chain.proceed(request)
@@ -146,6 +142,23 @@ object NetworkModule {
             })
             .build()
     }
+
+    @Provides
+    @Singleton
+    @Named("addon")
+    fun provideAddonOkHttpClient(
+        okHttpClient: OkHttpClient,
+        userAgentProvider: UserAgentProvider
+    ): OkHttpClient = okHttpClient.newBuilder()
+        .addInterceptor { chain ->
+            val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
+            val defaultUa = "Nuvio/$version"
+            val request = chain.request().newBuilder()
+                .header("User-Agent", userAgentProvider.currentOrDefault(defaultUa))
+                .build()
+            chain.proceed(request)
+        }
+        .build()
 
     @Provides
     @Singleton
@@ -291,6 +304,19 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    @Named("addon")
+    fun provideAddonRetrofit(
+        @Named("addon") okHttpClient: OkHttpClient,
+        moshi: Moshi
+    ): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://placeholder.nuvio.tv/")
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+
+    @Provides
+    @Singleton
     @Named("tmdb")
     fun provideTmdbRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit =
         Retrofit.Builder()
@@ -314,7 +340,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideAddonApi(retrofit: Retrofit): AddonApi =
+    fun provideAddonApi(@Named("addon") retrofit: Retrofit): AddonApi =
         retrofit.create(AddonApi::class.java)
 
     @Provides

--- a/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/NetworkModule.kt
@@ -42,6 +42,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import com.nuvio.tv.core.network.IPv4FirstDns
+import com.nuvio.tv.core.network.UserAgentProvider
 import com.nuvio.tv.core.diagnostics.SentryNetworkBreadcrumbInterceptor
 import java.io.File
 import java.security.SecureRandom
@@ -99,7 +100,10 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient {
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context,
+        userAgentProvider: UserAgentProvider
+    ): OkHttpClient {
         val trustAllManager = object : X509TrustManager {
             override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
             override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
@@ -117,8 +121,9 @@ object NetworkModule {
             .readTimeout(60, TimeUnit.SECONDS)
             .addInterceptor { chain ->
                 val version = BuildConfig.VERSION_NAME.ifBlank { "dev" }
+                val defaultUa = "Nuvio/$version"
                 val request = chain.request().newBuilder()
-                    .header("User-Agent", "Nuvio/$version")
+                    .header("User-Agent", userAgentProvider.currentOrDefault(defaultUa))
                     .header("Accept-Language", buildAcceptLanguageHeader())
                     .build()
                 chain.proceed(request)

--- a/app/src/main/java/com/nuvio/tv/core/network/UserAgentProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/core/network/UserAgentProvider.kt
@@ -1,0 +1,28 @@
+package com.nuvio.tv.core.network
+
+import com.nuvio.tv.data.local.DeviceLocalPlayerPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserAgentProvider @Inject constructor(
+    preferences: DeviceLocalPlayerPreferences
+) {
+    @Volatile
+    private var cached: String = ""
+
+    init {
+        preferences.customUserAgent
+            .onEach { cached = it }
+            .launchIn(CoroutineScope(SupervisorJob() + Dispatchers.Default))
+    }
+
+    fun currentOrDefault(default: String): String =
+        cached.takeIf { it.isNotBlank() } ?: default
+}

--- a/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
@@ -39,6 +39,7 @@ class DeviceLocalPlayerPreferences @Inject constructor(
     private val aspectModeKey = stringPreferencesKey("aspect_mode")
     private val playerStatsHudButtonEnabledKey = booleanPreferencesKey("player_stats_hud_enabled")
     private val playerStatsHudActiveKey = booleanPreferencesKey("player_stats_hud_active")
+    private val customUserAgentKey = stringPreferencesKey("custom_user_agent")
 
     val aspectMode: Flow<AspectMode> = store.data.map { prefs ->
         prefs[aspectModeKey]?.let {
@@ -85,6 +86,20 @@ class DeviceLocalPlayerPreferences @Inject constructor(
     suspend fun setPlayerStatsHudActive(active: Boolean) {
         store.edit { prefs ->
             prefs[playerStatsHudActiveKey] = active
+        }
+    }
+
+    val customUserAgent: Flow<String> = store.data.map { prefs ->
+        prefs[customUserAgentKey] ?: ""
+    }
+
+    suspend fun setCustomUserAgent(value: String) {
+        store.edit { prefs ->
+            if (value.isBlank()) {
+                prefs.remove(customUserAgentKey)
+            } else {
+                prefs[customUserAgentKey] = value
+            }
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/DeviceLocalPlayerPreferences.kt
@@ -94,12 +94,23 @@ class DeviceLocalPlayerPreferences @Inject constructor(
     }
 
     suspend fun setCustomUserAgent(value: String) {
+        val sanitized = sanitizeUserAgent(value)
         store.edit { prefs ->
-            if (value.isBlank()) {
+            if (sanitized.isBlank()) {
                 prefs.remove(customUserAgentKey)
             } else {
-                prefs[customUserAgentKey] = value
+                prefs[customUserAgentKey] = sanitized
             }
         }
+    }
+
+    private fun sanitizeUserAgent(raw: String): String {
+        val stripped = raw.filter { it.code in 0x20..0x7E }
+            .trim()
+        return stripped.take(MAX_USER_AGENT_LENGTH)
+    }
+
+    companion object {
+        private const val MAX_USER_AGENT_LENGTH = 256
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/AdvancedSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/AdvancedSettingsViewModel.kt
@@ -24,7 +24,8 @@ data class AdvancedSettingsUiState(
     val playbackIssueReportsEnabled: Boolean = false,
     val playerStatsHudEnabled: Boolean = false,
     val rgb565Enabled: Boolean = true,
-    val sentryEnabled: Boolean = true
+    val sentryEnabled: Boolean = true,
+    val customUserAgent: String = ""
 )
 
 sealed class AdvancedSettingsEvent {
@@ -35,6 +36,7 @@ sealed class AdvancedSettingsEvent {
     data class SetPlayerStatsHudEnabled(val enabled: Boolean) : AdvancedSettingsEvent()
     data class SetRgb565Enabled(val enabled: Boolean) : AdvancedSettingsEvent()
     data class SetSentryEnabled(val enabled: Boolean) : AdvancedSettingsEvent()
+    data class SetCustomUserAgent(val value: String) : AdvancedSettingsEvent()
 }
 
 @HiltViewModel
@@ -81,6 +83,11 @@ class AdvancedSettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(sentryEnabled = enabled) }
             }
         }
+        viewModelScope.launch {
+            deviceLocalPlayerPreferences.customUserAgent.collectLatest { value ->
+                _uiState.update { it.copy(customUserAgent = value) }
+            }
+        }
     }
 
     fun onEvent(event: AdvancedSettingsEvent) {
@@ -119,6 +126,11 @@ class AdvancedSettingsViewModel @Inject constructor(
             is AdvancedSettingsEvent.SetSentryEnabled -> {
                 viewModelScope.launch {
                     sentrySettingsDataStore.setEnabled(event.enabled)
+                }
+            }
+            is AdvancedSettingsEvent.SetCustomUserAgent -> {
+                viewModelScope.launch {
+                    deviceLocalPlayerPreferences.setCustomUserAgent(event.value)
                 }
             }
         }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/NetworkSettingsScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -67,6 +69,7 @@ import com.nuvio.tv.R
 import com.nuvio.tv.data.local.Dv7HandlingMode
 import com.nuvio.tv.data.local.InternalPlayerEngine
 import com.nuvio.tv.domain.model.ExperienceMode
+import com.nuvio.tv.ui.screens.account.InputField
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -752,6 +755,42 @@ fun AdvancedSettingsContent(
                                 cleared = true
                             }
                         }
+                    }
+                )
+            }
+        }
+
+        item(key = "other_header") {
+            Text(
+                text = stringResource(R.string.advanced_section_other),
+                style = MaterialTheme.typography.titleSmall,
+                color = NuvioTheme.colors.TextTertiary,
+                modifier = Modifier.padding(top = NuvioTheme.spacing.xs)
+            )
+        }
+
+        item(key = "other") {
+            SettingsGroupCard(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = stringResource(R.string.advanced_custom_user_agent),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = NuvioTheme.colors.TextPrimary
+                )
+                Text(
+                    text = stringResource(R.string.advanced_custom_user_agent_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NuvioTheme.colors.TextSecondary
+                )
+                var customUserAgentText by remember(uiState.customUserAgent) {
+                    mutableStateOf(uiState.customUserAgent)
+                }
+                InputField(
+                    value = customUserAgentText,
+                    onValueChange = { newValue -> customUserAgentText = newValue },
+                    placeholder = stringResource(R.string.advanced_custom_user_agent_placeholder),
+                    imeAction = ImeAction.Done,
+                    onImeAction = {
+                        viewModel.onEvent(AdvancedSettingsEvent.SetCustomUserAgent(customUserAgentText))
                     }
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -568,6 +568,7 @@
     <string name="sentry_turn_off">Turn off</string>
     <string name="sentry_turn_on">Turn on</string>
     <string name="advanced_section_cache">Cache</string>
+    <string name="advanced_section_other">Other</string>
     <string name="advanced_section_dv_diagnostics" translatable="false">DV Diagnostics</string>
     <string name="advanced_fast_horizontal_navigation">Fast Horizontal Navigation</string>
     <string name="advanced_fast_horizontal_navigation_subtitle">Increase D-pad repeat speed in rows while keeping repeat throttling enabled.</string>
@@ -589,6 +590,9 @@
     <string name="advanced_clear_cw_cache">Clear Continue Watching Cache</string>
     <string name="advanced_clear_cw_cache_subtitle">Remove cached thumbnails, titles, and enrichment data for Continue Watching</string>
     <string name="advanced_clear_cw_cache_done">Cache cleared</string>
+    <string name="advanced_custom_user_agent">Custom User-Agent</string>
+    <string name="advanced_custom_user_agent_subtitle">Set a custom User-Agent for this device</string>
+    <string name="advanced_custom_user_agent_placeholder">User-Agent</string>
     <string name="advanced_remember_last_profile">Remember Last Profile</string>
     <string name="advanced_remember_last_profile_subtitle">Remember last selected profile at startup</string>
     <string name="advanced_confirm_exit">Full exit on close</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,7 +591,7 @@
     <string name="advanced_clear_cw_cache_subtitle">Remove cached thumbnails, titles, and enrichment data for Continue Watching</string>
     <string name="advanced_clear_cw_cache_done">Cache cleared</string>
     <string name="advanced_custom_user_agent">Custom User-Agent</string>
-    <string name="advanced_custom_user_agent_subtitle">Set a custom User-Agent for this device</string>
+    <string name="advanced_custom_user_agent_subtitle">Set a custom addon User-Agent for this device</string>
     <string name="advanced_custom_user_agent_placeholder">User-Agent</string>
     <string name="advanced_remember_last_profile">Remember Last Profile</string>
     <string name="advanced_remember_last_profile_subtitle">Remember last selected profile at startup</string>


### PR DESCRIPTION
> [!IMPORTANT]
>This PR remains a draft as although complete and tested, it has not been approved. Feature approval requested in #3403.

## Summary
Adds a custom User-Agent override field under Advanced Settings. AIODtreams supports custom variants based on User-Agent, but every device currently sends the same hardcoded User-Agent (`Nuvio/$version`), so a profile is stuck using the same addon variant across all devices even when device capabilities differ (e.g. a non-4K TV vs. a 4K TV). This lets each device assign its own User-Agent so it can be matched to a device-appropriate variant. When the field is left blank, existing default behavior is unchanged.

## PR type
- [ ] Translation/localization only
- [ ] Critical bug fix

This is a small feature addition, not a bug fix or localization change.

## Why
AIOStreams lets a single addon configuration serve different results per client based on User-Agent. Without a way to customize Nuvio's User-Agent per device, a profile can't take advantage of that and all devices on a profile are forced into the same addon variant regardless of capability. 

## Issue or approval
#3403 

## Reproduction steps
Not applicable - this is not a bug fix.

## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [ ] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [ ] This PR is small, focused, and limited to one issue.
- [ ] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [ ] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [ ] I listed the testing performed below.

## Scope boundaries
No changes to the default User-Agent behavior when the field is left blank. No changes to other Advanced Settings rows, other OkHttp client configs beyond adding the override lookup, or UI outside the new input field. Input is sanitized (control characters stripped, length capped) before being persisted or applied.

## Testing
Tested using an instance of AIOStreams. With the custom User-Agent set, it shows up under AIOStreams' "Recently seen clients" section. Configured a variant in AIOStreams to check for this specific User-Agent, and confirmed the custom variant is correctlyselected/used when the override is set.

## Screenshots / Video
None.

## Breaking changes
None.

## Linked issues
#3403 