### PR TITLE
Fix Search: reset scroll on query change, restore focus from poster options

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/CatalogRowSection.kt
@@ -105,6 +105,9 @@ fun CatalogRowSection(
     /** Persisted focus index from parent — used only by focusRestorer to
      *  survive LazyColumn recycling.  Does NOT trigger a focus request. */
     restorerFocusedIndex: Int = -1,
+    /** Clears the remembered focus index when this changes, including when the new content has
+     *  the same items. */
+    focusResetToken: String? = null,
     onItemFocused: (itemIndex: Int) -> Unit = {},
     rowFocusRequester: FocusRequester? = null,
     /** FocusRequester that will be attached to the first-or-last-focused card.
@@ -153,6 +156,12 @@ fun CatalogRowSection(
     // Item keys as they were when lastFocusedItemIndex was recorded, so the index can be
     // relocated when the row changes instead of pointing at whatever took that slot.
     val previousRowItemKeys = remember { mutableStateOf<List<String>>(emptyList()) }
+    // Update during composition so focusRestorer sees the reset immediately.
+    val lastFocusResetToken = remember { mutableStateOf(focusResetToken) }
+    if (lastFocusResetToken.value != focusResetToken) {
+        lastFocusResetToken.value = focusResetToken
+        lastFocusedItemIndex.intValue = -1
+    }
     // Runs during composition, not in an effect: focusRestorer below is driven by the user and
     // can fire before an effect would have relocated the index, which would restore focus onto
     // whatever took that slot.

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -304,6 +304,16 @@ fun SearchScreen(
     val searchRowEntryFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val searchRowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
     var lastFocusedRowKey by remember { mutableStateOf(viewModel.savedFocusRowKey) }
+    var posterOptionsRowKey by remember { mutableStateOf<String?>(null) }
+
+    val saveSearchFocusForDetail: (String) -> Unit = { rowKey ->
+        viewModel.savedFocusRowKey = rowKey
+        viewModel.savedFocusItemIndex = searchRowFocusedItemIndex[rowKey] ?: 0
+        viewModel.savedRowScrollPositions = searchRowStates.mapValues {
+            it.value.firstVisibleItemIndex to it.value.firstVisibleItemScrollOffset
+        }
+        viewModel.hasSavedSearchFocus = true
+    }
 
     // Clean up stale keys when the catalog rows change.
     val visibleRowKeys = remember(uiState.catalogRows) {
@@ -510,6 +520,21 @@ fun SearchScreen(
         contentAlignment = Alignment.TopCenter
     ) {
         val listState = rememberLazyListState()
+
+        // Skip the initial composition; there is nothing stale to reset yet.
+        var lastScrollResetQuery by remember { mutableStateOf(uiState.query) }
+        LaunchedEffect(uiState.query) {
+            if (uiState.query == lastScrollResetQuery) return@LaunchedEffect
+            lastScrollResetQuery = uiState.query
+            // Clear stale focus so the restorer cannot return to an item from the previous query.
+            searchRowFocusedItemIndex.clear()
+            // Clear saved offsets too; rebuilt rows can otherwise inherit the old query's position.
+            viewModel.savedRowScrollPositions = emptyMap()
+            listState.scrollToItem(0)
+            // Snapshot the states because scrollToItem suspends.
+            searchRowStates.values.toList().forEach { it.scrollToItem(0) }
+        }
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -718,6 +743,7 @@ fun SearchScreen(
                                 } else {
                                     searchRowFocusedItemIndex[catalogKey] ?: -1
                                 },
+                                focusResetToken = uiState.query,
                                 isItemWatched = { item ->
                                     val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)
                                     if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds
@@ -749,13 +775,7 @@ fun SearchScreen(
                                 },
                                 onItemClick = { id, type, addonBaseUrl ->
                                     lastFocusedRowKey = catalogKey
-                                    // Save focus state to ViewModel before navigating
-                                    viewModel.savedFocusRowKey = catalogKey
-                                    viewModel.savedFocusItemIndex = searchRowFocusedItemIndex[catalogKey] ?: 0
-                                    viewModel.savedRowScrollPositions = searchRowStates.mapValues {
-                                        it.value.firstVisibleItemIndex to it.value.firstVisibleItemScrollOffset
-                                    }
-                                    viewModel.hasSavedSearchFocus = true
+                                    saveSearchFocusForDetail(catalogKey)
                                     val clickedItem = catalogRow.items.firstOrNull { it.id == id }
                                     val backdrop = viewModel.getCachedBackdrop(id, type)
                                         ?: clickedItem?.backdropUrl
@@ -763,6 +783,7 @@ fun SearchScreen(
                                     onNavigateToDetail(id, type, addonBaseUrl)
                                 },
                                 onItemLongPress = { item, addonBaseUrl ->
+                                    posterOptionsRowKey = catalogKey
                                     viewModel.posterOptions.show(item, addonBaseUrl)
                                 },
                                 onSeeAll = {
@@ -824,6 +845,9 @@ fun SearchScreen(
         state = posterOptionsState,
         controller = viewModel.posterOptions,
         onNavigateToDetail = { id, type, addonBaseUrl ->
+            // Consume it, so a later navigation cannot reuse this row.
+            posterOptionsRowKey?.let(saveSearchFocusForDetail)
+            posterOptionsRowKey = null
             val clickedItem = uiState.catalogRows
                 .flatMap { it.items }
                 .firstOrNull { it.id == id }


### PR DESCRIPTION
## Summary

Search could retain scroll position across query changes, and detail navigation from poster options did not preserve the originating result focus.

- Reset scroll and remembered row focus when the query changes.
- Save the originating row when poster options opens detail navigation.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Fixes #3384. Selecting a recent search can open the results part-way down instead of at the top, because the search list state is retained across queries.

The same state retention affects horizontal scrolling within result rows.

Clearing the parent index is not sufficient on its own. `CatalogRowSection` also remembers its own focus index and keeps it while the focused item remains in the row. If a new query returns the same items, that index can restore the old item and scroll the row back to it. Search now passes the query as a reset token to clear that state.

## Issue or approval

Fixes #3384

## Reproduction steps

Vertical, per #3384:

1. Build up three or more recent searches so the list scrolls.
2. Open Search and select the last one.
3. Before this change, the results can open part-way down. After it, they open at the top.

Horizontal:

1. Search for something with enough results to scroll a row sideways.
2. Scroll a row to the right, then search for something else.
3. Before this change, the new results can retain the old horizontal offset. After it, the row starts at the beginning.

Focus on return:

1. Search, focus a result, long press it and open its detail page from the sheet.
2. Press back.
3. Before this change, focus lands on the search bar. After it, focus returns to the opened item.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

A query change is the only scroll and focus reset trigger, so returning from details with an unchanged query preserves the existing restore behavior.

Keyed on `query` rather than `submittedQuery` so scrolling is reset as the search text changes, rather than waiting for the live-search debounce.

Intentionally not changed:

- Discover mode, which has separate scroll handling.
- Existing return-from-details behavior, apart from poster options now saving focus like a card click.

## Testing

**Build:** Passed.

**Unit tests:** None added. The affected behavior is Compose scroll and focus state rather than ViewModel state.

**Device:** Android TV.

| Check | Result |
| --- | --- |
| Recent search from a scrolled list opens at the top | Pass |
| Typing resets a sideways-scrolled row | Pass |
| A row returning the same results for the new query also resets | Pass |
| Focus entering a row after a reset does not restore the previously focused item | Pass |
| Return from details still restores focus and offset | Pass |
| Detail from poster options, back restores the opened item | Pass |
| Poster options on row A, dismiss, then row B, detail, back restores row B | Pass |
| Detail from a Discover poster, back does not jump into a result row | Pass |
| Home and collection folder rows keep their focus position in classic layout | Pass |
| Discover mode unaffected | Pass |

Not tested: rapid typing. Remote input is too slow to make this practical.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3384