### PR TITLE
feat(mdblist): add tracking and library support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ android {
 
     defaultConfig {
         applicationId = "com.nuvio.tv"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         minSdk = 24
         targetSdk = 36
         versionCode = 1055

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,7 @@ android {
         buildConfigField("String", "TRAKT_REDIRECT_URI", "\"${localProperties.getProperty("TRAKT_REDIRECT_URI", "urn:ietf:wg:oauth:2.0:oob")}\"")
         buildConfigField("String", "SIMKL_CLIENT_ID", buildConfigString(resolveProperty(devProperties, localProperties, "SIMKL_CLIENT_ID")))
         buildConfigField("String", "SIMKL_APP_NAME", buildConfigString(resolveProperty(devProperties, localProperties, "SIMKL_APP_NAME", "nuvio")))
+        buildConfigField("String", "MDBLIST_CLIENT_ID", buildConfigString(resolveProperty(devProperties, localProperties, "MDBLIST_CLIENT_ID", "kMMZyv8qithmUSF5102U6HTAPEDqfHtNbn1W4gkz")))
         buildConfigField("String", "TMDB_API_KEY", "\"${localProperties.getProperty("TMDB_API_KEY", "")}\"")
         buildConfigField("String", "TV_LOGIN_WEB_BASE_URL", "\"${localProperties.getProperty("TV_LOGIN_WEB_BASE_URL", "https://nuvio.tv/tv-login")}\"")
         buildConfigField("String", "DEVICE_LOGIN_WEB_BASE_URL", "\"${localProperties.getProperty("DEVICE_LOGIN_WEB_BASE_URL", "https://nuvio.tv/link")}\"")
@@ -548,6 +549,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/nuvio/tv/core/profile/ProtectedProfilePreferencesTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/core/profile/ProtectedProfilePreferencesTest.kt
@@ -1,0 +1,57 @@
+package com.nuvio.tv.core.profile
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.security.KeyStore
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProtectedProfilePreferencesTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val name = "protected_profile_instrumentation"
+    private val alias = "protected_profile_instrumentation.v1"
+    private val preferences = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+
+    @After
+    fun clearTestCredentials() {
+        preferences.edit().clear().commit()
+        KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.deleteEntry(alias)
+    }
+
+    @Test
+    fun encryptedCredentialsSurviveRecreationAndUseUniqueNonces() {
+        val store = ProtectedProfilePreferences(context, name, alias)
+        store.write(1, "private-token-one")
+        store.write(2, "private-token-two")
+        val firstCiphertext = preferences.getString("profile.1", null)
+        assertFalse(firstCiphertext.orEmpty().contains("private-token"))
+        store.write(1, "private-token-one")
+        assertNotEquals(firstCiphertext, preferences.getString("profile.1", null))
+        val restored = ProtectedProfilePreferences(context, name, alias)
+        assertEquals("private-token-one", restored.read(1))
+        assertEquals("private-token-two", restored.read(2))
+        restored.write(1, null)
+        assertNull(restored.read(1))
+        assertEquals("private-token-two", restored.read(2))
+    }
+
+    @Test
+    fun copiedOrCorruptedCredentialsAreRejectedWithoutAffectingOtherProfiles() {
+        val store = ProtectedProfilePreferences(context, name, alias)
+        store.write(1, "profile-one-token")
+        preferences.edit().putString("profile.2", preferences.getString("profile.1", null)).commit()
+        assertNull(store.read(2))
+        assertFalse(preferences.contains("profile.2"))
+        assertEquals("profile-one-token", store.read(1))
+        preferences.edit().putString("profile.2", "invalid-ciphertext").commit()
+        assertNull(store.read(2))
+        assertEquals("profile-one-token", store.read(1))
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveAccountTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveAccountTest.kt
@@ -1,0 +1,105 @@
+package com.nuvio.tv.data.mdblist
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nuvio.tv.BuildConfig
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MdbListLiveAccountTest {
+    @Test
+    fun approvedDeviceSessionRefreshAndReadSync() = runBlocking {
+        assumeTrue(InstrumentationRegistry.getArguments().getString("mdblistLiveRead") == "true")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val store = MdbListAuthStore(AndroidMdbListAuthPersistence(context))
+        val configuration = MdbListConfiguration(BuildConfig.MDBLIST_CLIENT_ID, BuildConfig.VERSION_NAME)
+        val engine = OkHttpMdbListEngine(
+            OkHttpClient.Builder().connectTimeout(15, TimeUnit.SECONDS).readTimeout(30, TimeUnit.SECONDS)
+                .callTimeout(45, TimeUnit.SECONDS).build(), configuration
+        )
+        val responses = mutableListOf<JsonObject>()
+        val report = File(context.getExternalFilesDir(null), "mdblist-live-read-report.json")
+        val http = MdbListHttpClient(MdbListHttpEngine { request ->
+            engine.execute(request).also { response ->
+                if (request.method == MdbListHttpMethod.GET) {
+                    responses += buildJsonObject {
+                        put("path", request.path)
+                        put("status", response.status)
+                        put("shape", shape(Json.parseToJsonElement(response.body)))
+                        if (request.path == "/sync/last_activities") {
+                            put("serverTime", Json.parseToJsonElement(response.body).jsonObject["server_time"] ?: JsonNull)
+                        }
+                    }
+                    report.writeText(JsonArray(responses).toString())
+                }
+            }
+        })
+        val auth = MdbListAuthRepository(http, configuration, store)
+        if (!store.state.value.isAuthenticated) {
+            val deviceFile = File(context.getExternalFilesDir(null), "mdblist-live-device.json")
+            val device = Json.parseToJsonElement(deviceFile.readText()).jsonObject
+            val scope = store.scope()
+            val now = System.currentTimeMillis()
+            store.saveSession(
+                MdbListDeviceSession(
+                    device.getValue("user_code").jsonPrimitive.content,
+                    device.getValue("verification_uri").jsonPrimitive.content,
+                    device.getValue("verification_uri_complete").jsonPrimitive.content,
+                    now + device.getValue("expires_in").jsonPrimitive.long * 1_000,
+                    device.getValue("interval").jsonPrimitive.long.toInt(), 0
+                ),
+                device.getValue("device_code").jsonPrimitive.content, scope
+            )
+            assertTrue(auth.pollDeviceAuthorization() == MdbListDevicePollResult.Authorized)
+            deviceFile.delete()
+        }
+        val scope = store.scope()
+        val current = store.authorization()!!
+        val refreshed = auth.authorization(scope, rejectedAccessToken = current.tokens.accessToken)
+        assertTrue(refreshed.tokens.expiresAtEpochMs > System.currentTimeMillis())
+        val api = MdbListApiClient(http, auth, store)
+        val user = api.refreshUser(scope)
+        val remote = MdbListHttpSyncRemote(api, scope)
+        val snapshot = MdbListSyncEngine(remote).synchronize(MdbListSyncSnapshot(user.id!!))
+        assertTrue(snapshot.isInitialized)
+        val projection = MdbListProgressProjection(snapshot)
+        val journal = snapshot.watermark?.let { remote.journal(it) }
+        report.writeText(buildJsonObject {
+            put("authorized", store.state.value.isAuthenticated)
+            put("refreshed", true)
+            put("watched", snapshot.watched.size)
+            put("paused", snapshot.playback.size)
+            put("dropped", snapshot.dropped.size)
+            put("continueWatching", projection.progress.size)
+            put("nextUpSeeds", projection.nextUp(true).size)
+            put("journalItems", journal?.items?.size ?: 0)
+            put("responses", JsonArray(responses))
+        }.toString())
+    }
+
+    private fun shape(element: JsonElement): JsonElement = when (element) {
+        JsonNull -> JsonPrimitive("null")
+        is JsonObject -> JsonObject(element.mapValues { shape(it.value) })
+        is JsonArray -> JsonArray(element.take(3).map(::shape))
+        is JsonPrimitive -> JsonPrimitive(if (element.isString) "string" else if (element.contentOrNull in setOf("true", "false")) "boolean" else "number")
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveLibraryTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveLibraryTest.kt
@@ -1,0 +1,137 @@
+package com.nuvio.tv.data.mdblist
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nuvio.tv.BuildConfig
+import java.io.File
+import java.util.concurrent.TimeUnit
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.ListMembershipChanges
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MdbListLiveLibraryTest {
+    @Test
+    fun privateStaticListLifecycle() = runBlocking<Unit> {
+        val arguments = InstrumentationRegistry.getArguments()
+        assumeTrue(arguments.getString("mdblistLiveLibrary") == "true")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val store = MdbListAuthStore(AndroidMdbListAuthPersistence(context))
+        store.selectProfile(arguments.getString("mdblistProfileId")?.toInt() ?: 1)
+        assertTrue(store.state.value.isAuthenticated)
+        val configuration = MdbListConfiguration(BuildConfig.MDBLIST_CLIENT_ID, BuildConfig.VERSION_NAME)
+        val client = OkHttpClient.Builder().connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS).callTimeout(45, TimeUnit.SECONDS).build()
+        val engine = OkHttpMdbListEngine(client, configuration)
+        val name = "Library QA ${System.currentTimeMillis()}"
+        var temporaryListId: Long? = null
+        val records = mutableListOf<JsonObject>()
+        val report = File(context.getExternalFilesDir(null), "mdblist-live-library-report.json")
+        val http = MdbListHttpClient(MdbListHttpEngine { request ->
+            engine.execute(request).also { response ->
+                val body = runCatching { Json.parseToJsonElement(response.body) }.getOrNull()
+                if (request.path == "/lists/user/add" && response.status in 200..299) {
+                    temporaryListId = (body as? JsonObject)?.number("id")
+                }
+                if (request.path == "/lists/user/add" || request.path == "/lists/user" ||
+                    temporaryListId?.let { request.path == "/lists/$it" || request.path.startsWith("/lists/$it/items") } == true) {
+                    records += buildJsonObject {
+                        put("method", request.method.name)
+                        put("path", request.path)
+                        put("status", response.status)
+                        if (body != null) put("body", if (request.path == "/lists/user" && body is JsonArray) {
+                            JsonArray(body.filter { it.objectValue().text("name")?.startsWith(name) == true })
+                        } else body)
+                    }
+                    report.writeText(JsonArray(records).toString())
+                }
+            }
+        })
+        val auth = MdbListAuthRepository(http, configuration, store)
+        val api = MdbListApiClient(http, auth, store)
+        val jobScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val storage = object : MdbListSyncStorage {
+            var saved: String? = null
+            override suspend fun load(profileId: Int): String? = saved
+            override suspend fun save(profileId: Int, payload: String, checkScope: () -> Unit) { checkScope(); saved = payload }
+            override suspend fun remove(profileId: Int, checkScope: () -> Unit) { checkScope(); saved = null }
+        }
+        val profile = MutableStateFlow(store.scope().profileId)
+        val sync = MdbListSyncRepository(storage, store, api, profile, jobScope)
+        val library = MdbListLibraryService(api, sync, store, profile, jobScope)
+        val movie = LibraryEntryInput("tmdb:278", "movie", "The Shawshank Redemption", tmdbId = 278)
+        val show = LibraryEntryInput("tmdb:1396", "series", "Breaking Bad", tmdbId = 1396)
+        var watchlistAdded = false
+        var deleted = false
+        try {
+            library.refresh(TrackingRefreshIntent.USER_INITIATED)
+            library.listManager.createList(name, null, LibraryListPrivacy.PRIVATE)
+            val created = sync.currentSnapshot()!!.library!!.lists.single { it.name == name }
+            assertEquals(temporaryListId, created.id)
+            assertTrue(created.private)
+            val add = ListMembershipChanges(mapOf(created.key to true))
+            library.applyMembershipChanges(movie, add)
+            library.applyMembershipChanges(show, add)
+            library.refresh(TrackingRefreshIntent.USER_INITIATED)
+            val contents = sync.currentSnapshot()!!.library!!.itemsByList.getValue(created.key)
+            assertEquals(setOf(MdbListItemType.MOVIE, MdbListItemType.SHOW), contents.map { it.type }.toSet())
+            assertEquals(setOf(278L, 1396L), contents.map { it.media.ids.tmdb }.toSet())
+            assertTrue(contents.all { !it.media.poster.isNullOrBlank() })
+            assertTrue(library.getMembershipSnapshot(movie).listMembership.getValue(created.key))
+            assertTrue(library.getMembershipSnapshot(show).listMembership.getValue(created.key))
+            library.listManager.updateList(created.key, "$name renamed", null, LibraryListPrivacy.PRIVATE)
+            library.refresh(TrackingRefreshIntent.USER_INITIATED)
+            assertEquals("$name renamed", sync.currentSnapshot()!!.library!!.lists.single { it.id == created.id }.name)
+            val remove = ListMembershipChanges(mapOf(created.key to false))
+            library.applyMembershipChanges(movie, remove)
+            library.applyMembershipChanges(show, remove)
+            library.refresh(TrackingRefreshIntent.USER_INITIATED)
+            assertTrue(sync.currentSnapshot()!!.library!!.itemsByList.getValue(created.key).isEmpty())
+            if (arguments.getString("mdblistLiveWatchlist") == "true" &&
+                !library.getMembershipSnapshot(movie).listMembership.getValue(MDBLIST_WATCHLIST_KEY)) {
+                watchlistAdded = true
+                library.applyMembershipChanges(movie, ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to true)))
+                library.refresh(TrackingRefreshIntent.USER_INITIATED)
+                assertTrue(library.getMembershipSnapshot(movie).listMembership.getValue(MDBLIST_WATCHLIST_KEY))
+                library.applyMembershipChanges(movie, ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to false)))
+                library.refresh(TrackingRefreshIntent.USER_INITIATED)
+                assertFalse(library.getMembershipSnapshot(movie).listMembership.getValue(MDBLIST_WATCHLIST_KEY))
+                watchlistAdded = false
+            }
+            library.listManager.deleteList(created.key)
+            deleted = true
+            library.refresh(TrackingRefreshIntent.USER_INITIATED)
+            assertTrue(sync.currentSnapshot()!!.library!!.lists.none { it.id == created.id })
+            assertFalse(sync.currentSnapshot()!!.library!!.itemsByList.containsKey(created.key))
+        } finally {
+            try {
+                if (watchlistAdded) api.post("/watchlist/items/remove", movie.mdbListLibraryItem().membershipBody(true))
+            } finally {
+                try {
+                    if (!deleted) temporaryListId?.let { api.delete("/lists/$it") }
+                } finally {
+                    jobScope.cancel()
+                }
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveScrobbleTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListLiveScrobbleTest.kt
@@ -1,0 +1,85 @@
+package com.nuvio.tv.data.mdblist
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.core.tracking.TrackingScrobbleAction
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MdbListLiveScrobbleTest {
+    @Test
+    fun existingEpisodeProgressSurvivesPauseResumeAndStop() = runBlocking {
+        val arguments = InstrumentationRegistry.getArguments()
+        assumeTrue(arguments.getString("mdblistLiveScrobble") == "true")
+        val imdb = requireNotNull(arguments.getString("mdblistShowImdb"))
+        require(imdb.matches(Regex("tt[0-9]+")))
+        val season = requireNotNull(arguments.getString("mdblistSeason")).toInt()
+        val episode = requireNotNull(arguments.getString("mdblistEpisode")).toInt()
+        val progress = requireNotNull(arguments.getString("mdblistProgress")).toDouble()
+        require(season >= 0 && episode > 0 && progress.isFinite() && progress in 0.0..<80.0)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val store = MdbListAuthStore(AndroidMdbListAuthPersistence(context))
+        store.selectProfile(arguments.getString("mdblistProfileId")?.toInt() ?: 1)
+        assertTrue(store.state.value.isAuthenticated)
+        val configuration = MdbListConfiguration(BuildConfig.MDBLIST_CLIENT_ID, BuildConfig.VERSION_NAME)
+        val client = OkHttpClient.Builder().connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS).callTimeout(45, TimeUnit.SECONDS).build()
+        val engine = OkHttpMdbListEngine(client, configuration)
+        val responses = mutableListOf<JsonObject>()
+        val report = File(context.getExternalFilesDir(null), "mdblist-live-scrobble-report.json")
+        val http = MdbListHttpClient(MdbListHttpEngine { request ->
+            engine.execute(request).also { response ->
+                if (request.path.startsWith("/scrobble/")) {
+                    val body = runCatching { Json.parseToJsonElement(response.body).jsonObject }.getOrNull()
+                    responses += buildJsonObject {
+                        put("path", request.path)
+                        put("status", response.status)
+                        put("sentProgress", Json.parseToJsonElement(request.body).jsonObject["progress"] ?: JsonNull)
+                        for (key in listOf("action", "progress", "error", "detail", "message", "errors")) {
+                            body?.get(key)?.let { put(key, it) }
+                        }
+                    }
+                    report.writeText(JsonArray(responses).toString())
+                }
+            }
+        })
+        val auth = MdbListAuthRepository(http, configuration, store)
+        val api = MdbListApiClient(http, auth, store)
+        val target = MdbListMutationTarget(
+            MdbListItemType.EPISODE, MdbListMedia(MdbListIds(imdb = imdb)), season, episode
+        )
+        var savedProgress = 0f
+        for (action in listOf(TrackingScrobbleAction.START, TrackingScrobbleAction.PAUSE,
+            TrackingScrobbleAction.START, TrackingScrobbleAction.STOP)) {
+            val response = api.post("/scrobble/${action.wireValue}", target.scrobbleBody(progress).toString(), store.scope())
+            val receipt = decodeMdbListScrobbleReceipt(response, target, action, System.currentTimeMillis())
+            assertTrue(!receipt.isWatched && receipt.progress < 80f)
+            savedProgress = receipt.progress
+        }
+        val paused = MdbListHttpSyncRemote(api, store.scope()).playback().singleOrNull(target::matches)
+        responses += buildJsonObject {
+            put("path", "/sync/playback")
+            put("matchedSession", paused != null)
+            paused?.let { put("progress", it.progress) }
+        }
+        report.writeText(JsonArray(responses).toString())
+        assertTrue(paused != null)
+        assertEquals(savedProgress, paused!!.progress, 0.001f)
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListTimestampTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/data/mdblist/MdbListTimestampTest.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.data.mdblist
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MdbListTimestampTest {
+    @Test
+    fun fractionalActivityTimestampsDecodeOnAndroid() {
+        val value = "2026-09-06T14:12:26.090Z"
+        assertEquals(1788703946090L, Instant.parse(value).toEpochMilli())
+        assertEquals(1788703946090L, mdbListTimestamp(value))
+        assertEquals(value, decodeMdbListActivities("""{"server_time":"$value","watched_at":null}""").serverTime)
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/library/LibraryListDialogsTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/library/LibraryListDialogsTest.kt
@@ -1,0 +1,125 @@
+package com.nuvio.tv.ui.screens.library
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nuvio.tv.R
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.ui.theme.NuvioTheme
+import com.nuvio.tv.ui.components.posteroptions.PosterListPickerDialog
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryListDialogsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val mdblist = TrackingListManagementCapabilities(listOf(LibraryListPrivacy.PRIVATE, LibraryListPrivacy.PUBLIC))
+
+    @Test
+    fun remoteSelectionDistinguishesTraktAndMdbListWatchlists() {
+        var selected: String? = null
+        val tabs = listOf(
+            LibraryListTab("watchlist", "Watchlist", LibraryListTab.Type.WATCHLIST, trackingProviderId = "trakt"),
+            LibraryListTab("mdblist:watchlist", "Watchlist", LibraryListTab.Type.WATCHLIST, trackingProviderId = "mdblist")
+        )
+        composeRule.setContent {
+            NuvioTheme {
+                PosterListPickerDialog("Lists", tabs, emptyMap(), false, null, { selected = it }, {}, {})
+            }
+        }
+        val watchlist = context.getString(R.string.library_watchlist)
+        composeRule.onNodeWithText("${context.getString(R.string.trakt_name)} · $watchlist")
+            .performSemanticsAction(SemanticsActions.RequestFocus) { it() }
+            .assertIsFocused().performKeyInput { pressKey(Key.DirectionDown) }
+        composeRule.onNodeWithText("${context.getString(R.string.mdblist_name)} · $watchlist")
+            .assertIsFocused().performKeyInput { pressKey(Key.DirectionCenter) }
+        composeRule.runOnIdle { assertEquals("mdblist:watchlist", selected) }
+    }
+
+    @Test
+    fun mdbListEditorOnlyOffersSupportedPrivacyAndFields() {
+        composeRule.setContent {
+            NuvioTheme {
+                ListEditorDialog(LibraryListEditorState(LibraryListEditorState.Mode.CREATE), mdblist, false, {}, {}, {}, {}, {})
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.library_list_name_label)).assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.library_list_description_label)).assertDoesNotExist()
+        composeRule.onNodeWithText("Private").assertIsDisplayed()
+        composeRule.onNodeWithText("Public").assertIsDisplayed()
+        composeRule.onNodeWithText("Friends").assertDoesNotExist()
+        composeRule.onNodeWithText("Link").assertDoesNotExist()
+    }
+
+    @Test
+    fun traktEditorRetainsDescriptionAndAllPrivacyChoices() {
+        composeRule.setContent {
+            NuvioTheme {
+                ListEditorDialog(LibraryListEditorState(LibraryListEditorState.Mode.EDIT),
+                    TrackingListManagementCapabilities(LibraryListPrivacy.entries, true, true), false, {}, {}, {}, {}, {})
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.library_list_description_label)).assertIsDisplayed()
+        composeRule.onNodeWithText("Friends").assertIsDisplayed()
+        composeRule.onNodeWithText("Link").assertIsDisplayed()
+    }
+
+    @Test
+    fun mdbListManagementHidesReorderingAndAcceptsRemoteSelection() {
+        var selected: String? = null
+        composeRule.setContent {
+            NuvioTheme {
+                ManageListsDialog(
+                    tabs = listOf(LibraryListTab("mdblist:list:7", "Private favourites", LibraryListTab.Type.PERSONAL)),
+                    capabilities = mdblist, selectedKey = "mdblist:list:7", errorMessage = null, pending = false,
+                    onSelect = { selected = it }, onCreate = {}, onEdit = {}, onMoveUp = {}, onMoveDown = {}, onDelete = {}, onDismiss = {}
+                )
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.library_manage_lists)).assertIsDisplayed()
+        composeRule.onNodeWithText(context.getString(R.string.library_list_move_up)).assertDoesNotExist()
+        composeRule.onNodeWithText(context.getString(R.string.library_list_move_down)).assertDoesNotExist()
+        composeRule.onNodeWithText("Private favourites").assertIsFocused().performKeyInput { pressKey(Key.DirectionCenter) }
+        composeRule.runOnIdle { assertEquals("mdblist:list:7", selected) }
+    }
+
+    @Test
+    fun pendingListOperationDisablesDuplicateManagementActions() {
+        composeRule.setContent {
+            NuvioTheme {
+                ManageListsDialog(emptyList(), mdblist, null, null, true, {}, {}, {}, {}, {}, {}, {})
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.library_list_create)).assertIsNotEnabled()
+        composeRule.onNodeWithText(context.getString(R.string.library_list_edit)).assertIsNotEnabled()
+        composeRule.onNodeWithText(context.getString(R.string.library_list_delete)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun emptyLibraryAllowsCreatingTheFirstListWithTheRemote() {
+        var created = 0
+        composeRule.setContent {
+            NuvioTheme {
+                ManageListsDialog(emptyList(), mdblist, null, null, false, {}, { created++ }, {}, {}, {}, {}, {})
+            }
+        }
+        composeRule.onNodeWithText(context.getString(R.string.library_list_create))
+            .assertIsFocused().performKeyInput { pressKey(Key.DirectionCenter) }
+        composeRule.runOnIdle { assertEquals(1, created) }
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/MdbListAccountDialogTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/MdbListAccountDialogTest.kt
@@ -1,0 +1,105 @@
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.pressKey
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nuvio.tv.R
+import com.nuvio.tv.data.mdblist.MdbListDeviceSession
+import com.nuvio.tv.ui.theme.NuvioTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MdbListAccountDialogTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun deviceAuthorizationShowsCodeVerificationAddressQrAndCancel() {
+        var canceled = 0
+        setDialog(
+            MdbListTrackerUiState(
+                session = MdbListDeviceSession(
+                    "ABCD-EFGH", "https://mdblist.com/oauth/device/",
+                    "https://mdblist.com/oauth/device/?user_code=ABCD-EFGH",
+                    System.currentTimeMillis() + 300_000, 5, System.currentTimeMillis() + 5_000
+                ),
+                isPolling = true
+            ),
+            onDismiss = { canceled++ }
+        )
+        composeRule.onNodeWithText("ABCD-EFGH").assertIsDisplayed()
+        composeRule.onNodeWithText("https://mdblist.com/oauth/device/").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(context.getString(R.string.mdblist_qr_description)).assertIsDisplayed()
+        pressButton(R.string.action_cancel)
+        composeRule.runOnIdle { assertEquals(1, canceled) }
+    }
+
+    @Test
+    fun failedAuthorizationOffersRetryAndDisplaysItsError() {
+        var retries = 0
+        setDialog(MdbListTrackerUiState(errorMessage = "Connection unavailable"), onStart = { retries++ })
+        composeRule.onNodeWithText("Connection unavailable").assertIsDisplayed()
+        pressButton(R.string.action_retry)
+        composeRule.runOnIdle { assertEquals(1, retries) }
+    }
+
+    @Test
+    fun connectedAccountShowsStatusAndDispatchesSyncAndDisconnect() {
+        var syncs = 0
+        var disconnects = 0
+        setDialog(
+            MdbListTrackerUiState(isConnected = true, username = "mdblist-viewer", statusMessage = "Last synced just now"),
+            onSync = { syncs++ }, onDisconnect = { disconnects++ }
+        )
+        composeRule.onNodeWithText(context.getString(R.string.mdblist_connected_as, "mdblist-viewer")).assertIsDisplayed()
+        composeRule.onNodeWithText("Last synced just now").assertIsDisplayed()
+        pressButton(R.string.simkl_sync_now)
+        pressButton(R.string.trakt_disconnect)
+        composeRule.runOnIdle {
+            assertEquals(1, syncs)
+            assertEquals(1, disconnects)
+        }
+    }
+
+    @Test
+    fun syncingAccountPreventsDuplicateSyncAndDisconnect() {
+        setDialog(MdbListTrackerUiState(isConnected = true, isSyncing = true))
+        composeRule.onNodeWithText(context.getString(R.string.simkl_sync_now)).assertIsNotEnabled()
+        composeRule.onNodeWithText(context.getString(R.string.trakt_disconnect)).assertIsNotEnabled()
+    }
+
+    private fun pressButton(text: Int) {
+        val button = composeRule.onNodeWithText(context.getString(text)).assertIsEnabled()
+        button.performSemanticsAction(SemanticsActions.RequestFocus)
+        button.assertIsFocused().performKeyInput { pressKey(Key.DirectionCenter) }
+    }
+
+    private fun setDialog(
+        state: MdbListTrackerUiState,
+        onStart: () -> Unit = {},
+        onSync: () -> Unit = {},
+        onDisconnect: () -> Unit = {},
+        onDismiss: () -> Unit = {}
+    ) {
+        composeRule.setContent {
+            NuvioTheme {
+                MdbListAccountDialog(state, onStart, onStart, onSync, onDisconnect, onDismiss)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsOverviewTest.kt
+++ b/app/src/androidTest/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsOverviewTest.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.settings
 
 import androidx.compose.runtime.remember
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -12,6 +13,8 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.nuvio.tv.R
@@ -39,9 +42,10 @@ class TrackingSettingsOverviewTest {
 
         composeRule.onNodeWithTag(TrackingSettingsTestTags.TRAKT_PROVIDER).assertIsDisplayed()
         composeRule.onNodeWithTag(TrackingSettingsTestTags.SIMKL_PROVIDER).assertIsDisplayed()
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.MDBLIST_PROVIDER).assertIsDisplayed()
         composeRule.onAllNodesWithText(
             context.getString(R.string.tracking_status_disconnected)
-        ).assertCountEquals(2)
+        ).assertCountEquals(3)
 
         val traktTop = composeRule
             .onNodeWithTag(TrackingSettingsTestTags.TRAKT_PROVIDER)
@@ -54,7 +58,10 @@ class TrackingSettingsOverviewTest {
             .boundsInRoot
             .top
 
+        val mdblistTop = composeRule.onNodeWithTag(TrackingSettingsTestTags.MDBLIST_PROVIDER)
+            .fetchSemanticsNode().boundsInRoot.top
         assertTrue(traktTop < simklTop)
+        assertTrue(simklTop < mdblistTop)
     }
 
     @Test
@@ -89,16 +96,29 @@ class TrackingSettingsOverviewTest {
     }
 
     @Test
-    fun disconnectedTraktDisablesEveryTraktFeature() {
-        setOverview()
-        scrollToTraktFeatures()
+    fun connectedMdbListDisplaysUsernameAndSelectedWatchSource() {
+        setOverview(
+            mdbListState = MdbListTrackerUiState(isConnected = true, username = "mdb-viewer"),
+            trackingState = TrackingSettingsUiState(
+                watchProgressSource = WatchProgressSource.MDBLIST,
+                connectedProviderIds = setOf(TrackingProviderId.MDBLIST), isReady = true
+            )
+        )
+        composeRule.onNodeWithText(context.getString(R.string.mdblist_connected_as, "mdb-viewer")).assertIsDisplayed()
+        composeRule.onAllNodesWithText(context.getString(R.string.tracking_status_connected)).assertCountEquals(1)
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.OVERVIEW_LIST).performScrollToIndex(1)
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.WATCH_PROGRESS_SOURCE).assertIsEnabled()
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.LIBRARY_SOURCE).assertIsEnabled()
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.CONTINUE_WATCHING).assertDoesNotExist()
+    }
 
-        composeRule.onNodeWithTag(TrackingSettingsTestTags.CONTINUE_WATCHING)
-            .assertIsNotEnabled()
-        composeRule.onNodeWithTag(TrackingSettingsTestTags.COMMENTS)
-            .assertIsNotEnabled()
-        composeRule.onNodeWithTag(TrackingSettingsTestTags.MORE_LIKE_THIS)
-            .assertIsNotEnabled()
+    @Test
+    fun disconnectedTraktHidesItsProviderFeatures() {
+        setOverview()
+
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.CONTINUE_WATCHING).assertDoesNotExist()
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.COMMENTS).assertDoesNotExist()
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.MORE_LIKE_THIS).assertDoesNotExist()
     }
 
     @Test
@@ -143,7 +163,7 @@ class TrackingSettingsOverviewTest {
     }
 
     @Test
-    fun initialFocusStartsOnTrakt() {
+    fun remoteFocusMovesFromTraktThroughSimklToMdbList() {
         lateinit var traktFocusRequester: FocusRequester
         composeRule.setContent {
             NuvioTheme {
@@ -151,20 +171,24 @@ class TrackingSettingsOverviewTest {
                 TrackingSettingsOverview(
                     traktState = TraktUiState(),
                     simklState = SimklSettingsUiState(),
+                    mdbListState = MdbListTrackerUiState(),
                     trackingState = TrackingSettingsUiState(isReady = true),
                     traktFocusRequester = traktFocusRequester,
                     simklFocusRequester = remember { FocusRequester() },
+                    mdbListFocusRequester = remember { FocusRequester() },
                     libraryFocusRequester = remember { FocusRequester() },
                     watchProgressFocusRequester = remember { FocusRequester() },
                     continueWatchingFocusRequester = remember { FocusRequester() },
                     moreLikeThisFocusRequester = remember { FocusRequester() },
                     onTraktClick = {},
                     onSimklClick = {},
+                    onMdbListClick = {},
                     onLibrarySourceClick = {},
                     onWatchProgressClick = {},
                     onContinueWatchingWindowClick = {},
                     onCommentsChanged = {},
-                    onMoreLikeThisClick = {}
+                    onMoreLikeThisClick = {},
+                    onAnimeIdClick = {}
                 )
             }
         }
@@ -173,7 +197,10 @@ class TrackingSettingsOverviewTest {
         }
 
         composeRule.onNodeWithTag(TrackingSettingsTestTags.TRAKT_PROVIDER)
-            .assertIsFocused()
+            .assertIsFocused().performKeyInput { pressKey(Key.DirectionDown) }
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.SIMKL_PROVIDER)
+            .assertIsFocused().performKeyInput { pressKey(Key.DirectionDown) }
+        composeRule.onNodeWithTag(TrackingSettingsTestTags.MDBLIST_PROVIDER).assertIsFocused()
     }
 
     @Test
@@ -184,7 +211,6 @@ class TrackingSettingsOverviewTest {
                     state = TraktUiState(),
                     onStartConnection = {},
                     onRetryPolling = {},
-                    onSync = {},
                     onDisconnect = {},
                     onDismiss = {}
                 )
@@ -207,7 +233,6 @@ class TrackingSettingsOverviewTest {
                     ),
                     onStartConnection = {},
                     onRetryPolling = {},
-                    onSync = {},
                     onDisconnect = {},
                     onDismiss = {}
                 )
@@ -221,6 +246,7 @@ class TrackingSettingsOverviewTest {
     private fun setOverview(
         traktState: TraktUiState = TraktUiState(),
         simklState: SimklSettingsUiState = SimklSettingsUiState(),
+        mdbListState: MdbListTrackerUiState = MdbListTrackerUiState(),
         trackingState: TrackingSettingsUiState = TrackingSettingsUiState(isReady = true)
     ) {
         composeRule.setContent {
@@ -228,20 +254,24 @@ class TrackingSettingsOverviewTest {
                 TrackingSettingsOverview(
                     traktState = traktState,
                     simklState = simklState,
+                    mdbListState = mdbListState,
                     trackingState = trackingState,
                     traktFocusRequester = remember { FocusRequester() },
                     simklFocusRequester = remember { FocusRequester() },
+                    mdbListFocusRequester = remember { FocusRequester() },
                     libraryFocusRequester = remember { FocusRequester() },
                     watchProgressFocusRequester = remember { FocusRequester() },
                     continueWatchingFocusRequester = remember { FocusRequester() },
                     moreLikeThisFocusRequester = remember { FocusRequester() },
                     onTraktClick = {},
                     onSimklClick = {},
+                    onMdbListClick = {},
                     onLibrarySourceClick = {},
                     onWatchProgressClick = {},
                     onContinueWatchingWindowClick = {},
                     onCommentsChanged = {},
-                    onMoreLikeThisClick = {}
+                    onMoreLikeThisClick = {},
+                    onAnimeIdClick = {}
                 )
             }
         }

--- a/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
@@ -31,6 +31,17 @@ import okhttp3.OkHttpClient
 object MdbListModule {
     @Provides
     @Singleton
+    fun library(
+        api: MdbListApiClient,
+        sync: MdbListSyncRepository,
+        auth: MdbListAuthStore,
+        profiles: ProfileManager
+    ) = com.nuvio.tv.data.mdblist.MdbListLibraryService(
+        api, sync, auth, profiles.activeProfileId, CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    )
+
+    @Provides
+    @Singleton
     fun configuration(): MdbListConfiguration = MdbListConfiguration(
         clientId = BuildConfig.MDBLIST_CLIENT_ID,
         appVersion = BuildConfig.VERSION_NAME

--- a/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
@@ -1,0 +1,72 @@
+package com.nuvio.tv.core.di
+
+import com.nuvio.tv.BuildConfig
+import com.nuvio.tv.core.profile.ProfileScopedCredentialStore
+import com.nuvio.tv.data.local.ProfileDataStore
+import com.nuvio.tv.data.mdblist.AndroidMdbListAuthPersistence
+import com.nuvio.tv.data.mdblist.MdbListApiClient
+import com.nuvio.tv.data.mdblist.MdbListAuthRepository
+import com.nuvio.tv.data.mdblist.MdbListAuthStore
+import com.nuvio.tv.data.mdblist.MdbListConfiguration
+import com.nuvio.tv.data.mdblist.MdbListHttpClient
+import com.nuvio.tv.data.mdblist.OkHttpMdbListEngine
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MdbListModule {
+    @Provides
+    @Singleton
+    fun configuration(): MdbListConfiguration = MdbListConfiguration(
+        clientId = BuildConfig.MDBLIST_CLIENT_ID,
+        appVersion = BuildConfig.VERSION_NAME
+    )
+
+    @Provides
+    @Singleton
+    fun http(configuration: MdbListConfiguration): MdbListHttpClient = MdbListHttpClient(
+        OkHttpMdbListEngine(
+            OkHttpClient.Builder()
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .callTimeout(45, TimeUnit.SECONDS)
+                .build(),
+            configuration
+        )
+    )
+
+    @Provides
+    @Singleton
+    fun authStore(persistence: AndroidMdbListAuthPersistence, profileDataStore: ProfileDataStore): MdbListAuthStore {
+        val store = MdbListAuthStore(persistence)
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            profileDataStore.activeProfileId.collect(store::selectProfile)
+        }
+        return store
+    }
+
+    @Provides
+    @IntoSet
+    fun credentialStore(store: MdbListAuthStore): ProfileScopedCredentialStore = store
+
+    @Provides
+    @Singleton
+    fun auth(http: MdbListHttpClient, configuration: MdbListConfiguration, store: MdbListAuthStore) =
+        MdbListAuthRepository(http, configuration, store)
+
+    @Provides
+    @Singleton
+    fun api(http: MdbListHttpClient, auth: MdbListAuthRepository, store: MdbListAuthStore) =
+        MdbListApiClient(http, auth, store)
+}

--- a/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/MdbListModule.kt
@@ -2,8 +2,11 @@ package com.nuvio.tv.core.di
 
 import com.nuvio.tv.BuildConfig
 import com.nuvio.tv.core.profile.ProfileScopedCredentialStore
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.data.local.ProfileDataStore
 import com.nuvio.tv.data.mdblist.AndroidMdbListAuthPersistence
+import com.nuvio.tv.data.mdblist.AndroidMdbListSyncStorage
+import com.nuvio.tv.data.mdblist.MdbListSyncRepository
 import com.nuvio.tv.data.mdblist.MdbListApiClient
 import com.nuvio.tv.data.mdblist.MdbListAuthRepository
 import com.nuvio.tv.data.mdblist.MdbListAuthStore
@@ -69,4 +72,16 @@ object MdbListModule {
     @Singleton
     fun api(http: MdbListHttpClient, auth: MdbListAuthRepository, store: MdbListAuthStore) =
         MdbListApiClient(http, auth, store)
+
+    @Provides
+    @Singleton
+    fun syncRepository(
+        storage: AndroidMdbListSyncStorage,
+        auth: MdbListAuthStore,
+        api: MdbListApiClient,
+        profiles: ProfileManager
+    ) = MdbListSyncRepository(
+        storage, auth, api, profiles.activeProfileId,
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    )
 }

--- a/app/src/main/java/com/nuvio/tv/core/di/TrackingModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/TrackingModule.kt
@@ -19,6 +19,9 @@ import com.nuvio.tv.data.simkl.SimklTrackingHistoryWriter
 import com.nuvio.tv.data.simkl.SimklTrackingProgressProvider
 import com.nuvio.tv.data.simkl.SimklTrackingProvider
 import com.nuvio.tv.core.profile.ProfileScopedCredentialStore
+import com.nuvio.tv.data.mdblist.MdbListTrackingHistoryWriter
+import com.nuvio.tv.data.mdblist.MdbListTrackingProgressProvider
+import com.nuvio.tv.data.mdblist.MdbListTrackingProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -29,6 +32,18 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class TrackingModule {
+    @Binds
+    @IntoSet
+    abstract fun bindMdbListProvider(provider: MdbListTrackingProvider): TrackingProvider
+
+    @Binds
+    @IntoSet
+    abstract fun bindMdbListProgress(provider: MdbListTrackingProgressProvider): TrackingProgressProvider
+
+    @Binds
+    @IntoSet
+    abstract fun bindMdbListHistory(writer: MdbListTrackingHistoryWriter): TrackingHistoryWriter
+
     @Binds
     @Singleton
     abstract fun bindSimklAuthStorage(storage: AndroidSimklAuthStorage): SimklAuthStorage

--- a/app/src/main/java/com/nuvio/tv/core/di/TrackingModule.kt
+++ b/app/src/main/java/com/nuvio/tv/core/di/TrackingModule.kt
@@ -34,6 +34,10 @@ import javax.inject.Singleton
 abstract class TrackingModule {
     @Binds
     @IntoSet
+    abstract fun bindMdbListLibrary(provider: com.nuvio.tv.data.mdblist.MdbListTrackingLibraryProvider): TrackingLibraryProvider
+
+    @Binds
+    @IntoSet
     abstract fun bindMdbListProvider(provider: MdbListTrackingProvider): TrackingProvider
 
     @Binds

--- a/app/src/main/java/com/nuvio/tv/core/profile/ProtectedProfilePreferences.kt
+++ b/app/src/main/java/com/nuvio/tv/core/profile/ProtectedProfilePreferences.kt
@@ -1,0 +1,73 @@
+package com.nuvio.tv.core.profile
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.io.IOException
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class ProtectedProfilePreferences(
+    context: Context,
+    name: String,
+    private val keyAlias: String
+) {
+    private val preferences = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+    private val lock = Any()
+
+    fun read(profileId: Int): String? = synchronized(lock) {
+        val key = "profile.$profileId"
+        val value = preferences.getString(key, null) ?: return@synchronized null
+        try {
+            val parts = value.split('.', limit = 2)
+            require(parts.size == 2)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, secretKey(), GCMParameterSpec(128, decode(parts[0])))
+            cipher.updateAAD("$keyAlias:$key".toByteArray(Charsets.UTF_8))
+            cipher.doFinal(decode(parts[1])).toString(Charsets.UTF_8)
+        } catch (_: Exception) {
+            if (!preferences.edit().remove(key).commit()) throw IOException("Unable to clear protected credentials")
+            null
+        }
+    }
+
+    fun write(profileId: Int, value: String?) = synchronized(lock) {
+        val key = "profile.$profileId"
+        val editor = preferences.edit()
+        if (value == null) {
+            editor.remove(key)
+        } else {
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+            cipher.updateAAD("$keyAlias:$key".toByteArray(Charsets.UTF_8))
+            val encrypted = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
+            editor.putString(key, "${encode(cipher.iv)}.${encode(encrypted)}")
+        }
+        if (!editor.commit()) throw IOException("Unable to save protected credentials")
+    }
+
+    fun clear() = synchronized(lock) {
+        if (!preferences.edit().clear().commit()) throw IOException("Unable to clear protected credentials")
+    }
+
+    private fun secretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (keyStore.getKey(keyAlias, null) as? SecretKey)?.let { return it }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").run {
+            init(
+                KeyGenParameterSpec.Builder(keyAlias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .build()
+            )
+            generateKey()
+        }
+    }
+
+    private fun encode(value: ByteArray): String = Base64.encodeToString(value, Base64.NO_WRAP)
+    private fun decode(value: String): ByteArray = Base64.decode(value, Base64.NO_WRAP)
+}

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingLibraryProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingLibraryProvider.kt
@@ -10,6 +10,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 
 interface TrackingLibraryProvider {
+    val listManager: TrackingListManager? get() = null
     val providerId: TrackingProviderId
     val isAuthenticated: Flow<Boolean>
     val isRefreshing: Flow<Boolean>

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingListManager.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingListManager.kt
@@ -1,0 +1,19 @@
+package com.nuvio.tv.core.tracking
+
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+
+data class TrackingListManagementCapabilities(
+    val privacyOptions: List<LibraryListPrivacy>,
+    val supportsDescription: Boolean = false,
+    val supportsReordering: Boolean = false
+)
+
+interface TrackingListManager {
+    val capabilities: TrackingListManagementCapabilities
+    suspend fun createList(name: String, description: String?, privacy: LibraryListPrivacy)
+    suspend fun updateList(key: String, name: String, description: String?, privacy: LibraryListPrivacy)
+    suspend fun deleteList(key: String)
+    suspend fun reorderLists(keys: List<String>) {
+        throw UnsupportedOperationException("This provider does not support list reordering")
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingMedia.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingMedia.kt
@@ -9,10 +9,11 @@ data class TrackingExternalIds(
     val mal: Long? = null,
     val anidb: Long? = null,
     val anilist: Long? = null,
-    val kitsu: Long? = null
+    val kitsu: Long? = null,
+    val mdblist: String? = null
 ) {
     val hasAny: Boolean
-        get() = listOf(imdb, tmdb, tvdb, trakt, simkl, mal, anidb, anilist, kitsu).any { it != null }
+        get() = listOf(imdb, tmdb, tvdb, trakt, simkl, mal, anidb, anilist, kitsu, mdblist).any { it != null }
 
     fun mergeMissing(other: TrackingExternalIds): TrackingExternalIds = TrackingExternalIds(
         imdb = imdb ?: other.imdb,
@@ -23,7 +24,8 @@ data class TrackingExternalIds(
         mal = mal ?: other.mal,
         anidb = anidb ?: other.anidb,
         anilist = anilist ?: other.anilist,
-        kitsu = kitsu ?: other.kitsu
+        kitsu = kitsu ?: other.kitsu,
+        mdblist = mdblist ?: other.mdblist
     )
 }
 
@@ -38,7 +40,8 @@ data class TrackingEpisode(
     val number: Int,
     val title: String? = null,
     val tvdbId: Long? = null,
-    val usesTvdbSeasonMapping: Boolean = false
+    val usesTvdbSeasonMapping: Boolean = false,
+    val tmdbId: Long? = null
 )
 
 data class TrackingCatalogReference(
@@ -73,6 +76,7 @@ data class TrackingMediaReference(
                     ?: ids.anidb?.let { "anidb:$it" }
                     ?: ids.anilist?.let { "anilist:$it" }
                     ?: ids.kitsu?.let { "kitsu:$it" }
+                    ?: ids.mdblist?.let { "mdblist:$it" }
                     ?: "title:${title.orEmpty().trim().lowercase()}:${year ?: 0}"
             )
         }
@@ -96,6 +100,7 @@ fun parseTrackingExternalIds(rawValue: String?): TrackingExternalIds {
         "anidb" -> TrackingExternalIds(anidb = value.toLongOrNull())
         "anilist" -> TrackingExternalIds(anilist = value.toLongOrNull())
         "kitsu" -> TrackingExternalIds(kitsu = value.toLongOrNull())
+        "mdblist" -> TrackingExternalIds(mdblist = value.takeIf(String::isNotBlank))
         else -> TrackingExternalIds(trakt = full.toLongOrNull())
     }
 }

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProgressProvider.kt
@@ -16,6 +16,8 @@ interface TrackingProgressProvider {
     val watchedMovieIds: Flow<Set<String>>
     val ownsCompletedHistoryProjection: Boolean
         get() = false
+    val clearsLocalProgressOnSelection: Boolean
+        get() = false
     val watchedItems: Flow<List<WatchedItem>>
         get() = flowOf(emptyList())
 

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingProvider.kt
@@ -6,7 +6,8 @@ import javax.inject.Singleton
 
 enum class TrackingProviderId(val storageId: String) {
     TRAKT("trakt"),
-    SIMKL("simkl");
+    SIMKL("simkl"),
+    MDBLIST("mdblist");
 
     companion object {
         fun fromStorage(value: String?): TrackingProviderId? {

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingRefreshGate.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingRefreshGate.kt
@@ -1,0 +1,28 @@
+package com.nuvio.tv.core.tracking
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class TrackingRefreshGate {
+    private val mutex = Mutex()
+    @Volatile private var completionSequence = 0L
+    private var lastCompletedProfileGeneration: Long? = null
+
+    suspend fun runIfNeeded(
+        profileGeneration: Long,
+        shouldRun: () -> Boolean,
+        block: suspend () -> Unit
+    ) {
+        val observedSequence = completionSequence
+        mutex.withLock {
+            if (completionSequence != observedSequence && lastCompletedProfileGeneration == profileGeneration) return
+            if (!shouldRun()) return
+            try {
+                block()
+            } finally {
+                lastCompletedProfileGeneration = profileGeneration
+                completionSequence += 1L
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSourceController.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSourceController.kt
@@ -9,7 +9,6 @@ import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.local.WatchedSeriesStateHolder
-import com.nuvio.tv.data.simkl.SimklSyncRepository
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
 class TrackingSourceController @Inject constructor(
     private val settingsDataStore: TraktSettingsDataStore,
     private val progressProviders: TrackingProgressProviderRegistry,
-    private val simklSyncRepository: SimklSyncRepository,
+    private val libraryProviders: TrackingLibraryProviderRegistry,
     private val startupSyncService: StartupSyncService,
     private val watchedItemsPreferences: WatchedItemsPreferences,
     private val watchProgressPreferences: WatchProgressPreferences,
@@ -97,9 +96,7 @@ class TrackingSourceController @Inject constructor(
     private suspend fun applyLibrarySourceMode(mode: LibrarySourceMode, profileId: Int) {
         settingsDataStore.setLibrarySourceMode(mode, profileId)
         if (profileManager.activeProfileId.value != profileId) return
-        if (mode == LibrarySourceMode.SIMKL) {
-            simklSyncRepository.refresh(TrackingRefreshIntent.USER_INITIATED)
-        }
+        mode.providerId?.let(libraryProviders::provider)?.refresh(TrackingRefreshIntent.USER_INITIATED)
     }
 
     private suspend fun repopulateWatchedItemsFromNuvioSync(profileId: Int) {

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSourceController.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSourceController.kt
@@ -9,8 +9,6 @@ import com.nuvio.tv.data.local.WatchProgressPreferences
 import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.local.WatchedItemsPreferences
 import com.nuvio.tv.data.local.WatchedSeriesStateHolder
-import com.nuvio.tv.data.repository.TraktProgressService
-import com.nuvio.tv.data.repository.isTraktCompatibleId
 import com.nuvio.tv.data.simkl.SimklSyncRepository
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import javax.inject.Inject
@@ -21,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
 @Singleton
 class TrackingSourceController @Inject constructor(
     private val settingsDataStore: TraktSettingsDataStore,
-    private val traktProgressService: TraktProgressService,
+    private val progressProviders: TrackingProgressProviderRegistry,
     private val simklSyncRepository: SimklSyncRepository,
     private val startupSyncService: StartupSyncService,
     private val watchedItemsPreferences: WatchedItemsPreferences,
@@ -78,25 +76,20 @@ class TrackingSourceController @Inject constructor(
         if (profileManager.activeProfileId.value != profileId) return
         continueWatchingEnrichmentCache.saveInProgressSnapshot(emptyList(), force = true)
         continueWatchingEnrichmentCache.saveNextUpSnapshot(emptyList(), force = true)
-        when (source) {
-            WatchProgressSource.TRAKT -> {
+        val provider = source.providerId?.let(progressProviders::provider)
+        if (provider != null) {
+            if (provider.clearsLocalProgressOnSelection) {
                 watchProgressPreferences.clearAllPreservingNonTraktIds(profileId) { contentId ->
-                    !isTraktCompatibleId(contentId)
+                    provider.retainsLocalProgress(contentId)
                 }
-                watchedItemsPreferences.clearAll(profileId)
-                watchedSeriesStateHolder.update(emptySet())
-                traktProgressService.refreshNow()
             }
-            WatchProgressSource.SIMKL -> {
-                watchedItemsPreferences.clearAll(profileId)
-                watchedSeriesStateHolder.update(emptySet())
-                simklSyncRepository.refresh(TrackingRefreshIntent.USER_INITIATED)
-            }
-            WatchProgressSource.NUVIO_SYNC -> {
-                repopulateWatchedItemsFromNuvioSync(profileId)
-                if (profileManager.activeProfileId.value == profileId) {
-                    startupSyncService.requestSyncNow()
-                }
+            watchedItemsPreferences.clearAll(profileId)
+            watchedSeriesStateHolder.update(emptySet())
+            provider.refresh(TrackingRefreshIntent.USER_INITIATED)
+        } else if (source == WatchProgressSource.NUVIO_SYNC) {
+            repopulateWatchedItemsFromNuvioSync(profileId)
+            if (profileManager.activeProfileId.value == profileId) {
+                startupSyncService.requestSyncNow()
             }
         }
     }

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSources.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSources.kt
@@ -16,6 +16,7 @@ val LibrarySourceMode.providerId: TrackingProviderId?
         LibrarySourceMode.LOCAL -> null
         LibrarySourceMode.TRAKT -> TrackingProviderId.TRAKT
         LibrarySourceMode.SIMKL -> TrackingProviderId.SIMKL
+        LibrarySourceMode.MDBLIST -> TrackingProviderId.MDBLIST
     }
 
 fun effectiveWatchProgressSource(
@@ -68,4 +69,5 @@ fun availableLibrarySourceModes(
     add(LibrarySourceMode.LOCAL)
     if (TrackingProviderId.TRAKT in connectedProviderIds) add(LibrarySourceMode.TRAKT)
     if (TrackingProviderId.SIMKL in connectedProviderIds) add(LibrarySourceMode.SIMKL)
+    if (TrackingProviderId.MDBLIST in connectedProviderIds) add(LibrarySourceMode.MDBLIST)
 }

--- a/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSources.kt
+++ b/app/src/main/java/com/nuvio/tv/core/tracking/TrackingSources.kt
@@ -7,6 +7,7 @@ val WatchProgressSource.providerId: TrackingProviderId?
     get() = when (this) {
         WatchProgressSource.TRAKT -> TrackingProviderId.TRAKT
         WatchProgressSource.SIMKL -> TrackingProviderId.SIMKL
+        WatchProgressSource.MDBLIST -> TrackingProviderId.MDBLIST
         WatchProgressSource.NUVIO_SYNC -> null
     }
 
@@ -58,6 +59,7 @@ fun availableWatchProgressSources(
     add(WatchProgressSource.NUVIO_SYNC)
     if (TrackingProviderId.TRAKT in connectedProviderIds) add(WatchProgressSource.TRAKT)
     if (TrackingProviderId.SIMKL in connectedProviderIds) add(WatchProgressSource.SIMKL)
+    if (TrackingProviderId.MDBLIST in connectedProviderIds) add(WatchProgressSource.MDBLIST)
 }
 
 fun availableLibrarySourceModes(

--- a/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/local/TraktSettingsDataStore.kt
@@ -25,6 +25,7 @@ import javax.inject.Singleton
 enum class WatchProgressSource {
     TRAKT,
     SIMKL,
+    MDBLIST,
     NUVIO_SYNC;
 
     companion object {

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/AndroidMdbListAuthPersistence.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/AndroidMdbListAuthPersistence.kt
@@ -1,0 +1,18 @@
+package com.nuvio.tv.data.mdblist
+
+import android.content.Context
+import com.nuvio.tv.core.profile.ProtectedProfilePreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidMdbListAuthPersistence @Inject constructor(
+    @ApplicationContext context: Context
+) : MdbListAuthPersistence {
+    private val preferences = ProtectedProfilePreferences(context, "mdblist_auth", "com.nuvio.tv.mdblist.credentials.v1")
+
+    override fun read(profileId: Int): String? = preferences.read(profileId)
+    override fun write(profileId: Int, value: String?) = preferences.write(profileId, value)
+    override fun clear() = preferences.clear()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
@@ -12,8 +12,9 @@ class MdbListApiClient(
     suspend fun get(
         path: String,
         query: Map<String, String> = emptyMap(),
-        scope: MdbListAuthScope = store.scope()
-    ): MdbListHttpResponse = execute(MdbListHttpMethod.GET, path, query, "", scope)
+        scope: MdbListAuthScope = store.scope(),
+        acceptedStatuses: Set<Int> = emptySet()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.GET, path, query, "", scope, acceptedStatuses)
 
     suspend fun post(
         path: String,
@@ -39,7 +40,8 @@ class MdbListApiClient(
         path: String,
         query: Map<String, String>,
         body: String,
-        scope: MdbListAuthScope
+        scope: MdbListAuthScope,
+        acceptedStatuses: Set<Int> = emptySet()
     ): MdbListHttpResponse {
         var authorization = auth.authorization(scope)
         repeat(2) { attempt ->
@@ -61,7 +63,9 @@ class MdbListApiClient(
                 }
                 authorization = auth.authorization(scope, authorization.tokens.accessToken)
             } else {
-                if (response.status !in 200..299) throw MdbListApiException(response.status, response.errorCode())
+                if (response.status !in 200..299 && response.status !in acceptedStatuses) {
+                    throw MdbListApiException(response.status, response.errorCode())
+                }
                 return response
             }
         }

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
@@ -19,8 +19,9 @@ class MdbListApiClient(
     suspend fun post(
         path: String,
         body: String,
-        scope: MdbListAuthScope = store.scope()
-    ): MdbListHttpResponse = execute(MdbListHttpMethod.POST, path, emptyMap(), body, scope)
+        scope: MdbListAuthScope = store.scope(),
+        query: Map<String, String> = emptyMap()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.POST, path, query, body, scope)
 
     suspend fun refreshUser(scope: MdbListAuthScope = store.scope()): MdbListUser {
         val previousLimitKey = limitKey(scope)

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
@@ -23,6 +23,17 @@ class MdbListApiClient(
         query: Map<String, String> = emptyMap()
     ): MdbListHttpResponse = execute(MdbListHttpMethod.POST, path, query, body, scope)
 
+    suspend fun put(
+        path: String,
+        body: String,
+        scope: MdbListAuthScope = store.scope()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.PUT, path, emptyMap(), body, scope)
+
+    suspend fun delete(
+        path: String,
+        scope: MdbListAuthScope = store.scope()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.DELETE, path, emptyMap(), "", scope)
+
     suspend fun refreshUser(scope: MdbListAuthScope = store.scope()): MdbListUser {
         val previousLimitKey = limitKey(scope)
         val response = get("/user", scope = scope)

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListApiClient.kt
@@ -1,0 +1,73 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.Json
+
+class MdbListApiClient(
+    private val http: MdbListHttpClient,
+    private val auth: MdbListAuthRepository,
+    private val store: MdbListAuthStore
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun get(
+        path: String,
+        query: Map<String, String> = emptyMap(),
+        scope: MdbListAuthScope = store.scope()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.GET, path, query, "", scope)
+
+    suspend fun post(
+        path: String,
+        body: String,
+        scope: MdbListAuthScope = store.scope()
+    ): MdbListHttpResponse = execute(MdbListHttpMethod.POST, path, emptyMap(), body, scope)
+
+    suspend fun refreshUser(scope: MdbListAuthScope = store.scope()): MdbListUser {
+        val previousLimitKey = limitKey(scope)
+        val response = get("/user", scope = scope)
+        val user = runCatching {
+            json.decodeFromString<MdbListUser>(response.body)
+        }.getOrElse { throw MdbListAuthException(MdbListAuthError.INVALID_RESPONSE) }
+        if (user.id == null || user.id <= 0L) throw MdbListAuthException(MdbListAuthError.INVALID_RESPONSE)
+        if (!store.saveUser(user, scope)) store.checkScope(scope)
+        http.associateAccountLimit(previousLimitKey, "user:${user.id}")
+        store.checkScope(scope)
+        return user
+    }
+
+    private suspend fun execute(
+        method: MdbListHttpMethod,
+        path: String,
+        query: Map<String, String>,
+        body: String,
+        scope: MdbListAuthScope
+    ): MdbListHttpResponse {
+        var authorization = auth.authorization(scope)
+        repeat(2) { attempt ->
+            val response = http.execute(
+                MdbListHttpRequest(
+                    method = method,
+                    path = path,
+                    query = query,
+                    body = body,
+                    accessToken = authorization.tokens.accessToken,
+                    limitKey = limitKey(scope)
+                ),
+                checkScope = { store.checkScope(scope) }
+            )
+            if (response.status == 401) {
+                if (attempt == 1) {
+                    store.clearAuth(scope, MdbListAuthError.AUTHORIZATION_REVOKED, authorization.tokens.accessToken)
+                    throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+                }
+                authorization = auth.authorization(scope, authorization.tokens.accessToken)
+            } else {
+                if (response.status !in 200..299) throw MdbListApiException(response.status, response.errorCode())
+                return response
+            }
+        }
+        throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+    }
+
+    private fun limitKey(scope: MdbListAuthScope): String = store.state.value.user?.id?.let { "user:$it" }
+        ?: "profile:${scope.profileId}:${scope.generation}"
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthModels.kt
@@ -1,0 +1,95 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+enum class MdbListAuthError {
+    MISSING_CLIENT_ID,
+    INVALID_RESPONSE,
+    CODE_EXPIRED,
+    ACCESS_DENIED,
+    AUTHORIZATION_REVOKED
+}
+
+data class MdbListAuthScope(val profileId: Int, val generation: Long)
+
+@Serializable
+data class MdbListDeviceSession(
+    val userCode: String,
+    val verificationUri: String,
+    val verificationUriComplete: String,
+    val expiresAtEpochMs: Long,
+    val intervalSeconds: Int,
+    val nextPollAtEpochMs: Long
+) {
+    override fun toString(): String = "MdbListDeviceSession(expiresAtEpochMs=$expiresAtEpochMs)"
+}
+
+data class MdbListAuthState(
+    val scope: MdbListAuthScope = MdbListAuthScope(1, 0),
+    val isAuthenticated: Boolean = false,
+    val user: MdbListUser? = null,
+    val session: MdbListDeviceSession? = null,
+    val error: MdbListAuthError? = null
+)
+
+@Serializable
+data class MdbListUser(
+    @SerialName("user_id") val id: Long? = null,
+    val username: String? = null,
+    @SerialName("is_supporter") val isSupporter: Boolean = false,
+    @SerialName("rate_limit") val rateLimit: Int? = null,
+    @SerialName("rate_limit_remaining") val rateLimitRemaining: Int? = null,
+    @SerialName("rate_limit_reset") val rateLimitReset: Long? = null
+)
+
+@Serializable
+data class MdbListTokens(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresAtEpochMs: Long
+) {
+    override fun toString(): String = "MdbListTokens(expiresAtEpochMs=$expiresAtEpochMs)"
+}
+
+class MdbListAuthorization(val scope: MdbListAuthScope, val tokens: MdbListTokens) {
+    override fun toString(): String = "MdbListAuthorization(scope=$scope)"
+}
+
+sealed interface MdbListDevicePollResult {
+    data object Pending : MdbListDevicePollResult
+    data object Authorized : MdbListDevicePollResult
+    data object Expired : MdbListDevicePollResult
+    data object Denied : MdbListDevicePollResult
+}
+
+class MdbListAuthException(val error: MdbListAuthError) : Exception(error.name)
+
+@Serializable
+internal data class MdbListStoredAuth(
+    val tokens: MdbListTokens? = null,
+    val user: MdbListUser? = null,
+    val session: MdbListDeviceSession? = null,
+    val deviceCode: String? = null
+) {
+    override fun toString(): String = "MdbListStoredAuth()"
+}
+
+@Serializable
+internal data class MdbListDeviceResponse(
+    @SerialName("device_code") val deviceCode: String? = null,
+    @SerialName("user_code") val userCode: String? = null,
+    @SerialName("verification_uri") val verificationUri: String? = null,
+    @SerialName("verification_uri_complete") val verificationUriComplete: String? = null,
+    @SerialName("expires_in") val expiresIn: Long? = null,
+    val interval: Int = 5
+)
+
+@Serializable
+internal data class MdbListTokenResponse(
+    @SerialName("access_token") val accessToken: String? = null,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("token_type") val tokenType: String? = null,
+    @SerialName("expires_in") val expiresIn: Long? = null,
+    val scope: String? = null
+)

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthModels.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 enum class MdbListAuthError {
     MISSING_CLIENT_ID,
     INVALID_RESPONSE,
+    INSUFFICIENT_SCOPE,
     CODE_EXPIRED,
     ACCESS_DENIED,
     AUTHORIZATION_REVOKED

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthRepository.kt
@@ -19,10 +19,10 @@ class MdbListAuthRepository(
 
     fun hasRequiredCredentials(): Boolean = configuration.clientId.isNotBlank()
 
-    suspend fun startDeviceAuthorization(): MdbListDeviceSession = deviceMutex.withLock {
+    suspend fun startDeviceAuthorization(scope: MdbListAuthScope = store.scope()): MdbListDeviceSession = deviceMutex.withLock {
+        store.checkScope(scope)
         if (!hasRequiredCredentials()) throw MdbListAuthException(MdbListAuthError.MISSING_CLIENT_ID)
         check(!state.value.isAuthenticated)
-        val scope = store.scope()
         val response = oauth("/oauth/device-authorization/", mapOf("scope" to "write"), scope)
         if (response.status !in 200..299) throw MdbListApiException(response.status, response.errorCode())
         val payload = decode<MdbListDeviceResponse>(response.body)
@@ -45,9 +45,9 @@ class MdbListAuthRepository(
         session
     }
 
-    suspend fun pollDeviceAuthorization(): MdbListDevicePollResult = deviceMutex.withLock {
+    suspend fun pollDeviceAuthorization(scope: MdbListAuthScope = store.scope()): MdbListDevicePollResult = deviceMutex.withLock {
+        store.checkScope(scope)
         val current = state.value
-        val scope = current.scope
         val session = current.session ?: scopeChanged()
         val now = nowEpochMs()
         if (now >= session.expiresAtEpochMs) {
@@ -61,7 +61,7 @@ class MdbListAuthRepository(
         }
         val response = oauth(
             "/oauth/token/",
-            mapOf("grant_type" to "urn:ietf:params:oauth:grant-type:device_code", "device_code" to deviceCode),
+            mapOf("grant_type" to "urn:ietf:params:oauth:grant-type:device_code", "device_code" to deviceCode, "scope" to "write"),
             scope
         )
         if (response.status in 200..299) {
@@ -122,9 +122,11 @@ class MdbListAuthRepository(
         MdbListAuthorization(scope, tokens)
     }
 
-    suspend fun disconnect(): Boolean {
+    suspend fun disconnect(scope: MdbListAuthScope = store.scope()): Boolean {
+        store.checkScope(scope)
         val current = store.authorization()
-        store.clearAuth()
+        if (current != null && current.scope != scope) scopeChanged()
+        if (!store.clearAuth(scope)) scopeChanged()
         if (current == null) return true
         return try {
             val response = http.execute(
@@ -162,7 +164,9 @@ class MdbListAuthRepository(
         val accessToken = payload.accessToken?.takeIf(String::isNotBlank) ?: invalidResponse()
         val refreshToken = payload.refreshToken?.takeIf(String::isNotBlank) ?: previousRefreshToken ?: invalidResponse()
         if (!payload.tokenType.equals("Bearer", ignoreCase = true)) invalidResponse()
-        if (payload.scope != null && "write" !in payload.scope.split(' ')) invalidResponse()
+        if (payload.scope != null && "write" !in payload.scope.split(Regex("\\s+"))) {
+            throw MdbListAuthException(MdbListAuthError.INSUFFICIENT_SCOPE)
+        }
         return MdbListTokens(accessToken, refreshToken, expiresAt(payload.expiresIn, nowEpochMs()))
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthRepository.kt
@@ -1,0 +1,182 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+class MdbListAuthRepository(
+    private val http: MdbListHttpClient,
+    private val configuration: MdbListConfiguration,
+    private val store: MdbListAuthStore,
+    private val nowEpochMs: () -> Long = System::currentTimeMillis
+) {
+    private val deviceMutex = Mutex()
+    private val refreshMutex = Mutex()
+    private val json = Json { ignoreUnknownKeys = true }
+    val state = store.state
+
+    fun hasRequiredCredentials(): Boolean = configuration.clientId.isNotBlank()
+
+    suspend fun startDeviceAuthorization(): MdbListDeviceSession = deviceMutex.withLock {
+        if (!hasRequiredCredentials()) throw MdbListAuthException(MdbListAuthError.MISSING_CLIENT_ID)
+        check(!state.value.isAuthenticated)
+        val scope = store.scope()
+        val response = oauth("/oauth/device-authorization/", mapOf("scope" to "write"), scope)
+        if (response.status !in 200..299) throw MdbListApiException(response.status, response.errorCode())
+        val payload = decode<MdbListDeviceResponse>(response.body)
+        val deviceCode = payload.deviceCode?.takeIf(String::isNotBlank) ?: invalidResponse()
+        val userCode = payload.userCode?.takeIf(String::isNotBlank) ?: invalidResponse()
+        val uri = verificationUrl(payload.verificationUri)
+        val complete = payload.verificationUriComplete?.let(::verificationUrl)
+            ?: uri.newBuilder().addQueryParameter("user_code", userCode).build()
+        val interval = payload.interval.takeIf { it in 1..3_600 } ?: invalidResponse()
+        val now = nowEpochMs()
+        val session = MdbListDeviceSession(
+            userCode = userCode,
+            verificationUri = uri.toString(),
+            verificationUriComplete = complete.toString(),
+            expiresAtEpochMs = expiresAt(payload.expiresIn, now),
+            intervalSeconds = interval,
+            nextPollAtEpochMs = now + interval * 1_000L
+        )
+        if (!store.saveSession(session, deviceCode, scope)) scopeChanged()
+        session
+    }
+
+    suspend fun pollDeviceAuthorization(): MdbListDevicePollResult = deviceMutex.withLock {
+        val current = state.value
+        val scope = current.scope
+        val session = current.session ?: scopeChanged()
+        val now = nowEpochMs()
+        if (now >= session.expiresAtEpochMs) {
+            store.cancelSession(MdbListAuthError.CODE_EXPIRED, scope)
+            return@withLock MdbListDevicePollResult.Expired
+        }
+        if (now < session.nextPollAtEpochMs) return@withLock MdbListDevicePollResult.Pending
+        val deviceCode = store.deviceCode(scope) ?: scopeChanged()
+        if (!store.updateSession(session.copy(nextPollAtEpochMs = now + session.intervalSeconds * 1_000L), scope)) {
+            scopeChanged()
+        }
+        val response = oauth(
+            "/oauth/token/",
+            mapOf("grant_type" to "urn:ietf:params:oauth:grant-type:device_code", "device_code" to deviceCode),
+            scope
+        )
+        if (response.status in 200..299) {
+            val tokens = tokensFrom(response)
+            if (!store.authorize(tokens, scope)) scopeChanged()
+            return@withLock MdbListDevicePollResult.Authorized
+        }
+        when (response.errorCode()) {
+            "authorization_pending" -> MdbListDevicePollResult.Pending
+            "slow_down" -> {
+                val interval = (session.intervalSeconds + 5).coerceAtMost(3_600)
+                store.updateSession(
+                    session.copy(intervalSeconds = interval, nextPollAtEpochMs = nowEpochMs() + interval * 1_000L),
+                    scope
+                )
+                MdbListDevicePollResult.Pending
+            }
+            "access_denied" -> {
+                store.cancelSession(MdbListAuthError.ACCESS_DENIED, scope)
+                MdbListDevicePollResult.Denied
+            }
+            "expired_token" -> {
+                store.cancelSession(MdbListAuthError.CODE_EXPIRED, scope)
+                MdbListDevicePollResult.Expired
+            }
+            else -> throw MdbListApiException(response.status, response.errorCode())
+        }
+    }
+
+    fun cancelDeviceAuthorization() {
+        store.cancelSession()
+    }
+
+    suspend fun authorization(
+        scope: MdbListAuthScope,
+        rejectedAccessToken: String? = null
+    ): MdbListAuthorization = refreshMutex.withLock {
+        store.checkScope(scope)
+        val current = store.authorization() ?: throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+        if (rejectedAccessToken != null && current.tokens.accessToken != rejectedAccessToken) return@withLock current
+        if (rejectedAccessToken == null && current.tokens.expiresAtEpochMs - nowEpochMs() > 60_000L) {
+            return@withLock current
+        }
+        val response = oauth(
+            "/oauth/token/",
+            mapOf("grant_type" to "refresh_token", "refresh_token" to current.tokens.refreshToken),
+            scope
+        )
+        if (response.status !in 200..299) {
+            if (response.errorCode() in setOf("invalid_grant", "invalid_token")) {
+                store.clearAuth(scope, MdbListAuthError.AUTHORIZATION_REVOKED, current.tokens.accessToken)
+                throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+            }
+            throw MdbListApiException(response.status, response.errorCode())
+        }
+        val tokens = tokensFrom(response, current.tokens.refreshToken)
+        if (!store.refreshTokens(tokens, current)) scopeChanged()
+        MdbListAuthorization(scope, tokens)
+    }
+
+    suspend fun disconnect(): Boolean {
+        val current = store.authorization()
+        store.clearAuth()
+        if (current == null) return true
+        return try {
+            val response = http.execute(
+                MdbListHttpRequest(
+                    method = MdbListHttpMethod.POST,
+                    path = "/oauth/revoke_token/",
+                    form = mapOf(
+                        "client_id" to configuration.clientId,
+                        "token" to current.tokens.refreshToken,
+                        "token_type_hint" to "refresh_token"
+                    )
+                )
+            )
+            response.status in 200..299
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: MdbListApiException) {
+            false
+        }
+    }
+
+    private suspend fun oauth(path: String, fields: Map<String, String>, scope: MdbListAuthScope) =
+        http.execute(
+            MdbListHttpRequest(
+                method = MdbListHttpMethod.POST,
+                path = path,
+                form = fields + ("client_id" to configuration.clientId),
+                limitKey = "oauth:${scope.profileId}"
+            ),
+            checkScope = { store.checkScope(scope) }
+        )
+
+    private fun tokensFrom(response: MdbListHttpResponse, previousRefreshToken: String? = null): MdbListTokens {
+        val payload = decode<MdbListTokenResponse>(response.body)
+        val accessToken = payload.accessToken?.takeIf(String::isNotBlank) ?: invalidResponse()
+        val refreshToken = payload.refreshToken?.takeIf(String::isNotBlank) ?: previousRefreshToken ?: invalidResponse()
+        if (!payload.tokenType.equals("Bearer", ignoreCase = true)) invalidResponse()
+        if (payload.scope != null && "write" !in payload.scope.split(' ')) invalidResponse()
+        return MdbListTokens(accessToken, refreshToken, expiresAt(payload.expiresIn, nowEpochMs()))
+    }
+
+    private fun verificationUrl(value: String?) = value?.toHttpUrlOrNull()
+        ?.takeIf { it.isHttps && it.host == "mdblist.com" && it.username.isEmpty() && it.password.isEmpty() }
+        ?: invalidResponse()
+
+    private fun expiresAt(seconds: Long?, now: Long): Long = seconds
+        ?.takeIf { it > 0L && it <= (Long.MAX_VALUE - now) / 1_000L }
+        ?.let { now + it * 1_000L } ?: invalidResponse()
+
+    private inline fun <reified T> decode(body: String): T =
+        runCatching { json.decodeFromString<T>(body) }.getOrElse { invalidResponse() }
+
+    private fun invalidResponse(): Nothing = throw MdbListAuthException(MdbListAuthError.INVALID_RESPONSE)
+    private fun scopeChanged(): Nothing = throw CancellationException("MDBList account changed")
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthStore.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListAuthStore.kt
@@ -1,0 +1,136 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.profile.ProfileScopedCredentialStore
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+interface MdbListAuthPersistence {
+    fun read(profileId: Int): String?
+    fun write(profileId: Int, value: String?)
+    fun clear()
+}
+
+class MdbListAuthStore(
+    private val persistence: MdbListAuthPersistence,
+    initialProfileId: Int = 1
+) : ProfileScopedCredentialStore {
+    private val lock = Any()
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private var currentScope = MdbListAuthScope(initialProfileId, 0)
+    private var stored = load(initialProfileId)
+    private val mutableState = MutableStateFlow(stateFor())
+
+    val state: StateFlow<MdbListAuthState> = mutableState.asStateFlow()
+
+    fun scope(): MdbListAuthScope = synchronized(lock) { currentScope }
+
+    fun isCurrent(scope: MdbListAuthScope): Boolean = synchronized(lock) { currentScope == scope }
+
+    fun checkScope(scope: MdbListAuthScope) {
+        if (!isCurrent(scope)) throw CancellationException("MDBList account changed")
+    }
+
+    fun authorization(): MdbListAuthorization? = synchronized(lock) {
+        stored.tokens?.let { MdbListAuthorization(currentScope, it) }
+    }
+
+    fun deviceCode(scope: MdbListAuthScope): String? = synchronized(lock) {
+        stored.deviceCode.takeIf { currentScope == scope }
+    }
+
+    fun selectProfile(profileId: Int) = synchronized(lock) {
+        if (currentScope.profileId == profileId) return@synchronized
+        val value = load(profileId)
+        currentScope = MdbListAuthScope(profileId, currentScope.generation + 1)
+        stored = value
+        publish()
+    }
+
+    fun saveSession(session: MdbListDeviceSession, deviceCode: String, scope: MdbListAuthScope): Boolean =
+        mutate(scope, advanceGeneration = true) {
+            it.copy(session = session, deviceCode = deviceCode)
+        }
+
+    fun updateSession(session: MdbListDeviceSession, scope: MdbListAuthScope): Boolean =
+        mutate(scope) { it.copy(session = session) }
+
+    fun cancelSession(error: MdbListAuthError? = null, scope: MdbListAuthScope = scope()): Boolean =
+        mutate(scope, advanceGeneration = true, error = error) {
+            it.copy(session = null, deviceCode = null)
+        }
+
+    fun authorize(tokens: MdbListTokens, scope: MdbListAuthScope): Boolean =
+        mutate(scope, advanceGeneration = true) { MdbListStoredAuth(tokens = tokens) }
+
+    fun refreshTokens(tokens: MdbListTokens, expected: MdbListAuthorization): Boolean = synchronized(lock) {
+        if (stored.tokens?.accessToken != expected.tokens.accessToken) return@synchronized false
+        mutate(expected.scope) { it.copy(tokens = tokens) }
+    }
+
+    fun saveUser(user: MdbListUser, scope: MdbListAuthScope): Boolean =
+        mutate(scope) { it.copy(user = user) }
+
+    fun clearAuth(
+        scope: MdbListAuthScope = scope(),
+        error: MdbListAuthError? = null,
+        expectedAccessToken: String? = null
+    ): Boolean = synchronized(lock) {
+        if (expectedAccessToken != null && stored.tokens?.accessToken != expectedAccessToken) {
+            return@synchronized false
+        }
+        mutate(scope, advanceGeneration = true, error = error) { MdbListStoredAuth() }
+    }
+
+    override fun removeProfile(profileId: Int) = synchronized(lock) {
+        persistence.write(profileId, null)
+        if (currentScope.profileId == profileId) {
+            currentScope = currentScope.copy(generation = currentScope.generation + 1)
+            stored = MdbListStoredAuth()
+            publish()
+        }
+    }
+
+    override fun clearAllProfiles() = synchronized(lock) {
+        persistence.clear()
+        currentScope = currentScope.copy(generation = currentScope.generation + 1)
+        stored = MdbListStoredAuth()
+        publish()
+    }
+
+    private fun mutate(
+        scope: MdbListAuthScope,
+        advanceGeneration: Boolean = false,
+        error: MdbListAuthError? = null,
+        transform: (MdbListStoredAuth) -> MdbListStoredAuth
+    ): Boolean = synchronized(lock) {
+        if (currentScope != scope) return@synchronized false
+        val value = transform(stored)
+        persistence.write(scope.profileId, json.encodeToString(value))
+        stored = value
+        if (advanceGeneration) currentScope = currentScope.copy(generation = currentScope.generation + 1)
+        publish(error)
+        true
+    }
+
+    private fun load(profileId: Int): MdbListStoredAuth = persistence.read(profileId)?.let { value ->
+        runCatching { json.decodeFromString<MdbListStoredAuth>(value) }.getOrNull()
+    }?.takeIf { value ->
+        value.tokens == null || (value.tokens.accessToken.isNotBlank() && value.tokens.refreshToken.isNotBlank())
+    } ?: MdbListStoredAuth()
+
+    private fun publish(error: MdbListAuthError? = null) {
+        mutableState.value = stateFor(error)
+    }
+
+    private fun stateFor(error: MdbListAuthError? = null) = MdbListAuthState(
+        scope = currentScope,
+        isAuthenticated = stored.tokens != null,
+        user = stored.user,
+        session = stored.session,
+        error = error
+    )
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHistoryPayload.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHistoryPayload.kt
@@ -1,0 +1,98 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal data class MdbListHistoryChange(val target: MdbListMutationTarget, val watchedAt: String?)
+
+internal fun mdbListHistoryPayload(changes: List<MdbListHistoryChange>): String = buildJsonObject {
+    val groups = changes.groupBy { change ->
+        when {
+            change.target.type == MdbListItemType.MOVIE -> "movies"
+            change.target.type == MdbListItemType.EPISODE &&
+                (change.target.episodeTmdbId != null || change.target.episodeTvdbId != null) -> "episodes"
+            else -> "shows"
+        }
+    }
+    groups.forEach { (group, items) ->
+        put(group, JsonArray(items.map { change ->
+            val target = change.target
+            buildJsonObject {
+                put("ids", if (group == "episodes") buildJsonObject {
+                    target.episodeTmdbId?.let { put("tmdb", it) }
+                    target.episodeTvdbId?.let { put("tvdb", it) }
+                } else target.media.ids.requestIds())
+                if (group == "shows" && target.type == MdbListItemType.EPISODE) {
+                    put("seasons", JsonArray(listOf(buildJsonObject {
+                        put("number", requireNotNull(target.season))
+                        put("episodes", JsonArray(listOf(buildJsonObject {
+                            put("number", requireNotNull(target.episode))
+                            change.watchedAt?.let { put("watched_at", it) }
+                        })))
+                    })))
+                } else change.watchedAt?.let { put("watched_at", it) }
+            }
+        }))
+    }
+}.toString()
+
+internal data class MdbListHistoryReceipt(
+    val confirmed: List<MdbListWatchedRecord>,
+    val complete: Boolean,
+    val needsSnapshot: Boolean,
+    val notFoundCount: Int
+)
+
+internal fun decodeMdbListHistoryReceipt(
+    body: String,
+    changes: List<MdbListHistoryChange>,
+    remove: Boolean
+): MdbListHistoryReceipt {
+    val payload = mdbListResponseElement(body).objectValue()
+    val counts = payload.objectValue(if (remove) "deleted" else "updated")
+        ?: (if (remove) payload.objectValue("removed") else null)
+        ?: throw MdbListDecodingException()
+    val failures = payload.objectValue("not_found")?.values.orEmpty().sumOf { value ->
+        when (value) {
+            is JsonArray -> value.size
+            else -> value.toString().toIntOrNull()?.coerceAtLeast(0) ?: throw MdbListDecodingException()
+        }
+    }
+    val errors = payload.arrayValue("errors").size
+    val complete = failures == 0 && errors == 0 && changes.groupingBy { it.target.type }.eachCount().all { (type, requested) ->
+        (counts.integer("${type.name.lowercase()}s") ?: 0) >= requested
+    }
+    val plays = if (remove) emptyList() else payload.arrayValue("plays").map { element -> decodePlay(element.objectValue(), changes) }
+    val confirmed = if (plays.isNotEmpty()) plays else if (complete && !remove) {
+        changes.filter { it.target.type != MdbListItemType.SHOW }.map { it.target.watched(requireNotNull(it.watchedAt)) }
+    } else emptyList()
+    val hasExpansion = changes.any { it.target.type == MdbListItemType.SHOW }
+    return MdbListHistoryReceipt(
+        confirmed = confirmed,
+        complete = complete,
+        needsSnapshot = !complete || hasExpansion || confirmed.size != changes.size && !remove,
+        notFoundCount = if (complete) 0 else maxOf(failures, errors, changes.size - confirmed.size, 1)
+    )
+}
+
+private fun decodePlay(row: JsonObject, changes: List<MdbListHistoryChange>): MdbListWatchedRecord {
+    val type = when (row.text("type")) {
+        "movie" -> MdbListItemType.MOVIE
+        "episode" -> MdbListItemType.EPISODE
+        else -> throw MdbListDecodingException()
+    }
+    val ids = decodeMdbListIds(if (type == MdbListItemType.MOVIE) row else row.objectValue("show") ?: throw MdbListDecodingException())
+    val season = if (type == MdbListItemType.EPISODE) row.integer("season")?.takeIf { it >= 0 } ?: throw MdbListDecodingException() else null
+    val episode = if (type == MdbListItemType.EPISODE) row.integer("number", "episode")?.takeIf { it > 0 } ?: throw MdbListDecodingException() else null
+    val record = MdbListWatchedRecord(
+        type, MdbListMedia(ids), row.timestamp("watched_at") ?: throw MdbListDecodingException(), season, episode,
+        episodeTmdbId = row.objectValue("ids")?.number("tmdb").takeIf { type == MdbListItemType.EPISODE },
+        episodeTvdbId = row.objectValue("ids")?.number("tvdb").takeIf { type == MdbListItemType.EPISODE }
+    )
+    val requested = changes.firstOrNull { it.target.matches(record) }?.target
+        ?: changes.firstOrNull { it.target.type == MdbListItemType.SHOW && it.target.media.ids.matches(ids) }?.target
+        ?: throw MdbListDecodingException()
+    return record.copy(media = record.media.merged(requested.media), episodeTitle = requested.episodeTitle)
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHistoryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHistoryService.kt
@@ -1,0 +1,74 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingHistoryItem
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import com.nuvio.tv.core.tracking.TrackingMutationResult
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MdbListHistoryService @Inject constructor(
+    private val api: MdbListApiClient,
+    private val sync: MdbListSyncRepository
+) {
+    suspend fun add(scope: MdbListAuthScope, items: Collection<TrackingHistoryItem>): TrackingMutationResult =
+        change(scope, items.toList(), remove = false)
+
+    suspend fun remove(scope: MdbListAuthScope, items: Collection<TrackingMediaReference>): TrackingMutationResult =
+        change(scope, items.map { TrackingHistoryItem(it) }, remove = true)
+
+    private suspend fun change(
+        scope: MdbListAuthScope,
+        items: List<TrackingHistoryItem>,
+        remove: Boolean
+    ): TrackingMutationResult {
+        var failed = 0
+        val resolvable = items.filter { item -> item.media.ids.toMdbListIds() != null }
+        failed += items.size - resolvable.size
+        for (batch in resolvable.chunked(100)) {
+            val result = sync.write(scope, setOf(MdbListSyncBucket.WATCHED)) { snapshot ->
+                val mapped = batch.mapNotNull { item ->
+                    snapshot.mutationTarget(item.media)?.let { target ->
+                        MdbListHistoryChange(target, if (remove) null else Instant.ofEpochMilli(
+                            item.watchedAtEpochMs ?: System.currentTimeMillis()
+                        ).toString())
+                    }
+                }
+                val changes = mapped.distinctBy { it.target.key }
+                if (changes.isEmpty()) return@write snapshot to TrackingMutationResult(batch.size, batch.size)
+                val response = api.post(
+                    if (remove) "/sync/watched/remove" else "/sync/watched",
+                    mdbListHistoryPayload(changes), scope,
+                    query = if (remove) emptyMap() else mapOf("report_added" to "true")
+                )
+                val receipt = decodeMdbListHistoryReceipt(response.body, changes, remove)
+                val watched = if (remove && receipt.complete) {
+                    snapshot.watched.filterNot { record -> changes.any { change ->
+                        change.target.matches(record) || change.target.type == MdbListItemType.SHOW &&
+                            record.type != MdbListItemType.MOVIE && change.target.media.ids.matches(record.media.ids)
+                    } }
+                } else {
+                    val confirmedTargets = receipt.confirmed.map { record ->
+                        MdbListMutationTarget(record.type, record.media, record.season, record.episode,
+                            record.episodeTitle, record.episodeTmdbId, record.episodeTvdbId)
+                    }
+                    snapshot.watched.filterNot { record -> confirmedTargets.any { it.matches(record) } } + receipt.confirmed
+                }
+                val next = snapshot.copy(
+                    watched = watched,
+                    invalidatedBuckets = snapshot.invalidatedBuckets +
+                        if (receipt.needsSnapshot) setOf(MdbListSyncBucket.WATCHED) else emptySet()
+                ).normalizeMedia()
+                next to TrackingMutationResult(
+                    attemptedCount = batch.size,
+                    notFoundCount = (batch.size - mapped.size + receipt.notFoundCount).coerceAtMost(batch.size)
+                )
+            }
+            failed += result.notFoundCount
+        }
+        if (sync.currentSnapshot()?.invalidatedBuckets?.isNotEmpty() == true) sync.refreshAsync(TrackingRefreshIntent.INVALIDATED)
+        return TrackingMutationResult(items.size, failed)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpClient.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpClient.kt
@@ -1,0 +1,77 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class MdbListHttpClient(
+    private val engine: MdbListHttpEngine,
+    private val nowEpochMs: () -> Long = System::currentTimeMillis,
+    private val sleep: suspend (Long) -> Unit = { delay(it) }
+) {
+    private val mutex = Mutex()
+    private val blockedUntil = mutableMapOf<String, Long>()
+
+    suspend fun associateAccountLimit(previousKey: String, accountKey: String) = mutex.withLock {
+        blockedUntil.remove(previousKey)?.let { until ->
+            blockedUntil[accountKey] = maxOf(until, blockedUntil[accountKey] ?: 0L)
+        }
+    }
+
+    suspend fun execute(
+        request: MdbListHttpRequest,
+        checkScope: () -> Unit = {}
+    ): MdbListHttpResponse = mutex.withLock {
+        val attempts = if (request.retrySafe) 3 else 1
+        repeat(attempts) { attempt ->
+            checkScope()
+            val now = nowEpochMs()
+            blockedUntil.entries.removeAll { it.value <= now }
+            blockedUntil[request.limitKey]?.let { reset ->
+                throw MdbListApiException(429, "rate_limited", reset)
+            }
+            val response = try {
+                engine.execute(request)
+            } catch (_: IOException) {
+                checkScope()
+                if (attempt == attempts - 1) throw MdbListApiException(code = "transport_failure")
+                sleep(1_000L shl attempt)
+                return@repeat
+            }
+            checkScope()
+            val retryAt = response.header("Retry-After")?.let { retryAfterEpochMs(it, nowEpochMs()) }
+            if (response.status == 429 || response.header("X-RateLimit-Remaining")?.toLongOrNull() == 0L) {
+                val reset = response.header("X-RateLimit-Reset")?.toLongOrNull()
+                    ?.takeIf { it in 1..Long.MAX_VALUE / 1_000L }?.times(1_000L)
+                blockedUntil[request.limitKey] = maxOf(
+                    nowEpochMs() + 1_000L,
+                    retryAt ?: reset ?: (nowEpochMs() + 60_000L),
+                    reset ?: 0L
+                )
+            }
+            if (response.status == 429) {
+                throw MdbListApiException(429, "rate_limited", blockedUntil[request.limitKey])
+            }
+            if (request.retrySafe && response.status in setOf(500, 502, 503, 504) && attempt < attempts - 1) {
+                val wait = maxOf(1_000L shl attempt, (retryAt ?: 0L) - nowEpochMs())
+                if (wait > 5_000L) throw MdbListApiException(response.status, retryAtEpochMs = retryAt)
+                sleep(wait)
+            } else {
+                return@withLock response
+            }
+        }
+        throw MdbListApiException(code = "request_failed")
+    }
+}
+
+internal fun retryAfterEpochMs(value: String, now: Long): Long? {
+    val seconds = value.trim().toLongOrNull()
+    if (seconds != null) return seconds.takeIf { it >= 0L && it <= (Long.MAX_VALUE - now) / 1_000L }
+        ?.let { now + it * 1_000L }
+    return runCatching {
+        ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant().toEpochMilli()
+    }.getOrNull()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpModels.kt
@@ -1,0 +1,52 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+data class MdbListConfiguration(
+    val clientId: String,
+    val appVersion: String,
+    val baseUrl: String = "https://api.mdblist.com"
+)
+
+enum class MdbListHttpMethod { GET, POST }
+
+class MdbListHttpRequest(
+    val method: MdbListHttpMethod,
+    val path: String,
+    val query: Map<String, String> = emptyMap(),
+    val body: String = "",
+    val form: Map<String, String>? = null,
+    val accessToken: String? = null,
+    val limitKey: String = "public",
+    val retrySafe: Boolean = method == MdbListHttpMethod.GET
+) {
+    override fun toString(): String = "MdbListHttpRequest(method=$method)"
+}
+
+class MdbListHttpResponse(
+    val status: Int,
+    val body: String,
+    val headers: Map<String, String> = emptyMap()
+) {
+    fun header(name: String): String? = headers.entries
+        .firstOrNull { it.key.equals(name, ignoreCase = true) }?.value
+
+    fun errorCode(): String? = runCatching {
+        (Json.parseToJsonElement(body) as? JsonObject)?.get("error")?.jsonPrimitive?.contentOrNull
+    }.getOrNull()?.takeIf { it.matches(Regex("[a-z_]{1,64}")) }
+
+    override fun toString(): String = "MdbListHttpResponse(status=$status)"
+}
+
+class MdbListApiException(
+    val status: Int? = null,
+    val code: String? = null,
+    val retryAtEpochMs: Long? = null
+) : Exception("MDBList request failed${status?.let { " (HTTP $it)" }.orEmpty()}")
+
+fun interface MdbListHttpEngine {
+    suspend fun execute(request: MdbListHttpRequest): MdbListHttpResponse
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListHttpModels.kt
@@ -11,7 +11,7 @@ data class MdbListConfiguration(
     val baseUrl: String = "https://api.mdblist.com"
 )
 
-enum class MdbListHttpMethod { GET, POST }
+enum class MdbListHttpMethod { GET, POST, PUT, DELETE }
 
 class MdbListHttpRequest(
     val method: MdbListHttpMethod,

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryDecoder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryDecoder.kt
@@ -1,0 +1,79 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+
+internal fun decodeMdbListLibraryLists(body: String, accountId: Long): List<MdbListLibraryList> {
+    val rows = mdbListResponseElement(body) as? JsonArray ?: throw MdbListDecodingException()
+    return rows.mapNotNull { element ->
+        val row = element.objectValue()
+        if (row.text("type") != "static" || row.flag("dynamic") == true ||
+            row.number("user_id")?.let { it != accountId } == true) return@mapNotNull null
+        val mediaType = row.text("mediatype")?.let(::mdbListLibraryType)
+        if (row.text("mediatype") != null && mediaType == null) return@mapNotNull null
+        val id = row.number("id") ?: row.arrayValue("ids").singleOrNull()
+            ?.let { (it as? JsonPrimitive)?.contentOrNull?.toLongOrNull() }
+        MdbListLibraryList(
+            id = id?.takeIf { it > 0 } ?: throw MdbListDecodingException(),
+            name = row.text("name") ?: throw MdbListDecodingException(),
+            private = row.flag("private") ?: throw MdbListDecodingException(),
+            description = row.text("description"),
+            mediaType = mediaType,
+            updatedAt = row.text("last_updated_at", "updated_at", "updated")
+        )
+    }.also { lists -> if (lists.map { it.id }.toSet().size != lists.size) throw MdbListDecodingException() }
+}
+
+internal fun decodeMdbListLibraryPage(body: String): MdbListPage<MdbListLibraryItem> {
+    val root = mdbListResponseElement(body)
+    if (root is JsonArray) return MdbListPage(root.mapNotNull { decodeLibraryItem(it.objectValue()) })
+    val value = root.objectValue()
+    val items = if (value["items"] is JsonArray) {
+        value.arrayValue("items").mapNotNull { decodeLibraryItem(it.objectValue()) }
+    } else {
+        if (listOf("movies", "shows", "seasons", "episodes").none(value::containsKey)) throw MdbListDecodingException()
+        value.arrayValue("movies").mapNotNull { decodeLibraryItem(it.objectValue(), MdbListItemType.MOVIE) } +
+            value.arrayValue("shows").mapNotNull { decodeLibraryItem(it.objectValue(), MdbListItemType.SHOW) }
+    }
+    return mdbListPage(value, items)
+}
+
+private fun decodeLibraryItem(row: JsonObject, bucket: MdbListItemType? = null): MdbListLibraryItem? {
+    val declaredType = row.text("mediatype", "type")
+    val type = declaredType?.let(::mdbListLibraryType) ?: bucket
+    if (declaredType in listOf("season", "episode")) return null
+    if (type == null || declaredType != null && mdbListLibraryType(declaredType) == null || bucket != null && type != bucket) throw MdbListDecodingException()
+    val nested = row.objectValue("ids")
+    val ids = decodeMdbListIds(buildJsonObject {
+        row.number("id")?.let { put("tmdb", it) }
+        row.text("imdb_id")?.let { put("imdb", it) }
+        row.number("tvdb_id")?.let { put("tvdb", it) }
+        nested?.forEach { (key, value) -> if (value != kotlinx.serialization.json.JsonNull) put(key, value) }
+    })
+    return MdbListLibraryItem(
+        type = type,
+        media = MdbListMedia(
+            ids = ids,
+            title = row.text("title", "name"),
+            year = row.integer("release_year", "year"),
+            poster = mdbListImageUrl(row.text("poster"), "w500"),
+            backdrop = mdbListImageUrl(row.text("backdrop", "background"), "w1280")
+        ),
+        description = row.text("description", "overview"),
+        genres = row.arrayValue("genres").mapNotNull {
+            (it as? JsonPrimitive)?.contentOrNull ?: (it as? JsonObject)?.text("name", "slug")
+        }.distinct(),
+        listedAt = row.timestamp("listed_at", "added_at")?.let(::mdbListTimestamp) ?: 0,
+        rank = row.integer("rank")?.takeIf { it > 0 }
+    )
+}
+
+internal fun mdbListLibraryType(type: String): MdbListItemType? = when (type.lowercase()) {
+    "movie" -> MdbListItemType.MOVIE
+    "show", "series", "tv", "anime" -> MdbListItemType.SHOW
+    else -> null
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryModels.kt
@@ -1,0 +1,62 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.LibraryListTab
+import kotlinx.serialization.Serializable
+
+internal const val MDBLIST_WATCHLIST_KEY = "mdblist:watchlist"
+internal const val MDBLIST_LIST_KEY_PREFIX = "mdblist:list:"
+
+@Serializable
+data class MdbListLibraryList(
+    val id: Long,
+    val name: String,
+    val private: Boolean,
+    val description: String? = null,
+    val mediaType: MdbListItemType? = null,
+    val updatedAt: String? = null
+) {
+    val key: String get() = "$MDBLIST_LIST_KEY_PREFIX$id"
+
+    fun tab() = LibraryListTab(
+        key = key,
+        title = name,
+        type = LibraryListTab.Type.PERSONAL,
+        privacy = if (private) LibraryListPrivacy.PRIVATE else LibraryListPrivacy.PUBLIC,
+        description = description,
+        trackingProviderId = "mdblist",
+        supportedContentTypes = when (mediaType) {
+            MdbListItemType.MOVIE -> setOf("movie")
+            MdbListItemType.SHOW -> setOf("series")
+            else -> setOf("movie", "series")
+        }
+    )
+}
+
+@Serializable
+data class MdbListLibraryItem(
+    val type: MdbListItemType,
+    val media: MdbListMedia,
+    val description: String? = null,
+    val genres: List<String> = emptyList(),
+    val listedAt: Long = 0,
+    val rank: Int? = null
+) {
+    val key: String get() = "$type:${media.ids.key}"
+    fun matches(other: MdbListLibraryItem): Boolean = type == other.type && media.ids.matches(other.media.ids)
+}
+
+@Serializable
+data class MdbListLibrarySnapshot(
+    val lists: List<MdbListLibraryList> = emptyList(),
+    val itemsByList: Map<String, List<MdbListLibraryItem>> = emptyMap(),
+    val checkedAtEpochMs: Long? = null,
+    val invalidated: Boolean = false
+) {
+    fun tabs(): List<LibraryListTab> = listOf(
+        LibraryListTab(
+            MDBLIST_WATCHLIST_KEY, "Watchlist", LibraryListTab.Type.WATCHLIST,
+            trackingProviderId = "mdblist", supportedContentTypes = setOf("movie", "series")
+        )
+    ) + lists.map(MdbListLibraryList::tab)
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryMutation.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryMutation.kt
@@ -1,0 +1,50 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal fun LibraryEntryInput.mdbListLibraryItem(): MdbListLibraryItem {
+    val type = requireNotNull(mdbListLibraryType(itemType)) { "MDBList lists support movies and shows" }
+    val ids = decodeMdbListIds(buildJsonObject {
+        when {
+            itemId.startsWith("tt") -> put("imdb", itemId)
+            itemId.startsWith("imdb:") -> put("imdb", itemId.removePrefix("imdb:"))
+            itemId.startsWith("tmdb:") -> put("tmdb", itemId.removePrefix("tmdb:"))
+            itemId.startsWith("tvdb:") -> put("tvdb", itemId.removePrefix("tvdb:"))
+            itemId.startsWith("trakt:") -> put("trakt", itemId.removePrefix("trakt:"))
+        }
+        imdbId?.let { put("imdb", it) }
+        tmdbId?.let { put("tmdb", it) }
+        traktId?.let { put("trakt", it) }
+    })
+    return MdbListLibraryItem(type, MdbListMedia(ids, title, year, poster, background), description, genres)
+}
+
+internal fun MdbListLibraryItem.membershipBody(watchlist: Boolean): String {
+    val ids = buildJsonObject {
+        media.ids.imdb?.let { put("imdb", it) }
+        media.ids.tmdb?.let { put("tmdb", it) }
+        media.ids.tvdb?.let { put("tvdb", it) }
+        media.ids.trakt?.let { put("trakt", it) }
+    }
+    require(ids.isNotEmpty()) { "An external movie or show ID is required" }
+    return buildJsonObject {
+        put(if (type == MdbListItemType.MOVIE) "movies" else "shows", JsonArray(listOf(
+            if (watchlist) buildJsonObject { put("ids", ids) } else ids
+        )))
+    }.toString()
+}
+
+internal fun verifyMdbListMembershipResponse(body: String, type: MdbListItemType, adding: Boolean) {
+    val value = mdbListResponseElement(body).objectValue()
+    val bucket = if (type == MdbListItemType.MOVIE) "movies" else "shows"
+    fun count(key: String): Long? = (value[key] as? JsonObject)?.number(bucket) ?: value.number(key)
+    val changed = count(if (adding) "added" else "removed") ?: throw MdbListDecodingException()
+    val unchanged = count(if (adding) "existing" else "not_found") ?: 0
+    if (changed < 0 || unchanged < 0 || changed + unchanged != 1L || adding && (count("not_found") ?: 0) != 0L) {
+        throw MdbListDecodingException()
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryProjection.kt
@@ -1,0 +1,49 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.domain.model.LibraryEntry
+
+internal class MdbListLibraryProjection(snapshot: MdbListLibrarySnapshot) {
+    val entries: List<LibraryEntry>
+    private val memberships = mutableMapOf<Pair<MdbListItemType, String>, Set<String>>()
+
+    init {
+        val index = MdbListMediaIndex(MdbListSyncSnapshot(0))
+        snapshot.itemsByList.values.flatten().forEach { index.add(it.type, it.media) }
+        val combined = linkedMapOf<String, LibraryEntry>()
+        snapshot.itemsByList.forEach { (listKey, items) ->
+            items.forEach { item ->
+                val media = index.resolve(item.type, item.media.ids)
+                val key = "${item.type}:${media.ids.key}"
+                val previous = combined[key]
+                val listKeys = previous?.listKeys.orEmpty() + listKey
+                val ranks = previous?.listRanks.orEmpty() + listOfNotNull(item.rank?.let { listKey to it }).toMap()
+                combined[key] = LibraryEntry(
+                    id = media.ids.contentId,
+                    type = if (item.type == MdbListItemType.MOVIE) "movie" else "series",
+                    name = media.title ?: media.ids.contentId,
+                    poster = media.poster,
+                    background = media.backdrop,
+                    logo = null,
+                    description = previous?.description ?: item.description,
+                    releaseInfo = media.year?.toString(),
+                    imdbRating = null,
+                    genres = (previous?.genres.orEmpty() + item.genres).distinct(),
+                    addonBaseUrl = null,
+                    listKeys = listKeys,
+                    listRanks = ranks,
+                    listedAt = maxOf(previous?.listedAt ?: 0, item.listedAt),
+                    imdbId = media.ids.imdb,
+                    tmdbId = media.ids.tmdb?.takeIf { it <= Int.MAX_VALUE }?.toInt(),
+                    traktId = media.ids.trakt?.takeIf { it <= Int.MAX_VALUE }?.toInt(),
+                    trackingProviderId = "mdblist",
+                    trackingProviderItemId = media.ids.mdblist,
+                    trackingSourceUrl = media.ids.mdblist?.let { "https://mdblist.com/${if (item.type == MdbListItemType.MOVIE) "movie" else "show"}/$it" }
+                )
+                media.ids.aliases().forEach { alias -> memberships[item.type to alias] = listKeys }
+            }
+        }
+        entries = combined.values.toList()
+    }
+
+    fun membership(id: String, type: String): Set<String> = memberships[mdbListLibraryType(type) to id].orEmpty()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryRemote.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryRemote.kt
@@ -1,0 +1,45 @@
+package com.nuvio.tv.data.mdblist
+
+internal class MdbListLibraryRemote(private val api: MdbListApiClient, private val scope: MdbListAuthScope) {
+    suspend fun synchronize(previous: MdbListLibrarySnapshot?, accountId: Long, now: Long): MdbListLibrarySnapshot {
+        val lists = decodeMdbListLibraryLists(api.get("/lists/user", mapOf("unified" to "false", "sort" to "ranked"), scope).body, accountId)
+        val items = linkedMapOf(MDBLIST_WATCHLIST_KEY to items(MDBLIST_WATCHLIST_KEY))
+        val previousLists = previous?.lists.orEmpty().associateBy { it.id }
+        for (list in lists) {
+            val cached = previous?.itemsByList?.get(list.key)
+            val unchanged = previous?.invalidated != true && list.updatedAt != null &&
+                previousLists[list.id]?.updatedAt == list.updatedAt
+            items[list.key] = if (unchanged && cached != null) cached else items(list.key)
+        }
+        return MdbListLibrarySnapshot(lists, items, now)
+    }
+
+    suspend fun items(key: String): List<MdbListLibraryItem> {
+        val path = mdbListLibraryItemsPath(key)
+        val initial = mapOf("limit" to "1000", "sort" to "rank", "order" to "asc", "append_to_response" to "poster,description,genres")
+        var query = initial
+        val visited = mutableSetOf<Map<String, String>>()
+        val items = mutableListOf<MdbListLibraryItem>()
+        repeat(1_000) {
+            if (!visited.add(query)) throw MdbListDecodingException()
+            val response = api.get(path, query, scope)
+            val page = decodeMdbListLibraryPage(response.body)
+            items += page.items
+            query = when {
+                page.nextCursor != null -> initial + ("cursor" to page.nextCursor)
+                page.nextOffset != null -> initial + ("offset" to page.nextOffset.toString())
+                response.header("X-Has-More").equals("true", ignoreCase = true) -> throw MdbListDecodingException()
+                else -> return items.distinctBy { it.key }
+            }
+        }
+        throw MdbListDecodingException()
+    }
+}
+
+internal fun mdbListLibraryItemsPath(key: String): String =
+    if (key == MDBLIST_WATCHLIST_KEY) "/watchlist/items" else "/lists/${mdbListPersonalListId(key)}/items"
+
+internal fun mdbListPersonalListId(key: String): Long {
+    require(key.startsWith(MDBLIST_LIST_KEY_PREFIX)) { "Invalid MDBList list" }
+    return requireNotNull(key.removePrefix(MDBLIST_LIST_KEY_PREFIX).toLongOrNull()?.takeIf { it > 0 }) { "Invalid MDBList list" }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryService.kt
@@ -1,0 +1,114 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingListManager
+import com.nuvio.tv.core.tracking.TrackingRefreshGate
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.ListMembershipChanges
+import com.nuvio.tv.domain.model.ListMembershipSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+
+class MdbListLibraryService(
+    private val api: MdbListApiClient,
+    private val sync: MdbListSyncRepository,
+    auth: MdbListAuthStore,
+    activeProfileId: StateFlow<Int>,
+    private val coroutineScope: CoroutineScope,
+    private val now: () -> Long = System::currentTimeMillis
+) {
+    private val writer = MdbListLibraryWriter(api, sync, now)
+    val listManager: TrackingListManager = writer
+    private val refreshGate = TrackingRefreshGate()
+    private val loadState = MutableStateFlow(LibraryLoadState())
+    private val snapshots = combine(sync.state, auth.state, activeProfileId) { state, authorization, profileId ->
+        state.snapshot?.library?.takeIf {
+            authorization.isAuthenticated && state.scope == authorization.scope && state.scope.profileId == profileId
+        }
+    }.distinctUntilChanged().onEach { refreshAsync() }
+    private val projection = snapshots.map { MdbListLibraryProjection(it ?: MdbListLibrarySnapshot()) }
+
+    val items = projection.map { it.entries }.onStart { refreshAsync() }.distinctUntilChanged()
+    val tabs = snapshots.map { it?.tabs().orEmpty() }.onStart { refreshAsync() }.distinctUntilChanged()
+    val isRefreshing = combine(loadState, auth.state, activeProfileId) { state, authorization, profileId ->
+        state.refreshing && state.scope == authorization.scope && authorization.isAuthenticated && state.scope.profileId == profileId
+    }.distinctUntilChanged()
+
+    fun observeMembership(id: String, type: String) = projection.map { it.membership(id, type) }.distinctUntilChanged()
+
+    suspend fun getMembershipSnapshot(input: LibraryEntryInput): ListMembershipSnapshot {
+        val scope = sync.currentScope()
+        refresh(TrackingRefreshIntent.AUTOMATIC)
+        if (sync.currentScope() != scope) throw CancellationException("MDBList account changed")
+        val library = sync.currentSnapshot()?.library ?: throw loadState.value.error ?: MdbListDecodingException()
+        val target = runCatching { input.mdbListLibraryItem() }.getOrNull()
+        return ListMembershipSnapshot(library.tabs().associate { tab ->
+            tab.key to library.itemsByList[tab.key].orEmpty().any { item ->
+                target?.matches(item) == true || item.type == mdbListLibraryType(input.itemType) && input.itemId in item.media.ids.aliases()
+            }
+        })
+    }
+
+    suspend fun applyMembershipChanges(input: LibraryEntryInput, changes: ListMembershipChanges) {
+        val scope = sync.currentScope()
+        refresh(TrackingRefreshIntent.AUTOMATIC)
+        writer.applyMembershipChanges(scope, input, changes)
+    }
+
+    suspend fun refresh(intent: TrackingRefreshIntent) {
+        val scope = try {
+            sync.currentScope()
+        } catch (error: Exception) {
+            if (intent != TrackingRefreshIntent.AUTOMATIC) throw error
+            return
+        }
+        refreshGate.runIfNeeded(scope.generation, { shouldRefresh(scope, intent) }) {
+            try {
+                sync.ensureLoaded()
+                if (!shouldRefresh(scope, intent)) return@runIfNeeded
+                loadState.value = LibraryLoadState(scope, refreshing = true, attemptedAt = now())
+                sync.mutate(scope) { previous ->
+                    val library = MdbListLibraryRemote(api, scope).synchronize(previous.library, previous.accountId, now())
+                    previous.copy(library = library) to Unit
+                }
+                loadState.value = LibraryLoadState(scope)
+            } catch (error: CancellationException) {
+                loadState.value = LibraryLoadState(scope)
+                throw error
+            } catch (error: Exception) {
+                loadState.value = LibraryLoadState(scope, error = error, attemptedAt = now())
+            }
+        }
+        if (intent != TrackingRefreshIntent.AUTOMATIC) loadState.value.takeIf { it.scope == scope }?.error?.let { throw it }
+    }
+
+    private fun refreshAsync() {
+        coroutineScope.launch { refresh(TrackingRefreshIntent.AUTOMATIC) }
+    }
+
+    private fun shouldRefresh(scope: MdbListAuthScope, intent: TrackingRefreshIntent): Boolean {
+        if (runCatching { sync.currentScope() }.getOrNull() != scope) return false
+        val state = loadState.value.takeIf { it.scope == scope }
+        val time = now()
+        if ((state?.error as? MdbListApiException)?.retryAtEpochMs?.let { it > time } == true) return false
+        if (intent != TrackingRefreshIntent.AUTOMATIC) return true
+        if (state?.error != null && time - state.attemptedAt in 0 until MdbListSyncRepository.ERROR_RETRY_MS) return false
+        val library = sync.currentSnapshot()?.library ?: return true
+        return library.invalidated || library.checkedAtEpochMs?.let { time - it !in 0 until MdbListSyncRepository.AUTOMATIC_INTERVAL_MS } != false
+    }
+
+    private data class LibraryLoadState(
+        val scope: MdbListAuthScope? = null,
+        val refreshing: Boolean = false,
+        val error: Exception? = null,
+        val attemptedAt: Long = 0
+    )
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryWriter.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListLibraryWriter.kt
@@ -1,0 +1,114 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
+import com.nuvio.tv.core.tracking.TrackingListManager
+import com.nuvio.tv.core.tracking.supportsMembershipFor
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.ListMembershipChanges
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal class MdbListLibraryWriter(
+    private val api: MdbListApiClient,
+    private val sync: MdbListSyncRepository,
+    private val now: () -> Long
+) : TrackingListManager {
+    override val capabilities = TrackingListManagementCapabilities(
+        privacyOptions = listOf(LibraryListPrivacy.PRIVATE, LibraryListPrivacy.PUBLIC)
+    )
+
+    override suspend fun createList(name: String, description: String?, privacy: LibraryListPrivacy) {
+        val body = metadataBody(name, description, privacy)
+        val scope = sync.currentScope()
+        write(scope) { library ->
+            val response = mdbListResponseElement(api.post("/lists/user/add", body, scope).body).objectValue()
+            val id = response.number("id")?.takeIf { it > 0 } ?: throw MdbListDecodingException()
+            val created = MdbListLibraryList(id, response.text("name") ?: name.trim(), privacy == LibraryListPrivacy.PRIVATE)
+            library.copy(lists = library.lists.filterNot { it.id == id } + created,
+                itemsByList = library.itemsByList + (created.key to emptyList()))
+        }
+    }
+
+    override suspend fun updateList(key: String, name: String, description: String?, privacy: LibraryListPrivacy) {
+        val body = metadataBody(name, description, privacy)
+        val id = mdbListPersonalListId(key)
+        val scope = sync.currentScope()
+        write(scope) { library ->
+            require(library.lists.any { it.id == id }) { "This static list is no longer available" }
+            val response = mdbListResponseElement(api.put("/lists/$id", body, scope).body).objectValue()
+            if (response.flag("success") != true || response.number("id") != id) throw MdbListDecodingException()
+            library.copy(lists = library.lists.map { list ->
+                if (list.id != id) list else list.copy(name = response.text("name") ?: name.trim(),
+                    private = response.flag("private") ?: (privacy == LibraryListPrivacy.PRIVATE))
+            })
+        }
+    }
+
+    override suspend fun deleteList(key: String) {
+        val id = mdbListPersonalListId(key)
+        val scope = sync.currentScope()
+        write(scope) { library ->
+            require(library.lists.any { it.id == id }) { "This static list is no longer available" }
+            val response = api.delete("/lists/$id", scope)
+            if (response.status != 204) {
+                val body = mdbListResponseElement(response.body).objectValue()
+                if (body.flag("success") != true || body.number("id") != id) throw MdbListDecodingException()
+            }
+            library.copy(lists = library.lists.filterNot { it.id == id }, itemsByList = library.itemsByList - key)
+        }
+    }
+
+    suspend fun applyMembershipChanges(scope: MdbListAuthScope, input: LibraryEntryInput, changes: ListMembershipChanges) {
+        val suppliedTarget = runCatching { input.mdbListLibraryItem() }.getOrNull()
+        for ((key, desired) in changes.desiredMembership) {
+            mdbListLibraryItemsPath(key)
+            write(scope) { library ->
+                val tab = library.tabs().firstOrNull { it.key == key }
+                require(tab != null) { "This list is no longer available" }
+                if (!desired && !tab.supportsMembershipFor(input.itemType)) return@write library
+                require(tab.supportsMembershipFor(input.itemType)) { "This list does not accept this item" }
+                val current = library.itemsByList[key].orEmpty()
+                val resolved = suppliedTarget ?: current.firstOrNull {
+                    it.type == mdbListLibraryType(input.itemType) && input.itemId in it.media.ids.aliases()
+                }
+                if (resolved == null && !desired) return@write library
+                val target = requireNotNull(resolved) { "An external movie or show ID is required" }
+                if (current.any(target::matches) == desired) return@write library
+                val action = if (desired) "add" else "remove"
+                val response = api.post("${mdbListLibraryItemsPath(key)}/$action", target.membershipBody(key == MDBLIST_WATCHLIST_KEY), scope)
+                verifyMdbListMembershipResponse(response.body, target.type, desired)
+                val items = current.filterNot(target::matches) + if (desired) listOf(target.copy(
+                    listedAt = now(), rank = (current.mapNotNull { it.rank }.maxOrNull() ?: 0) + 1
+                )) else emptyList()
+                library.copy(itemsByList = library.itemsByList + (key to items))
+            }
+        }
+    }
+
+    private fun metadataBody(name: String, description: String?, privacy: LibraryListPrivacy): String {
+        require(name.isNotBlank()) { "Enter a list name" }
+        require(description.isNullOrBlank()) { "MDBList does not support editing list descriptions" }
+        require(privacy in capabilities.privacyOptions) { "MDBList supports private and public lists" }
+        return buildJsonObject { put("name", name.trim()); put("private", privacy == LibraryListPrivacy.PRIVATE) }.toString()
+    }
+
+    private suspend fun write(scope: MdbListAuthScope, update: suspend (MdbListLibrarySnapshot) -> MdbListLibrarySnapshot) {
+        try {
+            sync.mutate(scope) { previous ->
+                val library = previous.library ?: MdbListLibraryRemote(api, scope).synchronize(null, previous.accountId, now())
+                previous.copy(library = update(library)) to Unit
+            }
+        } catch (error: Exception) {
+            withContext(NonCancellable) {
+                try {
+                    sync.mutate(scope) { previous -> previous.copy(library = previous.library?.copy(invalidated = true)) to Unit }
+                } catch (_: Exception) {
+                }
+            }
+            throw error
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMediaIndex.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMediaIndex.kt
@@ -1,0 +1,34 @@
+package com.nuvio.tv.data.mdblist
+
+internal class MdbListMediaIndex(snapshot: MdbListSyncSnapshot) {
+    private val byAlias = mutableMapOf<Pair<Boolean, String>, MdbListMedia>()
+
+    init {
+        snapshot.watched.forEach { add(it.type, it.media) }
+        snapshot.playback.forEach { add(it.type, it.media) }
+    }
+
+    fun add(type: MdbListItemType, media: MdbListMedia): MdbListMedia {
+        val movie = type == MdbListItemType.MOVIE
+        val merged = media.ids.aliases().mapNotNull { byAlias[movie to it] }
+            .fold(media, MdbListMedia::merged)
+        merged.ids.aliases().forEach { byAlias[movie to it] = merged }
+        return merged
+    }
+
+    fun resolve(type: MdbListItemType, ids: MdbListIds): MdbListMedia =
+        ids.aliases().firstNotNullOfOrNull { byAlias[(type == MdbListItemType.MOVIE) to it] }
+            ?.let { it.copy(ids = it.ids.merged(ids)) } ?: MdbListMedia(ids)
+}
+
+internal fun MdbListSyncSnapshot.normalizeMedia(): MdbListSyncSnapshot {
+    val index = MdbListMediaIndex(this)
+    return copy(
+        watched = watched.map { it.copy(media = index.resolve(it.type, it.media.ids)) }
+            .groupBy(MdbListWatchedRecord::key)
+            .map { (_, records) -> records.maxBy { mdbListTimestamp(it.watchedAt) } },
+        playback = playback.map { it.copy(media = index.resolve(it.type, it.media.ids)) }
+            .groupBy(MdbListPlayback::id)
+            .map { (_, records) -> records.maxBy { mdbListTimestamp(it.updatedAt) } }
+    )
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMediaIndex.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMediaIndex.kt
@@ -28,7 +28,7 @@ internal fun MdbListSyncSnapshot.normalizeMedia(): MdbListSyncSnapshot {
             .groupBy(MdbListWatchedRecord::key)
             .map { (_, records) -> records.maxBy { mdbListTimestamp(it.watchedAt) } },
         playback = playback.map { it.copy(media = index.resolve(it.type, it.media.ids)) }
-            .groupBy(MdbListPlayback::id)
+            .groupBy { it.id?.let { id -> "id:$id" } ?: "${it.type}:${it.media.ids.key}:${it.season}:${it.episode}" }
             .map { (_, records) -> records.maxBy { mdbListTimestamp(it.updatedAt) } }
     )
 }

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMutationTarget.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMutationTarget.kt
@@ -3,6 +3,8 @@ package com.nuvio.tv.data.mdblist
 import com.nuvio.tv.core.tracking.TrackingExternalIds
 import com.nuvio.tv.core.tracking.TrackingMediaKind
 import com.nuvio.tv.core.tracking.TrackingMediaReference
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -42,7 +44,10 @@ internal data class MdbListMutationTarget(
                 put("episode", requireNotNull(episode))
             }
         })
-        progress?.let { require(it.isFinite() && it in 0.0..100.0); put("progress", it) }
+        progress?.let {
+            require(it.isFinite() && it in 0.0..100.0)
+            put("progress", BigDecimal.valueOf(it).setScale(2, RoundingMode.DOWN).toDouble())
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMutationTarget.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListMutationTarget.kt
@@ -1,0 +1,87 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingMediaKind
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal data class MdbListMutationTarget(
+    val type: MdbListItemType,
+    val media: MdbListMedia,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val episodeTitle: String? = null,
+    val episodeTmdbId: Long? = null,
+    val episodeTvdbId: Long? = null,
+    val scrobbleCoordinatesResolved: Boolean = true
+) {
+    val key: String
+        get() = "$type:${media.ids.key}:${season ?: -1}:${episode ?: -1}"
+
+    fun matches(record: MdbListWatchedRecord): Boolean = record.type == type &&
+        media.ids.matches(record.media.ids) && (type != MdbListItemType.EPISODE ||
+        (episodeTmdbId != null && episodeTmdbId == record.episodeTmdbId) ||
+        (episodeTvdbId != null && episodeTvdbId == record.episodeTvdbId) ||
+        (season == record.season && episode == record.episode))
+
+    fun matches(record: MdbListPlayback): Boolean = record.type == type &&
+        media.ids.matches(record.media.ids) && season == record.season && episode == record.episode
+
+    fun watched(at: String) = MdbListWatchedRecord(
+        type, media, at, season, episode, episodeTitle, episodeTmdbId, episodeTvdbId
+    )
+
+    fun scrobbleBody(progress: Double? = null): JsonObject = buildJsonObject {
+        require(type == MdbListItemType.MOVIE || type == MdbListItemType.EPISODE && scrobbleCoordinatesResolved)
+        put(if (type == MdbListItemType.MOVIE) "movie" else "show", buildJsonObject {
+            put("ids", media.ids.requestIds())
+            if (type == MdbListItemType.EPISODE) {
+                put("season", requireNotNull(season))
+                put("episode", requireNotNull(episode))
+            }
+        })
+        progress?.let { require(it.isFinite() && it in 0.0..100.0); put("progress", it) }
+    }
+}
+
+internal fun MdbListSyncSnapshot.mutationTarget(reference: TrackingMediaReference): MdbListMutationTarget? {
+    val ids = reference.ids.toMdbListIds() ?: return null
+    val isMovie = reference.kind == TrackingMediaKind.MOVIE || reference.catalog?.contentType in setOf("movie", "film")
+    val type = if (isMovie) MdbListItemType.MOVIE else if (reference.episode != null) MdbListItemType.EPISODE else MdbListItemType.SHOW
+    val index = MdbListMediaIndex(this)
+    val media = index.resolve(type, ids).merged(MdbListMedia(ids, reference.title, reference.year, reference.posterUrl))
+    val episode = reference.episode.takeUnless { isMovie }
+    val known = if (episode == null) null else watched.firstOrNull { record ->
+        record.type == MdbListItemType.EPISODE && record.media.ids.matches(ids) &&
+            ((episode.tmdbId != null && episode.tmdbId == record.episodeTmdbId) ||
+                (episode.tvdbId != null && episode.tvdbId == record.episodeTvdbId) ||
+                (!episode.usesTvdbSeasonMapping && episode.season == record.season && episode.number == record.episode))
+    }
+    val season = known?.season ?: episode?.season
+    val number = known?.episode ?: episode?.number
+    if (type == MdbListItemType.EPISODE && (season == null || season < 0 || number == null || number < 1)) return null
+    return MdbListMutationTarget(
+        type, media, season, number, known?.episodeTitle ?: episode?.title,
+        known?.episodeTmdbId ?: episode?.tmdbId,
+        known?.episodeTvdbId ?: episode?.tvdbId,
+        scrobbleCoordinatesResolved = episode?.usesTvdbSeasonMapping != true || known != null
+    )
+}
+
+internal fun TrackingExternalIds.toMdbListIds(): MdbListIds? = MdbListIds(
+    imdb = imdb?.takeIf { it.matches(Regex("tt[0-9]+")) },
+    tmdb = tmdb?.takeIf { it > 0L },
+    tvdb = tvdb?.toLongOrNull()?.takeIf { it > 0L },
+    trakt = trakt?.takeIf { it > 0L },
+    mdblist = mdblist?.takeIf(String::isNotBlank)
+).takeIf { it.aliases().isNotEmpty() }
+
+internal fun MdbListIds.requestIds(): JsonObject = buildJsonObject {
+    imdb?.let { put("imdb", it) }
+    tmdb?.let { put("tmdb", it) }
+    tvdb?.let { put("tvdb", it) }
+    trakt?.let { put("trakt", it) }
+    mdblist?.let { put("mdblist", it) }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListProgressProjection.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListProgressProjection.kt
@@ -1,0 +1,115 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.selectPreferredTrackingNextUpSeeds
+import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.WatchedItem
+
+internal class MdbListProgressProjection(snapshot: MdbListSyncSnapshot) {
+    private val mediaIndex = MdbListMediaIndex(snapshot)
+    private val watchedById = snapshot.watched.filter { it.type == MdbListItemType.EPISODE }
+        .flatMap { record -> record.media.ids.aliases().map { it to record } }
+        .groupBy({ it.first }, { it.second })
+    private val droppedById = snapshot.dropped.flatMap { record ->
+        mediaIndex.resolve(MdbListItemType.SHOW, record.ids).ids.aliases().map { it to record.season }
+    }
+        .groupBy({ it.first }, { it.second })
+    private val historyByKey = snapshot.watched.associateBy(MdbListWatchedRecord::key)
+    val watchedMovieIds = snapshot.watched.filter { it.type == MdbListItemType.MOVIE }
+        .flatMapTo(linkedSetOf()) { it.media.ids.aliases() }
+    val watchedItems = snapshot.watched.filter { it.type in setOf(MdbListItemType.MOVIE, MdbListItemType.EPISODE) }
+        .map { record ->
+            WatchedItem(
+                contentId = record.media.ids.contentId,
+                contentType = if (record.type == MdbListItemType.MOVIE) "movie" else "series",
+                title = record.media.title ?: record.media.ids.contentId,
+                season = record.season,
+                episode = record.episode,
+                watchedAt = mdbListTimestamp(record.watchedAt),
+                poster = record.media.poster,
+                releaseInfo = record.media.year?.toString(),
+                trackingProviderId = "mdblist",
+                trackingProviderItemId = record.media.ids.mdblist?.let { "mdblist:$it" }
+            )
+        }.sortedByDescending(WatchedItem::watchedAt)
+    val watchedShowEpisodes = watchedById.mapValues { (_, records) ->
+        records.mapNotNullTo(linkedSetOf()) { record ->
+            record.season?.let { season -> record.episode?.let { season to it } }
+        }
+    }
+    val showIdSiblings = snapshot.watched.filter { it.type != MdbListItemType.MOVIE }
+        .map { it.media.ids.aliases() }.plus(snapshot.playback.filter { it.type != MdbListItemType.MOVIE }.map { it.media.ids.aliases() })
+        .flatMap { aliases -> aliases.map { it to aliases } }.toMap()
+    val progress = snapshot.playback.filter { session ->
+        val watched = historyByKey["${session.type}:${session.media.ids.key}:${session.season ?: -1}:${session.episode ?: -1}"]
+        session.progress < COMPLETION_PERCENT && !isHidden(session.media.ids.contentId, session.season) &&
+            (watched == null || mdbListTimestamp(session.updatedAt) > mdbListTimestamp(watched.watchedAt))
+    }.map { session ->
+        progress(
+            session.type, session.media, session.season, session.episode, session.episodeTitle,
+            session.progress, session.updatedAt, session.runtimeMinutes, WatchProgress.SOURCE_REMOTE_PLAYBACK
+        )
+    }.groupBy { Triple(it.contentId, it.season, it.episode) }
+        .map { (_, entries) -> entries.maxBy(WatchProgress::lastWatched) }
+        .sortedByDescending(WatchProgress::lastWatched)
+    private val episodeProgressById = progress.filter { it.season != null && it.episode != null }
+        .flatMap { item -> (showIdSiblings[item.contentId] ?: setOf(item.contentId)).map { it to item } }
+        .groupBy({ it.first }, { it.second })
+    private val seeds = snapshot.watched.filter { record ->
+        record.type == MdbListItemType.EPISODE && record.season != null && record.season > 0 &&
+            !isHidden(record.media.ids.contentId)
+    }.map { record ->
+        progress(
+            record.type, record.media, record.season, record.episode, record.episodeTitle,
+            100f, record.watchedAt, null, WatchProgress.SOURCE_REMOTE_HISTORY
+        ).copy(excludedNextUpSeasons = droppedById[record.media.ids.contentId].orEmpty().filterNotNull().toSet())
+    }
+
+    fun nextUp(preferFurthest: Boolean): List<WatchProgress> =
+        selectPreferredTrackingNextUpSeeds(seeds, preferFurthest)
+
+    fun isHidden(contentId: String, season: Int? = null): Boolean =
+        droppedById[contentId]?.any { it == null || (season != null && it == season) } == true
+
+    fun isWatched(contentId: String, season: Int?, episode: Int?): Boolean =
+        if (season != null && episode != null) season to episode in watchedShowEpisodes[contentId].orEmpty()
+        else contentId in watchedMovieIds
+
+    fun episodeProgress(contentId: String): Map<Pair<Int, Int>, WatchProgress> =
+        episodeProgressById[contentId].orEmpty().associateBy { it.season!! to it.episode!! }
+
+    private fun progress(
+        type: MdbListItemType,
+        media: MdbListMedia,
+        season: Int?,
+        episode: Int?,
+        episodeTitle: String?,
+        percent: Float,
+        timestamp: String,
+        runtime: Int?,
+        source: String
+    ) = WatchProgress(
+        contentId = media.ids.contentId,
+        contentType = if (type == MdbListItemType.MOVIE) "movie" else "series",
+        name = media.title ?: media.ids.contentId,
+        poster = media.poster,
+        backdrop = media.backdrop,
+        logo = null,
+        videoId = if (type == MdbListItemType.MOVIE) media.ids.contentId else "${media.ids.contentId}:$season:$episode",
+        season = season,
+        episode = episode,
+        episodeTitle = episodeTitle,
+        position = 0,
+        duration = (runtime ?: media.runtimeMinutes ?: 0).toLong() * 60_000L,
+        lastWatched = mdbListTimestamp(timestamp),
+        progressPercent = percent,
+        source = source,
+        trackingProviderId = "mdblist",
+        trackingProviderItemId = media.ids.mdblist?.let { "mdblist:$it" },
+        completionThresholdOverride = COMPLETION_PERCENT / 100f
+    )
+
+    companion object {
+        const val COMPLETION_PERCENT = 80f
+        val Empty = MdbListProgressProjection(MdbListSyncSnapshot(0))
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListResponseValues.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListResponseValues.kt
@@ -1,0 +1,87 @@
+package com.nuvio.tv.data.mdblist
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+
+internal fun mdbListResponseElement(body: String): JsonElement =
+    runCatching { Json.parseToJsonElement(body) }.getOrElse { throw MdbListDecodingException() }
+
+internal fun JsonElement.objectValue(): JsonObject = this as? JsonObject ?: throw MdbListDecodingException()
+internal fun JsonObject.objectValue(name: String): JsonObject? = when (val value = get(name)) {
+    null, JsonNull -> null
+    else -> value.objectValue()
+}
+
+internal fun JsonObject.arrayValue(name: String): JsonArray = when (val value = get(name)) {
+    null, JsonNull -> JsonArray(emptyList())
+    is JsonArray -> value
+    else -> throw MdbListDecodingException()
+}
+
+internal fun JsonObject.text(vararg names: String): String? = names.firstNotNullOfOrNull { name ->
+    (get(name) as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf(String::isNotBlank)
+}
+
+internal fun JsonObject.number(vararg names: String): Long? = text(*names)?.toLongOrNull()
+internal fun JsonObject.integer(vararg names: String): Int? = number(*names)
+    ?.takeIf { it in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong() }?.toInt()
+internal fun JsonObject.flag(name: String): Boolean? = (get(name) as? JsonPrimitive)?.booleanOrNull
+
+internal fun mdbListTimestamp(value: String): Long = runCatching { Instant.parse(value).toEpochMilli() }
+    .recoverCatching { OffsetDateTime.parse(value).toInstant().toEpochMilli() }
+    .getOrElse { throw MdbListDecodingException() }
+
+internal fun JsonObject.timestamp(vararg names: String): String? = text(*names)?.also(::mdbListTimestamp)
+
+internal fun decodeMdbListIds(value: JsonObject): MdbListIds {
+    val ids = value.objectValue("ids") ?: value
+    return MdbListIds(
+        imdb = ids.text("imdb", "imdbid")?.takeIf { it.matches(Regex("tt[0-9]+")) },
+        tmdb = ids.number("tmdb", "tmdbid")?.takeIf { it > 0L },
+        tvdb = ids.number("tvdb", "tvdbid")?.takeIf { it > 0L },
+        trakt = ids.number("trakt", "traktid")?.takeIf { it > 0L },
+        mdblist = ids.text("mdblist")
+    ).also { it.key }
+}
+
+internal fun decodeMdbListMedia(value: JsonObject): MdbListMedia = MdbListMedia(
+    ids = decodeMdbListIds(value),
+    title = value.text("title", "name"),
+    year = value.integer("year"),
+    poster = mdbListImageUrl(value.text("poster"), "w500"),
+    backdrop = mdbListImageUrl(value.text("backdrop", "background"), "w1280"),
+    runtimeMinutes = value.number("runtime")?.takeIf { it in 1..Int.MAX_VALUE }?.toInt()
+)
+
+internal fun mdbListImageUrl(value: String?, size: String): String? = when {
+    value == null -> null
+    value.startsWith("https://") || value.startsWith("http://") -> value
+    value.startsWith('/') && !value.startsWith("//") -> "https://image.tmdb.org/t/p/$size$value"
+    else -> null
+}
+
+internal fun <T> mdbListPage(value: JsonObject, items: List<T>): MdbListPage<T> {
+    val pagination = value.objectValue("pagination") ?: value
+    val cursor = pagination.text("next_cursor")
+    val offset = pagination.number("offset")
+    val limit = pagination.number("limit")
+    val total = pagination.number("total")
+    val hasMore = pagination.flag("has_more") ?: if (offset != null && limit != null && total != null) {
+        offset + limit < total
+    } else false
+    val nextOffset = if (hasMore == true && cursor == null) {
+        if (offset == null || offset < 0L || limit == null || limit < 1L || offset + limit > Int.MAX_VALUE) {
+            throw MdbListDecodingException()
+        }
+        (offset + limit).toInt()
+    } else null
+    return MdbListPage(items, cursor, nextOffset, value.timestamp("server_time"))
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListScrobbleReceipt.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListScrobbleReceipt.kt
@@ -1,0 +1,72 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingScrobbleAction
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+internal data class MdbListScrobbleReceipt(
+    val target: MdbListMutationTarget,
+    val action: TrackingScrobbleAction,
+    val progress: Float,
+    val timestamp: String,
+    val playbackId: Long?
+) {
+    val isWatched: Boolean
+        get() = action != TrackingScrobbleAction.START && progress >= MdbListProgressProjection.COMPLETION_PERCENT
+}
+
+internal fun decodeMdbListScrobbleReceipt(
+    response: MdbListHttpResponse,
+    target: MdbListMutationTarget,
+    action: TrackingScrobbleAction,
+    nowEpochMs: Long
+): MdbListScrobbleReceipt {
+    val body = mdbListResponseElement(response.body).objectValue()
+    val acceptedActions = if (action == TrackingScrobbleAction.START) setOf("start") else setOf("pause", "stop", "scrobble")
+    if (body.text("action") !in acceptedActions) throw MdbListDecodingException()
+    val progress = body.text("progress")?.toFloatOrNull()?.takeIf { it.isFinite() && it in 0f..100f }
+        ?: throw MdbListDecodingException()
+    val episode = body.objectValue("episode")
+    val parent = body.objectValue(if (target.type == MdbListItemType.MOVIE) "movie" else "show")
+        ?: episode?.objectValue("show")
+    val media = parent?.let(::decodeMdbListMedia)?.also {
+        if (!it.ids.matches(target.media.ids)) throw MdbListDecodingException()
+    }?.merged(target.media) ?: target.media
+    val resolved = target.copy(
+        media = media,
+        season = episode?.integer("season") ?: target.season,
+        episode = episode?.integer("number", "episode") ?: target.episode,
+        episodeTitle = episode?.text("title", "name") ?: target.episodeTitle,
+        episodeTmdbId = episode?.objectValue("ids")?.number("tmdb", "tmdbid") ?: target.episodeTmdbId,
+        episodeTvdbId = episode?.objectValue("ids")?.number("tvdb", "tvdbid") ?: target.episodeTvdbId
+    )
+    if (resolved.type == MdbListItemType.EPISODE && (resolved.season == null || resolved.season < 0 ||
+        resolved.episode == null || resolved.episode < 1)) throw MdbListDecodingException()
+    val timestamp = body.timestamp("watched_at", "paused_at")
+        ?: body.timestamp("started_at").takeIf { action == TrackingScrobbleAction.START }
+        ?: response.header("Date")?.let {
+        runCatching { ZonedDateTime.parse(it, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant().toString() }.getOrNull()
+    } ?: Instant.ofEpochMilli(nowEpochMs).toString()
+    return MdbListScrobbleReceipt(resolved, action, progress, timestamp, body.number("id")?.takeIf { it > 0 })
+}
+
+internal fun MdbListSyncSnapshot.applyScrobble(receipt: MdbListScrobbleReceipt): MdbListSyncSnapshot {
+    val target = receipt.target
+    val remainingPlayback = playback.filterNot(target::matches)
+    if (receipt.action == TrackingScrobbleAction.START) return copy(playback = remainingPlayback)
+    val watched = if (receipt.isWatched) this.watched.filterNot(target::matches) + target.watched(receipt.timestamp) else this.watched
+    val playback = if (receipt.isWatched) remainingPlayback else remainingPlayback + MdbListPlayback(
+        id = receipt.playbackId ?: this.playback.firstOrNull(target::matches)?.id,
+        type = target.type,
+        media = target.media,
+        progress = receipt.progress,
+        updatedAt = receipt.timestamp,
+        season = target.season,
+        episode = target.episode,
+        episodeTitle = target.episodeTitle,
+        episodeTmdbId = target.episodeTmdbId,
+        episodeTvdbId = target.episodeTvdbId
+    )
+    return copy(watched = watched, playback = playback).normalizeMedia()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListScrobbleService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListScrobbleService.kt
@@ -1,0 +1,44 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingScrobbleAction
+import com.nuvio.tv.core.tracking.TrackingScrobbleEvent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MdbListScrobbleService @Inject constructor(
+    private val api: MdbListApiClient,
+    private val sync: MdbListSyncRepository
+) {
+    suspend fun scrobble(scope: MdbListAuthScope, action: TrackingScrobbleAction, event: TrackingScrobbleEvent) {
+        if (!event.progressPercent.isFinite() || event.media.ids.toMdbListIds() == null) return
+        sync.write(scope, setOf(MdbListSyncBucket.WATCHED, MdbListSyncBucket.PLAYBACK)) { snapshot ->
+            val target = snapshot.mutationTarget(event.media) ?: return@write snapshot to Unit
+            if (target.type == MdbListItemType.SHOW || !target.scrobbleCoordinatesResolved) return@write snapshot to Unit
+            val response = api.post("/scrobble/${action.wireValue}", target.scrobbleBody(event.progressPercent.coerceIn(0.0, 100.0)).toString(), scope)
+            val receipt = decodeMdbListScrobbleReceipt(response, target, action, System.currentTimeMillis())
+            snapshot.applyScrobble(receipt) to Unit
+        }
+    }
+
+    suspend fun clear(scope: MdbListAuthScope, contentId: String, season: Int?, episode: Int?) {
+        sync.ensureLoaded()
+        val sessions = sync.currentSnapshot()?.playback.orEmpty().filter { session ->
+            contentId in session.media.ids.aliases() &&
+                (season == null || episode == null || session.season == season && session.episode == episode)
+        }
+        for (session in sessions) {
+            sync.write(scope, setOf(MdbListSyncBucket.PLAYBACK)) { snapshot ->
+                val target = MdbListMutationTarget(session.type, session.media, session.season, session.episode)
+                try {
+                    val response = api.post("/scrobble/clear", target.scrobbleBody().toString(), scope)
+                    val body = mdbListResponseElement(response.body).objectValue()
+                    if (body.text("action") != "clear" || body.flag("deleted") == null) throw MdbListDecodingException()
+                } catch (error: MdbListApiException) {
+                    if (error.status != 404) throw error
+                }
+                snapshot.copy(playback = snapshot.playback.filterNot(target::matches)) to Unit
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncDecoders.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncDecoders.kt
@@ -1,0 +1,114 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+
+internal fun decodeMdbListActivities(body: String): MdbListActivities {
+    val payload = mdbListResponseElement(body).objectValue()
+    val serverTime = payload.timestamp("server_time") ?: throw MdbListDecodingException()
+    if (listOf("watched_at", "episode_watched_at", "journal_at").none(payload::containsKey)) {
+        throw MdbListDecodingException()
+    }
+    return MdbListActivities(
+        values = payload.keys.filter { it.endsWith("_at") }.associateWith { key -> payload.timestamp(key) },
+        serverTime = serverTime
+    )
+}
+
+internal fun decodeMdbListPlayback(body: String): List<MdbListPlayback> {
+    val payload = mdbListResponseElement(body) as? JsonArray ?: throw MdbListDecodingException()
+    return payload.map { item ->
+        val row = item.objectValue()
+        val type = when (row.text("type")) {
+            "movie" -> MdbListItemType.MOVIE
+            "episode" -> MdbListItemType.EPISODE
+            else -> throw MdbListDecodingException()
+        }
+        val episode = row.objectValue("episode")
+        val media = decodeMdbListMedia(
+            row.objectValue(if (type == MdbListItemType.MOVIE) "movie" else "show")
+                ?: episode?.objectValue("show") ?: throw MdbListDecodingException()
+        )
+        val progress = row.text("progress")?.toFloatOrNull()
+            ?.takeIf { it.isFinite() && it in 0f..100f } ?: throw MdbListDecodingException()
+        val updatedAt = row.timestamp("paused_at", "updated_at")
+            ?: throw MdbListDecodingException()
+        val season = episode?.integer("season")
+        val number = episode?.integer("number", "episode")
+        if (type == MdbListItemType.EPISODE && (season == null || season < 0 || number == null || number < 1)) {
+            throw MdbListDecodingException()
+        }
+        MdbListPlayback(
+            id = row.number("id")?.takeIf { it > 0L } ?: throw MdbListDecodingException(),
+            type = type,
+            media = media,
+            progress = progress,
+            updatedAt = updatedAt,
+            season = season,
+            episode = number,
+            episodeTitle = episode?.text("title", "name"),
+            episodeTmdbId = episode?.objectValue("ids")?.number("tmdb", "tmdbid"),
+            episodeTvdbId = episode?.objectValue("ids")?.number("tvdb", "tvdbid"),
+            runtimeMinutes = row.integer("runtime")?.takeIf { it > 0 }
+        )
+    }
+}
+
+internal fun decodeMdbListDropped(body: String, seasons: Boolean): MdbListPage<MdbListDroppedRecord> {
+    val payload = mdbListResponseElement(body).objectValue()
+    val name = if (seasons) "season" else "show"
+    if (!payload.containsKey("${name}s")) throw MdbListDecodingException()
+    val items = payload.arrayValue("${name}s").map { element ->
+        val row = element.objectValue()
+        val target = row.objectValue(name) ?: throw MdbListDecodingException()
+        val parent = if (seasons) row.objectValue("show") ?: target.objectValue("show") else target
+        val number = if (seasons) {
+            target.integer("number", "season")?.takeIf { it >= 0 } ?: throw MdbListDecodingException()
+        } else null
+        MdbListDroppedRecord(decodeMdbListIds(parent ?: throw MdbListDecodingException()), number)
+    }
+    return mdbListPage(payload, items)
+}
+
+internal fun decodeMdbListJournal(body: String): MdbListPage<MdbListJournalRecord> {
+    val payload = mdbListResponseElement(body).objectValue()
+    if (payload.flag("requires_full_sync") == true) {
+        return MdbListPage(emptyList(), serverTime = payload.timestamp("server_time"), requiresFullSync = true)
+    }
+    if (!payload.containsKey("journal") || payload["journal"] == JsonNull) throw MdbListDecodingException()
+    val records = payload.arrayValue("journal").mapNotNull { element ->
+        val row = element.objectValue()
+        when (row.text("category")) {
+            "rated" -> return@mapNotNull null
+            "watched" -> Unit
+            else -> throw MdbListDecodingException()
+        }
+        val type = MdbListItemType.entries.firstOrNull { it.name.equals(row.text("item_type"), ignoreCase = true) }
+            ?: throw MdbListDecodingException()
+        val season = row.integer("season")
+        val episode = row.integer("episode")
+        if (type in setOf(MdbListItemType.SEASON, MdbListItemType.EPISODE) && (season == null || season < 0)) {
+            throw MdbListDecodingException()
+        }
+        if (type == MdbListItemType.EPISODE && (episode == null || episode < 1)) throw MdbListDecodingException()
+        val removed = when (row.text("status")) {
+            "added" -> false
+            "removed" -> true
+            else -> throw MdbListDecodingException()
+        }
+        val watchedAt = row.timestamp("value_at")
+        if (!removed && watchedAt == null) throw MdbListDecodingException()
+        MdbListJournalRecord(
+            type = type,
+            ids = decodeMdbListIds(row.objectValue("ids") ?: throw MdbListDecodingException()),
+            removed = removed,
+            actionAt = row.timestamp("action_at") ?: throw MdbListDecodingException(),
+            watchedAt = watchedAt,
+            season = season,
+            episode = episode,
+            episodeTmdbId = row.number("episode_tmdb_id"),
+            episodeTvdbId = row.number("episode_tvdb_id")
+        )
+    }
+    return mdbListPage(payload, records)
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncEngine.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncEngine.kt
@@ -1,0 +1,78 @@
+package com.nuvio.tv.data.mdblist
+
+class MdbListSyncEngine(
+    private val remote: MdbListSyncRemote,
+    private val now: () -> Long = System::currentTimeMillis
+) {
+    suspend fun synchronize(previous: MdbListSyncSnapshot): MdbListSyncSnapshot {
+        val activities = remote.activities()
+        val previousActivities = previous.activities
+        val full = !previous.isInitialized || previousActivities == null
+        val watermark = previous.watermark
+        val expired = watermark == null || mdbListTimestamp(activities.serverTime) -
+            mdbListTimestamp(watermark) !in 0 until JOURNAL_RETENTION_MS
+        val watched = when {
+            full || expired -> remote.watched()
+            activities.watchedChanged(previousActivities) -> {
+                val journal = remote.journal(watermark)
+                if (journal.requiresFullSync) remote.watched()
+                else applyMdbListJournal(previous, journal.items)
+            }
+            else -> previous.watched
+        }
+        val playback = if (full || expired || activities.playbackChanged(previousActivities)) {
+            remote.playback()
+        } else previous.playback
+        val dropped = if (full || expired || activities.droppedChanged(previousActivities)) {
+            remote.dropped()
+        } else previous.dropped
+        val next = previous.copy(
+            watched = watched,
+            playback = playback,
+            dropped = dropped,
+            activities = activities,
+            watermark = activities.serverTime,
+            checkedAtEpochMs = now(),
+            isInitialized = true
+        )
+        return if (watched === previous.watched && playback === previous.playback) next else next.normalizeMedia()
+    }
+
+    private companion object {
+        const val JOURNAL_RETENTION_MS = 30L * 24 * 60 * 60 * 1_000
+    }
+}
+
+internal fun applyMdbListJournal(
+    snapshot: MdbListSyncSnapshot,
+    journal: List<MdbListJournalRecord>
+): List<MdbListWatchedRecord> {
+    val index = MdbListMediaIndex(snapshot)
+    journal.forEach { index.add(it.type, MdbListMedia(it.ids)) }
+    val records = snapshot.watched.associateByTo(linkedMapOf()) { record ->
+        record.copy(media = index.resolve(record.type, record.media.ids)).key
+    }
+    journal.sortedBy { mdbListTimestamp(it.actionAt) }.forEach { change ->
+        val media = index.resolve(change.type, change.ids)
+        val record = MdbListWatchedRecord(
+            type = change.type,
+            media = media,
+            watchedAt = change.watchedAt ?: change.actionAt,
+            season = change.season,
+            episode = change.episode,
+            episodeTmdbId = change.episodeTmdbId,
+            episodeTvdbId = change.episodeTvdbId
+        )
+        if (change.removed) {
+            records.remove(record.key)
+        } else {
+            val previous = records[record.key]
+            records[record.key] = record.copy(
+                episodeTitle = previous?.episodeTitle,
+                episodeTmdbId = record.episodeTmdbId ?: previous?.episodeTmdbId,
+                episodeTvdbId = record.episodeTvdbId ?: previous?.episodeTvdbId
+            )
+        }
+    }
+    return records.values.toList()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncEngine.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncEngine.kt
@@ -12,7 +12,7 @@ class MdbListSyncEngine(
         val expired = watermark == null || mdbListTimestamp(activities.serverTime) -
             mdbListTimestamp(watermark) !in 0 until JOURNAL_RETENTION_MS
         val watched = when {
-            full || expired -> remote.watched()
+            full || expired || MdbListSyncBucket.WATCHED in previous.invalidatedBuckets -> remote.watched()
             activities.watchedChanged(previousActivities) -> {
                 val journal = remote.journal(watermark)
                 if (journal.requiresFullSync) remote.watched()
@@ -20,10 +20,12 @@ class MdbListSyncEngine(
             }
             else -> previous.watched
         }
-        val playback = if (full || expired || activities.playbackChanged(previousActivities)) {
+        val playback = if (full || expired || MdbListSyncBucket.PLAYBACK in previous.invalidatedBuckets ||
+            activities.playbackChanged(previousActivities)) {
             remote.playback()
         } else previous.playback
-        val dropped = if (full || expired || activities.droppedChanged(previousActivities)) {
+        val dropped = if (full || expired || MdbListSyncBucket.DROPPED in previous.invalidatedBuckets ||
+            activities.droppedChanged(previousActivities)) {
             remote.dropped()
         } else previous.dropped
         val next = previous.copy(
@@ -33,7 +35,8 @@ class MdbListSyncEngine(
             activities = activities,
             watermark = activities.serverTime,
             checkedAtEpochMs = now(),
-            isInitialized = true
+            isInitialized = true,
+            invalidatedBuckets = emptySet()
         )
         return if (watched === previous.watched && playback === previous.playback) next else next.normalizeMedia()
     }

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
@@ -1,0 +1,137 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MdbListIds(
+    val imdb: String? = null,
+    val tmdb: Long? = null,
+    val tvdb: Long? = null,
+    val trakt: Long? = null,
+    val mdblist: String? = null
+) {
+    val key: String
+        get() = mdblist?.let { "mdblist:$it" } ?: imdb ?: tmdb?.let { "tmdb:$it" }
+            ?: tvdb?.let { "tvdb:$it" } ?: trakt?.let { "trakt:$it" }
+            ?: throw MdbListDecodingException()
+
+    val contentId: String
+        get() = imdb ?: tmdb?.let { "tmdb:$it" } ?: tvdb?.let { "tvdb:$it" }
+            ?: trakt?.let { "trakt:$it" } ?: key
+
+    fun matches(other: MdbListIds): Boolean =
+        (mdblist != null && mdblist == other.mdblist) || (imdb != null && imdb == other.imdb) ||
+            (tmdb != null && tmdb == other.tmdb) || (tvdb != null && tvdb == other.tvdb) ||
+            (trakt != null && trakt == other.trakt)
+
+    fun merged(other: MdbListIds) = MdbListIds(
+        imdb ?: other.imdb, tmdb ?: other.tmdb, tvdb ?: other.tvdb,
+        trakt ?: other.trakt, mdblist ?: other.mdblist
+    )
+
+    fun aliases(): Set<String> = buildSet {
+        imdb?.let { add(it); add("imdb:$it") }
+        tmdb?.let { add("tmdb:$it") }
+        tvdb?.let { add("tvdb:$it") }
+        trakt?.let { add("trakt:$it") }
+        mdblist?.let { add("mdblist:$it") }
+    }
+}
+
+@Serializable
+data class MdbListMedia(
+    val ids: MdbListIds,
+    val title: String? = null,
+    val year: Int? = null,
+    val poster: String? = null,
+    val backdrop: String? = null,
+    val runtimeMinutes: Int? = null
+) {
+    fun merged(other: MdbListMedia) = MdbListMedia(
+        ids.merged(other.ids), title ?: other.title, year ?: other.year,
+        poster ?: other.poster, backdrop ?: other.backdrop, runtimeMinutes ?: other.runtimeMinutes
+    )
+}
+
+@Serializable
+enum class MdbListItemType { MOVIE, SHOW, SEASON, EPISODE }
+
+@Serializable
+data class MdbListWatchedRecord(
+    val type: MdbListItemType,
+    val media: MdbListMedia,
+    val watchedAt: String,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val episodeTitle: String? = null,
+    val episodeTmdbId: Long? = null,
+    val episodeTvdbId: Long? = null
+) {
+    val key: String
+        get() = "$type:${media.ids.key}:${season ?: -1}:${episode ?: -1}"
+}
+
+@Serializable
+data class MdbListPlayback(
+    val id: Long,
+    val type: MdbListItemType,
+    val media: MdbListMedia,
+    val progress: Float,
+    val updatedAt: String,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val episodeTitle: String? = null,
+    val episodeTmdbId: Long? = null,
+    val episodeTvdbId: Long? = null,
+    val runtimeMinutes: Int? = null
+)
+
+@Serializable
+data class MdbListDroppedRecord(val ids: MdbListIds, val season: Int? = null)
+
+@Serializable
+data class MdbListActivities(val values: Map<String, String?>, val serverTime: String) {
+    fun watchedChanged(previous: MdbListActivities): Boolean = changed(previous) {
+        it.contains("watched") || it == "journal_at"
+    }
+
+    fun playbackChanged(previous: MdbListActivities): Boolean = changed(previous) { it.contains("paused") }
+    fun droppedChanged(previous: MdbListActivities): Boolean = changed(previous) { it.contains("dropped") }
+
+    private fun changed(previous: MdbListActivities, includes: (String) -> Boolean): Boolean =
+        (values.keys + previous.values.keys).filter(includes).any { values[it] != previous.values[it] }
+}
+
+data class MdbListJournalRecord(
+    val type: MdbListItemType,
+    val ids: MdbListIds,
+    val removed: Boolean,
+    val actionAt: String,
+    val watchedAt: String?,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val episodeTmdbId: Long? = null,
+    val episodeTvdbId: Long? = null
+)
+
+data class MdbListPage<T>(
+    val items: List<T>,
+    val nextCursor: String? = null,
+    val nextOffset: Int? = null,
+    val serverTime: String? = null,
+    val requiresFullSync: Boolean = false
+)
+
+@Serializable
+data class MdbListSyncSnapshot(
+    val accountId: Long,
+    val watched: List<MdbListWatchedRecord> = emptyList(),
+    val playback: List<MdbListPlayback> = emptyList(),
+    val dropped: List<MdbListDroppedRecord> = emptyList(),
+    val activities: MdbListActivities? = null,
+    val watermark: String? = null,
+    val checkedAtEpochMs: Long? = null,
+    val isInitialized: Boolean = false
+)
+
+class MdbListDecodingException : Exception("MDBList returned an incomplete response")

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
@@ -73,7 +73,7 @@ data class MdbListWatchedRecord(
 
 @Serializable
 data class MdbListPlayback(
-    val id: Long,
+    val id: Long?,
     val type: MdbListItemType,
     val media: MdbListMedia,
     val progress: Float,
@@ -131,7 +131,11 @@ data class MdbListSyncSnapshot(
     val activities: MdbListActivities? = null,
     val watermark: String? = null,
     val checkedAtEpochMs: Long? = null,
-    val isInitialized: Boolean = false
+    val isInitialized: Boolean = false,
+    val invalidatedBuckets: Set<MdbListSyncBucket> = emptySet()
 )
+
+@Serializable
+enum class MdbListSyncBucket { WATCHED, PLAYBACK, DROPPED }
 
 class MdbListDecodingException : Exception("MDBList returned an incomplete response")

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncModels.kt
@@ -132,7 +132,8 @@ data class MdbListSyncSnapshot(
     val watermark: String? = null,
     val checkedAtEpochMs: Long? = null,
     val isInitialized: Boolean = false,
-    val invalidatedBuckets: Set<MdbListSyncBucket> = emptySet()
+    val invalidatedBuckets: Set<MdbListSyncBucket> = emptySet(),
+    val library: MdbListLibrarySnapshot? = null
 )
 
 @Serializable

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRemote.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRemote.kt
@@ -1,0 +1,63 @@
+package com.nuvio.tv.data.mdblist
+
+interface MdbListSyncRemote {
+    suspend fun activities(): MdbListActivities
+    suspend fun watched(): List<MdbListWatchedRecord>
+    suspend fun journal(since: String): MdbListPage<MdbListJournalRecord>
+    suspend fun playback(): List<MdbListPlayback>
+    suspend fun dropped(): List<MdbListDroppedRecord>
+}
+
+class MdbListHttpSyncRemote(
+    private val api: MdbListApiClient,
+    private val scope: MdbListAuthScope
+) : MdbListSyncRemote {
+    override suspend fun activities(): MdbListActivities =
+        decodeMdbListActivities(api.get("/sync/last_activities", scope = scope).body)
+
+    override suspend fun watched(): List<MdbListWatchedRecord> = pages(
+        "/sync/watched", mapOf("append_to_response" to "poster"), ::decodeMdbListWatched
+    ).items
+
+    override suspend fun journal(since: String): MdbListPage<MdbListJournalRecord> =
+        pages("/sync/journal", mapOf("since" to since), ::decodeMdbListJournal)
+
+    override suspend fun playback(): List<MdbListPlayback> =
+        decodeMdbListPlayback(api.get("/sync/playback", scope = scope).body)
+
+    override suspend fun dropped(): List<MdbListDroppedRecord> =
+        pages("/sync/dropped") { decodeMdbListDropped(it, seasons = false) }.items +
+            pages("/sync/seasons/dropped") { decodeMdbListDropped(it, seasons = true) }.items
+
+    private suspend fun <T> pages(
+        path: String,
+        initialQuery: Map<String, String> = emptyMap(),
+        decode: (String) -> MdbListPage<T>
+    ): MdbListPage<T> {
+        val results = mutableListOf<T>()
+        val visited = mutableSetOf<Map<String, String>>()
+        var query = initialQuery + ("limit" to "1000")
+        var serverTime: String? = null
+        repeat(1_000) {
+            if (!visited.add(query)) throw MdbListDecodingException()
+            val response = api.get(
+                path, query, scope,
+                acceptedStatuses = if (path == "/sync/journal") setOf(409) else emptySet()
+            )
+            val page = decode(response.body)
+            if (page.requiresFullSync) return page.copy(items = emptyList())
+            if (response.status == 409) throw MdbListApiException(response.status, response.errorCode())
+            results += page.items
+            serverTime = serverTime ?: page.serverTime
+            query = when {
+                page.nextCursor != null -> initialQuery.minus("since") +
+                    mapOf("limit" to "1000", "cursor" to page.nextCursor)
+                page.nextOffset != null && path != "/sync/journal" -> initialQuery +
+                    mapOf("limit" to "1000", "offset" to page.nextOffset.toString())
+                page.nextOffset != null -> throw MdbListDecodingException()
+                else -> return MdbListPage(results, serverTime = serverTime)
+            }
+        }
+        throw MdbListDecodingException()
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRepository.kt
@@ -33,9 +33,9 @@ class MdbListSyncRepository(
     private val mutex = Mutex()
     private val gate = TrackingRefreshGate()
     private val mutableState = MutableStateFlow(MdbListSyncState())
-    private val mutableProjection = MutableStateFlow(MdbListProgressProjection.Empty)
+    private val mutableProjection = MutableStateFlow(MdbListProgressState())
     val state = mutableState.asStateFlow()
-    internal val projection = mutableProjection.asStateFlow()
+    internal val progressState = mutableProjection.asStateFlow()
 
     init {
         coroutineScope.launch {
@@ -59,6 +59,9 @@ class MdbListSyncRepository(
     fun currentScope(): MdbListAuthScope = auth.scope().also(::checkScope)
 
     fun currentSnapshot(): MdbListSyncSnapshot? = mutableState.value.takeIf { matchesCurrent(it.scope) }?.snapshot
+
+    internal fun currentProjection(): MdbListProgressProjection = mutableProjection.value
+        .takeIf { matchesCurrent(it.scope) && auth.state.value.isAuthenticated }?.projection ?: MdbListProgressProjection.Empty
 
     suspend fun ensureLoaded() = withContext(dispatcher) { mutex.withLock { loadCurrent() } }
 
@@ -134,7 +137,7 @@ class MdbListSyncRepository(
         checkScope(scope)
         val projection = runCatching { MdbListProgressProjection(snapshot) }.getOrNull()
         val usable = if (projection != null) snapshot else MdbListSyncSnapshot(accountId)
-        mutableProjection.value = projection ?: MdbListProgressProjection.Empty
+        mutableProjection.value = MdbListProgressState(scope, projection ?: MdbListProgressProjection.Empty)
         mutableState.value = MdbListSyncState(scope, usable)
         return usable
     }
@@ -144,12 +147,12 @@ class MdbListSyncRepository(
         val previous = mutableState.value.snapshot
         val projection = if (previous != null && previous.watched === snapshot.watched &&
             previous.playback === snapshot.playback && previous.dropped === snapshot.dropped) {
-            mutableProjection.value
+            mutableProjection.value.projection
         } else MdbListProgressProjection(snapshot)
         val payload = json.encodeToString(snapshot)
         storage.save(scope.profileId, payload) { checkScope(scope) }
         checkScope(scope)
-        mutableProjection.value = projection
+        mutableProjection.value = MdbListProgressState(scope, projection)
         mutableState.value = MdbListSyncState(scope, snapshot)
     }
 
@@ -174,7 +177,7 @@ class MdbListSyncRepository(
         scope != null && scope.profileId == activeProfileId.value && auth.isCurrent(scope)
 
     private fun clearPublished() {
-        mutableProjection.value = MdbListProgressProjection.Empty
+        mutableProjection.value = MdbListProgressState()
         mutableState.value = MdbListSyncState()
     }
 

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncRepository.kt
@@ -1,0 +1,185 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingRefreshGate
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class MdbListSyncRepository(
+    private val storage: MdbListSyncStorage,
+    private val auth: MdbListAuthStore,
+    private val api: MdbListApiClient,
+    private val activeProfileId: StateFlow<Int>,
+    private val coroutineScope: CoroutineScope,
+    private val now: () -> Long = System::currentTimeMillis,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val remote: (MdbListAuthScope) -> MdbListSyncRemote = { MdbListHttpSyncRemote(api, it) }
+) {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private val mutex = Mutex()
+    private val gate = TrackingRefreshGate()
+    private val mutableState = MutableStateFlow(MdbListSyncState())
+    private val mutableProjection = MutableStateFlow(MdbListProgressProjection.Empty)
+    val state = mutableState.asStateFlow()
+    internal val projection = mutableProjection.asStateFlow()
+
+    init {
+        coroutineScope.launch {
+            combine(activeProfileId, auth.state) { profileId, authorization ->
+                Triple(profileId, authorization.scope, authorization.user?.id)
+            }.distinctUntilChanged().collectLatest {
+                if (!matchesCurrent(mutableState.value.scope)) clearPublished()
+                try {
+                    ensureLoaded()
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    if (matchesCurrent(auth.scope())) mutableState.value = MdbListSyncState(
+                        scope = auth.scope(), error = error.toMdbListSyncError()
+                    )
+                }
+            }
+        }
+    }
+
+    fun currentScope(): MdbListAuthScope = auth.scope().also(::checkScope)
+
+    fun currentSnapshot(): MdbListSyncSnapshot? = mutableState.value.takeIf { matchesCurrent(it.scope) }?.snapshot
+
+    suspend fun ensureLoaded() = withContext(dispatcher) { mutex.withLock { loadCurrent() } }
+
+    fun refreshAsync(intent: TrackingRefreshIntent) {
+        coroutineScope.launch { refresh(intent) }
+    }
+
+    suspend fun refresh(intent: TrackingRefreshIntent) = withContext(dispatcher) {
+        val scope = auth.scope()
+        gate.runIfNeeded(scope.generation, shouldRun = {
+            auth.state.value.isAuthenticated && matchesCurrent(scope) && shouldRefresh(intent)
+        }) {
+            mutex.withLock {
+                checkScope(scope)
+                val attemptedAt = now()
+                try {
+                    if (auth.state.value.user?.id == null) api.refreshUser(scope)
+                    val snapshot = loadCurrent() ?: return@withLock
+                    mutableState.value = mutableState.value.copy(isLoading = true, error = null, attemptedAtEpochMs = attemptedAt)
+                    val result = MdbListSyncEngine(remote(scope), now).synchronize(snapshot)
+                    commit(scope, result)
+                    mutableState.value = mutableState.value.copy(attemptedAtEpochMs = attemptedAt)
+                } catch (error: CancellationException) {
+                    if (matchesCurrent(scope)) mutableState.value = mutableState.value.copy(isLoading = false)
+                    throw error
+                } catch (error: Exception) {
+                    if (matchesCurrent(scope)) mutableState.value = mutableState.value.copy(
+                        scope = scope,
+                        isLoading = false,
+                        error = error.toMdbListSyncError(),
+                        retryAtEpochMs = (error as? MdbListApiException)?.retryAtEpochMs,
+                        attemptedAtEpochMs = attemptedAt
+                    )
+                }
+            }
+        }
+    }
+
+    internal suspend fun <T> mutate(
+        scope: MdbListAuthScope,
+        block: suspend (MdbListSyncSnapshot) -> Pair<MdbListSyncSnapshot, T>
+    ): T = withContext(dispatcher) {
+        mutex.withLock {
+            checkScope(scope)
+            if (auth.state.value.user?.id == null) api.refreshUser(scope)
+            val previous = loadCurrent() ?: throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+            val (next, result) = block(previous)
+            if (next != previous) commit(scope, next)
+            checkScope(scope)
+            result
+        }
+    }
+
+    internal suspend fun invalidate(scope: MdbListAuthScope, buckets: Set<MdbListSyncBucket>) {
+        mutate(scope) { previous -> previous.copy(invalidatedBuckets = previous.invalidatedBuckets + buckets) to Unit }
+    }
+
+    private suspend fun loadCurrent(): MdbListSyncSnapshot? {
+        val scope = auth.scope()
+        checkScope(scope, requireAuthorization = false)
+        val authorization = auth.state.value
+        if (!authorization.isAuthenticated) {
+            clearPublished()
+            storage.remove(scope.profileId) { checkScope(scope, requireAuthorization = false) }
+            return null
+        }
+        val accountId = authorization.user?.id ?: return null
+        val current = mutableState.value
+        if (current.scope == scope && current.snapshot?.accountId == accountId) return current.snapshot
+        val payload = storage.load(scope.profileId)
+        val snapshot = payload?.let { runCatching { json.decodeFromString<MdbListSyncSnapshot>(it) }.getOrNull() }
+            ?.takeIf { it.accountId == accountId } ?: MdbListSyncSnapshot(accountId)
+        checkScope(scope)
+        val projection = runCatching { MdbListProgressProjection(snapshot) }.getOrNull()
+        val usable = if (projection != null) snapshot else MdbListSyncSnapshot(accountId)
+        mutableProjection.value = projection ?: MdbListProgressProjection.Empty
+        mutableState.value = MdbListSyncState(scope, usable)
+        return usable
+    }
+
+    private suspend fun commit(scope: MdbListAuthScope, snapshot: MdbListSyncSnapshot) {
+        checkScope(scope)
+        val previous = mutableState.value.snapshot
+        val projection = if (previous != null && previous.watched === snapshot.watched &&
+            previous.playback === snapshot.playback && previous.dropped === snapshot.dropped) {
+            mutableProjection.value
+        } else MdbListProgressProjection(snapshot)
+        val payload = json.encodeToString(snapshot)
+        storage.save(scope.profileId, payload) { checkScope(scope) }
+        checkScope(scope)
+        mutableProjection.value = projection
+        mutableState.value = MdbListSyncState(scope, snapshot)
+    }
+
+    private fun shouldRefresh(intent: TrackingRefreshIntent): Boolean {
+        val current = mutableState.value.takeIf { matchesCurrent(it.scope) } ?: return true
+        val now = now()
+        if (current.retryAtEpochMs?.let { it > now } == true) return false
+        if (intent != TrackingRefreshIntent.AUTOMATIC) return true
+        if (current.error != null) return current.attemptedAtEpochMs?.let { now - it !in 0 until ERROR_RETRY_MS } ?: true
+        if (current.snapshot?.invalidatedBuckets?.isNotEmpty() == true) return true
+        return current.snapshot?.checkedAtEpochMs?.let { now - it !in 0 until AUTOMATIC_INTERVAL_MS } ?: true
+    }
+
+    private fun checkScope(scope: MdbListAuthScope, requireAuthorization: Boolean = true) {
+        if (!matchesCurrent(scope)) throw CancellationException("MDBList account changed")
+        if (requireAuthorization && !auth.state.value.isAuthenticated) {
+            throw MdbListAuthException(MdbListAuthError.AUTHORIZATION_REVOKED)
+        }
+    }
+
+    private fun matchesCurrent(scope: MdbListAuthScope?): Boolean =
+        scope != null && scope.profileId == activeProfileId.value && auth.isCurrent(scope)
+
+    private fun clearPublished() {
+        mutableProjection.value = MdbListProgressProjection.Empty
+        mutableState.value = MdbListSyncState()
+    }
+
+    companion object {
+        const val AUTOMATIC_INTERVAL_MS = 15L * 60 * 1_000
+        const val ERROR_RETRY_MS = 60_000L
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncState.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncState.kt
@@ -1,0 +1,22 @@
+package com.nuvio.tv.data.mdblist
+
+enum class MdbListSyncError { UNAVAILABLE, INVALID_RESPONSE, RATE_LIMIT, AUTHORIZATION_REVOKED }
+
+data class MdbListSyncState(
+    val scope: MdbListAuthScope? = null,
+    val snapshot: MdbListSyncSnapshot? = null,
+    val isLoading: Boolean = false,
+    val error: MdbListSyncError? = null,
+    val retryAtEpochMs: Long? = null,
+    val attemptedAtEpochMs: Long? = null
+) {
+    val hasLoaded: Boolean
+        get() = snapshot?.isInitialized == true
+}
+
+internal fun Throwable.toMdbListSyncError(): MdbListSyncError = when {
+    this is MdbListAuthException -> MdbListSyncError.AUTHORIZATION_REVOKED
+    this is MdbListDecodingException -> MdbListSyncError.INVALID_RESPONSE
+    this is MdbListApiException && status == 429 -> MdbListSyncError.RATE_LIMIT
+    else -> MdbListSyncError.UNAVAILABLE
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncState.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncState.kt
@@ -2,6 +2,11 @@ package com.nuvio.tv.data.mdblist
 
 enum class MdbListSyncError { UNAVAILABLE, INVALID_RESPONSE, RATE_LIMIT, AUTHORIZATION_REVOKED }
 
+internal data class MdbListProgressState(
+    val scope: MdbListAuthScope? = null,
+    val projection: MdbListProgressProjection = MdbListProgressProjection.Empty
+)
+
 data class MdbListSyncState(
     val scope: MdbListAuthScope? = null,
     val snapshot: MdbListSyncSnapshot? = null,

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncStorage.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListSyncStorage.kt
@@ -1,0 +1,43 @@
+package com.nuvio.tv.data.mdblist
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.nuvio.tv.data.local.ProfileDataStoreFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+
+interface MdbListSyncStorage {
+    suspend fun load(profileId: Int): String?
+    suspend fun save(profileId: Int, payload: String, checkScope: () -> Unit)
+    suspend fun remove(profileId: Int, checkScope: () -> Unit)
+}
+
+@Singleton
+class AndroidMdbListSyncStorage @Inject constructor(
+    private val factory: ProfileDataStoreFactory
+) : MdbListSyncStorage {
+    override suspend fun load(profileId: Int): String? =
+        factory.get(profileId, FEATURE).data.first()[SNAPSHOT]
+
+    override suspend fun save(profileId: Int, payload: String, checkScope: () -> Unit) {
+        factory.get(profileId, FEATURE).edit { preferences ->
+            checkScope()
+            if (factory.isProfileDeleted(profileId)) throw CancellationException("MDBList profile removed")
+            preferences[SNAPSHOT] = payload
+        }
+    }
+
+    override suspend fun remove(profileId: Int, checkScope: () -> Unit) {
+        factory.get(profileId, FEATURE).edit { preferences ->
+            checkScope()
+            preferences.remove(SNAPSHOT)
+        }
+    }
+
+    private companion object {
+        const val FEATURE = "mdblist_sync"
+        val SNAPSHOT = stringPreferencesKey("snapshot")
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingLibraryProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingLibraryProvider.kt
@@ -1,0 +1,37 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingLibraryProvider
+import com.nuvio.tv.core.tracking.TrackingProviderId
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.ListMembershipChanges
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MdbListTrackingLibraryProvider @Inject constructor(
+    private val service: MdbListLibraryService,
+    tracking: MdbListTrackingProvider
+) : TrackingLibraryProvider {
+    override val providerId = TrackingProviderId.MDBLIST
+    override val listManager = service.listManager
+    override val isAuthenticated = tracking.isAuthenticated
+    override val isRefreshing = service.isRefreshing
+    override val items = service.items
+    override val tabs = service.tabs
+
+    override fun recognizesListKey(key: String): Boolean =
+        key == MDBLIST_WATCHLIST_KEY || key.startsWith(MDBLIST_LIST_KEY_PREFIX)
+
+    override fun observeMembership(itemId: String, itemType: String) = service.observeMembership(itemId, itemType)
+
+    override fun toggledDefaultMembership(currentMembership: Map<String, Boolean>): Map<String, Boolean> =
+        currentMembership + (MDBLIST_WATCHLIST_KEY to (currentMembership[MDBLIST_WATCHLIST_KEY] != true))
+
+    override suspend fun getMembershipSnapshot(item: LibraryEntryInput) = service.getMembershipSnapshot(item)
+
+    override suspend fun applyMembershipChanges(item: LibraryEntryInput, changes: ListMembershipChanges, destructiveRemovalConfirmed: Boolean) =
+        service.applyMembershipChanges(item, changes)
+
+    override suspend fun refresh(intent: TrackingRefreshIntent) = service.refresh(intent)
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProgressProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProgressProvider.kt
@@ -1,0 +1,93 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tracking.TrackingProgressProvider
+import com.nuvio.tv.core.tracking.TrackingProviderId
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.core.tracking.parseTrackingExternalIds
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.domain.model.WatchProgress
+import com.nuvio.tv.domain.model.WatchedItem
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+
+@Singleton
+class MdbListTrackingProgressProvider @Inject constructor(
+    private val sync: MdbListSyncRepository,
+    private val scrobbles: MdbListScrobbleService,
+    auth: MdbListAuthStore,
+    profiles: ProfileManager,
+    layout: LayoutPreferenceDataStore
+) : TrackingProgressProvider {
+    override val providerId = TrackingProviderId.MDBLIST
+    override val isAuthenticated = combine(auth.state, profiles.activeProfileId) { authorization, profileId ->
+        authorization.isAuthenticated && authorization.scope.profileId == profileId
+    }.distinctUntilChanged()
+    private val projection = combine(sync.progressState, auth.state, profiles.activeProfileId) { state, authorization, profileId ->
+        if (authorization.isAuthenticated && authorization.scope.profileId == profileId &&
+            state.scope == authorization.scope) state.projection else MdbListProgressProjection.Empty
+    }.distinctUntilChanged()
+    override val allProgress = projection.map { it.progress }.loadOnStart()
+    override val watchedItems = projection.map { it.watchedItems }.loadOnStart()
+    override val watchedMovieIds = projection.map { it.watchedMovieIds }.loadOnStart()
+    override val nextUpSeeds = combine(projection, layout.nextUpFromFurthestEpisode) { projection, furthest ->
+        projection.nextUp(furthest)
+    }.loadOnStart()
+    override val remoteProgressLoaded = combine(sync.state, auth.state, profiles.activeProfileId) { state, authorization, profileId ->
+        state.hasLoaded && state.scope == authorization.scope && authorization.scope.profileId == profileId && authorization.isAuthenticated
+    }.distinctUntilChanged()
+
+    override fun episodeProgress(contentId: String): Flow<Map<Pair<Int, Int>, WatchProgress>> =
+        projection.map { it.episodeProgress(contentId) }.loadOnStart()
+
+    override fun airedEpisodeOrder(contentId: String): Flow<List<Pair<Int, Int>>> = flowOf(emptyList())
+
+    override fun isWatched(contentId: String, videoId: String?, season: Int?, episode: Int?): Flow<Boolean> =
+        projection.map { it.isWatched(contentId, season, episode) }.loadOnStart()
+
+    override suspend fun watchedShowEpisodes(): Map<String, Set<Pair<Int, Int>>> {
+        sync.refresh(TrackingRefreshIntent.AUTOMATIC)
+        return currentProjection().watchedShowEpisodes
+    }
+
+    override suspend fun showIdSiblings(): Map<String, Set<String>> {
+        sync.ensureLoaded()
+        return currentProjection().showIdSiblings
+    }
+
+    override fun isWatchedByVideoId(videoId: String, episode: Int): Boolean? {
+        val parts = videoId.split(':')
+        if (parts.size < 3 || parts.last().toIntOrNull() != episode) return null
+        val season = parts[parts.lastIndex - 1].toIntOrNull() ?: return null
+        val parent = parts.dropLast(2).joinToString(":")
+        if (retainsLocalProgress(parent)) return null
+        return currentProjection().isWatched(parent, season, episode)
+    }
+
+    override suspend fun refresh(intent: TrackingRefreshIntent) = sync.refresh(intent)
+
+    override suspend fun removeProgress(contentId: String, season: Int?, episode: Int?) =
+        scrobbles.clear(sync.currentScope(), contentId, season, episode)
+
+    override fun applyOptimisticProgress(progress: WatchProgress, quiet: Boolean) = Unit
+    override fun applyOptimisticRemoval(contentId: String, season: Int?, episode: Int?) = Unit
+    override fun clearOptimistic() = Unit
+    override fun isHiddenFromProgress(contentId: String): Boolean = currentProjection().isHidden(contentId)
+    override suspend fun prepareNextUpSeed(progress: WatchProgress): WatchProgress = progress
+    override fun retainsLocalProgress(contentId: String): Boolean = parseTrackingExternalIds(contentId).toMdbListIds() == null
+    override fun retainsLocalWatchedEpisode(item: WatchedItem): Boolean = retainsLocalProgress(item.contentId)
+
+    private fun currentProjection(): MdbListProgressProjection =
+        sync.currentProjection()
+
+    private fun <T> Flow<T>.loadOnStart(): Flow<T> = onStart {
+        sync.ensureLoaded()
+        sync.refreshAsync(TrackingRefreshIntent.AUTOMATIC)
+    }.distinctUntilChanged()
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProvider.kt
@@ -30,7 +30,7 @@ class MdbListTrackingProvider @Inject constructor(
     override val descriptor = TrackingProviderDescriptor(
         TrackingProviderId.MDBLIST,
         "MDBList",
-        setOf(TrackingCapability.AUTHENTICATION, TrackingCapability.WATCHED_READ,
+        setOf(TrackingCapability.AUTHENTICATION, TrackingCapability.LIBRARY_READ, TrackingCapability.LIBRARY_WRITE, TrackingCapability.WATCHED_READ,
             TrackingCapability.WATCHED_WRITE, TrackingCapability.PROGRESS_READ,
             TrackingCapability.PROGRESS_WRITE, TrackingCapability.SCROBBLE)
     )

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListTrackingProvider.kt
@@ -1,0 +1,75 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tracking.TrackingCapability
+import com.nuvio.tv.core.tracking.TrackingHistoryItem
+import com.nuvio.tv.core.tracking.TrackingHistoryWriter
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import com.nuvio.tv.core.tracking.TrackingMutationResult
+import com.nuvio.tv.core.tracking.TrackingProvider
+import com.nuvio.tv.core.tracking.TrackingProviderDescriptor
+import com.nuvio.tv.core.tracking.TrackingProviderId
+import com.nuvio.tv.core.tracking.TrackingScrobbleAction
+import com.nuvio.tv.core.tracking.TrackingScrobbleEvent
+import com.nuvio.tv.core.tracking.TrackingScrobbler
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+@Singleton
+class MdbListTrackingProvider @Inject constructor(
+    auth: MdbListAuthStore,
+    profiles: ProfileManager,
+    override val scrobbler: MdbListTrackingScrobbler
+) : TrackingProvider {
+    override val descriptor = TrackingProviderDescriptor(
+        TrackingProviderId.MDBLIST,
+        "MDBList",
+        setOf(TrackingCapability.AUTHENTICATION, TrackingCapability.WATCHED_READ,
+            TrackingCapability.WATCHED_WRITE, TrackingCapability.PROGRESS_READ,
+            TrackingCapability.PROGRESS_WRITE, TrackingCapability.SCROBBLE)
+    )
+    override val isAuthenticated = combine(auth.state, profiles.activeProfileId) { authorization, profileId ->
+        authorization.isAuthenticated && authorization.scope.profileId == profileId
+    }.stateIn(
+        CoroutineScope(SupervisorJob() + Dispatchers.IO), SharingStarted.Eagerly,
+        auth.state.value.isAuthenticated && auth.scope().profileId == profiles.activeProfileId.value
+    )
+}
+
+@Singleton
+class MdbListTrackingScrobbler @Inject constructor(
+    private val sync: MdbListSyncRepository,
+    private val service: MdbListScrobbleService
+) : TrackingScrobbler {
+    override val providerId = TrackingProviderId.MDBLIST
+
+    override suspend fun scrobble(action: TrackingScrobbleAction, event: TrackingScrobbleEvent) {
+        service.scrobble(sync.currentScope(), action, event)
+    }
+}
+
+@Singleton
+class MdbListTrackingHistoryWriter @Inject constructor(
+    private val sync: MdbListSyncRepository,
+    private val service: MdbListHistoryService
+) : TrackingHistoryWriter {
+    override val providerId = TrackingProviderId.MDBLIST
+
+    override suspend fun addToHistory(profileId: Int, items: Collection<TrackingHistoryItem>): TrackingMutationResult {
+        val scope = sync.currentScope()
+        if (scope.profileId != profileId) return TrackingMutationResult(0)
+        return service.add(scope, items)
+    }
+
+    override suspend fun removeFromHistory(profileId: Int, items: Collection<TrackingMediaReference>): TrackingMutationResult {
+        val scope = sync.currentScope()
+        if (scope.profileId != profileId) return TrackingMutationResult(0)
+        return service.remove(scope, items)
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListWatchedDecoder.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListWatchedDecoder.kt
@@ -1,0 +1,64 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.serialization.json.JsonObject
+
+internal fun decodeMdbListWatched(body: String): MdbListPage<MdbListWatchedRecord> {
+    val payload = mdbListResponseElement(body).objectValue()
+    if (listOf("movies", "shows", "seasons", "episodes").none(payload::containsKey)) {
+        throw MdbListDecodingException()
+    }
+    val records = buildList {
+        for (type in MdbListItemType.entries) {
+            val name = type.name.lowercase()
+            payload.arrayValue("${name}s").forEach { item ->
+                val row = item.objectValue()
+                val target = row.objectValue(name) ?: throw MdbListDecodingException()
+                val parent = if (type in setOf(MdbListItemType.SEASON, MdbListItemType.EPISODE)) {
+                    row.objectValue("show") ?: target.objectValue("show") ?: throw MdbListDecodingException()
+                } else target
+                val media = decodeMdbListMedia(parent)
+                watchedRecord(type, row, target, media)?.let(::add)
+                if (type == MdbListItemType.SHOW) addAll(nestedEpisodes(row, media))
+            }
+        }
+    }
+    return mdbListPage(payload, records.distinctBy(MdbListWatchedRecord::key))
+}
+
+private fun watchedRecord(
+    type: MdbListItemType,
+    row: JsonObject,
+    target: JsonObject,
+    media: MdbListMedia,
+    seasonOverride: Int? = null
+): MdbListWatchedRecord? {
+    val watchedAt = row.timestamp("last_watched_at", "watched_at") ?: return null
+    val season = when (type) {
+        MdbListItemType.SEASON -> target.integer("number", "season")
+        MdbListItemType.EPISODE -> seasonOverride ?: target.integer("season")
+        else -> null
+    }
+    val episode = if (type == MdbListItemType.EPISODE) target.integer("number", "episode") else null
+    if (type in setOf(MdbListItemType.SEASON, MdbListItemType.EPISODE) && (season == null || season < 0)) {
+        throw MdbListDecodingException()
+    }
+    if (type == MdbListItemType.EPISODE && (episode == null || episode < 1)) throw MdbListDecodingException()
+    val ids = target.objectValue("ids")
+    return MdbListWatchedRecord(
+        type, media, watchedAt, season, episode,
+        episodeTitle = target.text("title", "name").takeIf { type == MdbListItemType.EPISODE },
+        episodeTmdbId = ids?.number("tmdb", "tmdbid").takeIf { type == MdbListItemType.EPISODE },
+        episodeTvdbId = ids?.number("tvdb", "tvdbid").takeIf { type == MdbListItemType.EPISODE }
+    )
+}
+
+private fun nestedEpisodes(row: JsonObject, media: MdbListMedia): List<MdbListWatchedRecord> = buildList {
+    row.arrayValue("seasons").forEach { element ->
+        val season = element.objectValue()
+        val number = season.integer("number", "season") ?: throw MdbListDecodingException()
+        season.arrayValue("episodes").forEach { episode ->
+            val target = episode.objectValue()
+            watchedRecord(MdbListItemType.EPISODE, target, target, media, number)?.let(::add)
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListWriteReconciliation.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/MdbListWriteReconciliation.kt
@@ -1,0 +1,29 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+internal suspend fun <T> MdbListSyncRepository.write(
+    scope: MdbListAuthScope,
+    buckets: Set<MdbListSyncBucket>,
+    block: suspend (MdbListSyncSnapshot) -> Pair<MdbListSyncSnapshot, T>
+): T = try {
+    mutate(scope, block)
+} catch (error: CancellationException) {
+    withContext(NonCancellable) {
+        try {
+            invalidate(scope, buckets)
+        } catch (_: Exception) {
+        }
+    }
+    throw error
+} catch (error: Exception) {
+    try {
+        invalidate(scope, buckets)
+        refreshAsync(TrackingRefreshIntent.INVALIDATED)
+    } catch (_: Exception) {
+    }
+    throw error
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngine.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngine.kt
@@ -1,0 +1,99 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okio.Buffer
+import okio.BufferedSource
+
+class OkHttpMdbListEngine(
+    client: OkHttpClient,
+    private val configuration: MdbListConfiguration
+) : MdbListHttpEngine {
+    private val client = client.newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .retryOnConnectionFailure(false)
+        .build()
+
+    override suspend fun execute(request: MdbListHttpRequest): MdbListHttpResponse =
+        suspendCancellableCoroutine { continuation ->
+            val call = client.newCall(buildRequest(request))
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    if (continuation.isActive) continuation.resumeWithException(e)
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    response.use {
+                        try {
+                            val body = response.body.let { body ->
+                                readMdbListResponseBody(body.source(), body.contentLength())
+                            }
+                            if (continuation.isActive) {
+                                continuation.resume(
+                                    MdbListHttpResponse(
+                                        status = response.code,
+                                        body = body,
+                                        headers = response.headers.toMultimap()
+                                            .mapValues { it.value.joinToString(",") }
+                                    )
+                                )
+                            }
+                        } catch (error: IOException) {
+                            if (continuation.isActive) continuation.resumeWithException(error)
+                        }
+                    }
+                }
+            })
+        }
+
+    internal fun buildRequest(request: MdbListHttpRequest): Request {
+        require(request.path.startsWith('/') && !request.path.startsWith("//"))
+        require(request.path.none { it == '?' || it == '#' })
+        val base = configuration.baseUrl.toHttpUrl()
+        require(base.isHttps || base.host in setOf("localhost", "127.0.0.1", "::1"))
+        val url = base.newBuilder().encodedPath(request.path).query(null).fragment(null).apply {
+            request.query.forEach { (key, value) -> addQueryParameter(key, value) }
+        }.build()
+        return Request.Builder().url(url)
+            .header("Accept", "application/json")
+            .header("User-Agent", "NuvioTV/${configuration.appVersion}")
+            .apply {
+                request.accessToken?.let { header("Authorization", "Bearer $it") }
+                when (request.method) {
+                    MdbListHttpMethod.GET -> get()
+                    MdbListHttpMethod.POST -> post(
+                        request.form?.let { fields ->
+                            FormBody.Builder().apply { fields.forEach { (key, value) -> add(key, value) } }.build()
+                        } ?: request.body.toRequestBody("application/json".toMediaType())
+                    )
+                }
+            }.build()
+    }
+}
+
+internal fun readMdbListResponseBody(
+    source: BufferedSource,
+    contentLength: Long,
+    maxBytes: Long = 16L * 1024L * 1024L
+): String {
+    if (contentLength > maxBytes) throw IOException("MDBList response exceeds size limit")
+    val buffer = Buffer()
+    while (true) {
+        val count = source.read(buffer, minOf(8_192L, maxBytes - buffer.size + 1L))
+        if (count == -1L) return buffer.readUtf8()
+        if (buffer.size > maxBytes) throw IOException("MDBList response exceeds size limit")
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngine.kt
+++ b/app/src/main/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngine.kt
@@ -38,9 +38,9 @@ class OkHttpMdbListEngine(
                 override fun onResponse(call: Call, response: Response) {
                     response.use {
                         try {
-                            val body = response.body.let { body ->
+                            val body = response.body?.let { body ->
                                 readMdbListResponseBody(body.source(), body.contentLength())
-                            }
+                            }.orEmpty()
                             if (continuation.isActive) {
                                 continuation.resume(
                                     MdbListHttpResponse(
@@ -74,11 +74,12 @@ class OkHttpMdbListEngine(
                 request.accessToken?.let { header("Authorization", "Bearer $it") }
                 when (request.method) {
                     MdbListHttpMethod.GET -> get()
-                    MdbListHttpMethod.POST -> post(
+                    MdbListHttpMethod.POST, MdbListHttpMethod.PUT -> method(request.method.name,
                         request.form?.let { fields ->
                             FormBody.Builder().apply { fields.forEach { (key, value) -> add(key, value) } }.build()
                         } ?: request.body.toRequestBody("application/json".toMediaType())
                     )
+                    MdbListHttpMethod.DELETE -> delete()
                 }
             }.build()
     }

--- a/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/LibraryRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.network.NetworkResult
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.sync.LibrarySyncService
+import com.nuvio.tv.core.tracking.TrackingListManager
 import com.nuvio.tv.core.tracking.TrackingLibraryProviderRegistry
 import com.nuvio.tv.core.tracking.TrackingMembershipApplyResult
 import com.nuvio.tv.core.tracking.TrackingProviderId
@@ -15,7 +16,6 @@ import com.nuvio.tv.core.tracking.TrackingRefreshIntent
 import com.nuvio.tv.core.tracking.effectiveLibrarySourceMode
 import com.nuvio.tv.core.tracking.providerId
 import com.nuvio.tv.data.local.LibraryPreferences
-import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.domain.repository.MetaRepository
 import com.nuvio.tv.domain.model.LibraryEntry
@@ -25,7 +25,7 @@ import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.ListMembershipSnapshot
 import com.nuvio.tv.domain.model.SavedLibraryItem
-import com.nuvio.tv.domain.model.TraktListPrivacy
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import com.nuvio.tv.domain.repository.LibraryRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -53,9 +53,7 @@ import javax.inject.Singleton
 class LibraryRepositoryImpl @Inject constructor(
     @dagger.hilt.android.qualifiers.ApplicationContext private val appContext: android.content.Context,
     private val libraryPreferences: LibraryPreferences,
-    private val traktAuthDataStore: TraktAuthDataStore,
     private val traktSettingsDataStore: TraktSettingsDataStore,
-    private val traktLibraryService: TraktLibraryService,
     private val librarySyncService: LibrarySyncService,
     private val authManager: AuthManager,
     private val metaRepository: MetaRepository,
@@ -303,34 +301,40 @@ class LibraryRepositoryImpl @Inject constructor(
         return TrackingMembershipApplyResult()
     }
 
-    override suspend fun createPersonalList(name: String, description: String?, privacy: TraktListPrivacy) {
-        requireTraktAuth()
-        traktLibraryService.createPersonalList(name = name, description = description, privacy = privacy)
+    override suspend fun createPersonalList(name: String, description: String?, privacy: LibraryListPrivacy, source: LibrarySourceMode) {
+        selectedListManager(source).createList(name, description, privacy)
     }
 
     override suspend fun updatePersonalList(
         listId: String,
         name: String,
         description: String?,
-        privacy: TraktListPrivacy
+        privacy: LibraryListPrivacy,
+        source: LibrarySourceMode
     ) {
-        requireTraktAuth()
-        traktLibraryService.updatePersonalList(
-            listId = listId,
-            name = name,
-            description = description,
-            privacy = privacy
-        )
+        selectedListManager(source, listOf(listId)).updateList(listId, name, description, privacy)
     }
 
-    override suspend fun deletePersonalList(listId: String) {
-        requireTraktAuth()
-        traktLibraryService.deletePersonalList(listId)
+    override suspend fun deletePersonalList(listId: String, source: LibrarySourceMode) {
+        selectedListManager(source, listOf(listId)).deleteList(listId)
     }
 
-    override suspend fun reorderPersonalLists(orderedListIds: List<String>) {
-        requireTraktAuth()
-        traktLibraryService.reorderPersonalLists(orderedListIds)
+    override suspend fun reorderPersonalLists(orderedListIds: List<String>, source: LibrarySourceMode) {
+        selectedListManager(source, orderedListIds).reorderLists(orderedListIds)
+    }
+
+    private suspend fun selectedListManager(
+        source: LibrarySourceMode,
+        keys: List<String> = emptyList()
+    ): TrackingListManager {
+        val profileId = profileManager.activeProfileId.value
+        check(sourceMode.first() == source) { "Library source changed" }
+        val provider = source.providerId?.let(trackingProviders::provider)
+            ?: throw IllegalStateException("This library does not support list management")
+        check(provider.isAuthenticated.first()) { "Connect the library account first" }
+        require(keys.all(provider::recognizesListKey)) { "Invalid list for the library provider" }
+        check(profileManager.activeProfileId.value == profileId) { "Profile changed" }
+        return provider.listManager ?: throw IllegalStateException("This provider does not support list management")
     }
 
     override suspend fun refreshNow() {
@@ -339,11 +343,6 @@ class LibraryRepositoryImpl @Inject constructor(
             ?.refresh(TrackingRefreshIntent.USER_INITIATED)
     }
 
-    private suspend fun requireTraktAuth() {
-        if (!traktAuthDataStore.isEffectivelyAuthenticated.first()) {
-            throw IllegalStateException(appContext.getString(com.nuvio.tv.R.string.trakt_error_auth_required))
-        }
-    }
 
     private fun LibraryEntryInput.toSavedLibraryItem(): SavedLibraryItem {
         return SavedLibraryItem(

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktLibraryService.kt
@@ -21,7 +21,7 @@ import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.ListMembershipSnapshot
-import com.nuvio.tv.domain.model.TraktListPrivacy
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -164,7 +164,7 @@ class TraktLibraryService @Inject constructor(
     suspend fun createPersonalList(
         name: String,
         description: String?,
-        privacy: TraktListPrivacy
+        privacy: LibraryListPrivacy
     ) {
         val response = traktAuthService.executeAuthorizedRequest { authHeader ->
             traktApi.createUserList(
@@ -203,7 +203,7 @@ class TraktLibraryService @Inject constructor(
         listId: String,
         name: String,
         description: String?,
-        privacy: TraktListPrivacy
+        privacy: LibraryListPrivacy
     ) {
         performOptimisticMutation(
             optimistic = { snapshot ->
@@ -623,7 +623,7 @@ class TraktLibraryService @Inject constructor(
             traktListId = traktId,
             slug = slug,
             description = dto.description,
-            privacy = TraktListPrivacy.fromApi(dto.privacy),
+            privacy = LibraryListPrivacy.fromApi(dto.privacy),
             sortBy = dto.sortBy,
             sortHow = dto.sortHow
         )

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktTrackingLibraryProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktTrackingLibraryProvider.kt
@@ -1,10 +1,13 @@
 package com.nuvio.tv.data.repository
 
 import com.nuvio.tv.core.tracking.TrackingLibraryProvider
+import com.nuvio.tv.core.tracking.TrackingListManager
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
 import com.nuvio.tv.core.tracking.TrackingProviderId
 import com.nuvio.tv.core.tracking.TrackingRefreshIntent
 import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,6 +18,30 @@ class TraktTrackingLibraryProvider @Inject constructor(
     private val service: TraktLibraryService,
     authDataStore: TraktAuthDataStore
 ) : TrackingLibraryProvider {
+    override val listManager = object : TrackingListManager {
+        override val capabilities = TrackingListManagementCapabilities(
+            privacyOptions = LibraryListPrivacy.entries,
+            supportsDescription = true,
+            supportsReordering = true
+        )
+
+        override suspend fun createList(name: String, description: String?, privacy: LibraryListPrivacy) {
+            service.createPersonalList(name, description, privacy)
+        }
+
+        override suspend fun updateList(key: String, name: String, description: String?, privacy: LibraryListPrivacy) {
+            service.updatePersonalList(personalListId(key), name, description, privacy)
+        }
+
+        override suspend fun deleteList(key: String) = service.deletePersonalList(personalListId(key))
+
+        override suspend fun reorderLists(keys: List<String>) = service.reorderPersonalLists(keys.map(::personalListId))
+
+        private fun personalListId(key: String): String {
+            require(key.startsWith(TraktLibraryService.PERSONAL_KEY_PREFIX))
+            return key.removePrefix(TraktLibraryService.PERSONAL_KEY_PREFIX).also { require(it.isNotBlank()) }
+        }
+    }
     override val providerId = TrackingProviderId.TRAKT
     override val isAuthenticated = authDataStore.isEffectivelyAuthenticated
     override val isRefreshing = service.observeIsRefreshing()

--- a/app/src/main/java/com/nuvio/tv/data/repository/TraktTrackingProgressProvider.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/TraktTrackingProgressProvider.kt
@@ -23,6 +23,7 @@ class TraktTrackingProgressProvider @Inject constructor(
     override val providerId = TrackingProviderId.TRAKT
     override val isAuthenticated = authDataStore.isEffectivelyAuthenticated
     override val ownsCompletedHistoryProjection = true
+    override val clearsLocalProgressOnSelection = true
     override val allProgress = service.observeAllProgress()
     override val remoteProgressLoaded = service.observeRemoteProgressLoaded()
     override val watchedMovieIds = service.observeAllWatchedMovieIds()

--- a/app/src/main/java/com/nuvio/tv/data/simkl/SimklRefreshPolicy.kt
+++ b/app/src/main/java/com/nuvio/tv/data/simkl/SimklRefreshPolicy.kt
@@ -1,8 +1,7 @@
 package com.nuvio.tv.data.simkl
 
 import com.nuvio.tv.core.tracking.TrackingRefreshIntent
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import com.nuvio.tv.core.tracking.TrackingRefreshGate
 
 const val SIMKL_AUTOMATIC_REFRESH_INTERVAL_MINUTES = 15
 const val SIMKL_AUTOMATIC_REFRESH_INTERVAL_MS =
@@ -21,31 +20,4 @@ fun shouldRunSimklRefresh(
     return elapsedMs < 0L || elapsedMs >= automaticIntervalMs
 }
 
-class SimklRefreshGate {
-    private val mutex = Mutex()
-    @Volatile private var completionSequence = 0L
-    private var lastCompletedProfileGeneration: Long? = null
-
-    suspend fun runIfNeeded(
-        profileGeneration: Long,
-        shouldRun: () -> Boolean,
-        block: suspend () -> Unit
-    ) {
-        val observedSequence = completionSequence
-        mutex.withLock {
-            if (
-                completionSequence != observedSequence &&
-                lastCompletedProfileGeneration == profileGeneration
-            ) {
-                return
-            }
-            if (!shouldRun()) return
-            try {
-                block()
-            } finally {
-                lastCompletedProfileGeneration = profileGeneration
-                completionSequence += 1L
-            }
-        }
-    }
-}
+typealias SimklRefreshGate = TrackingRefreshGate

--- a/app/src/main/java/com/nuvio/tv/domain/model/LibraryListTabLocalization.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/LibraryListTabLocalization.kt
@@ -4,6 +4,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.nuvio.tv.R
 import com.nuvio.tv.core.tracking.LOCAL_LIBRARY_LIST_KEY
+import com.nuvio.tv.core.tracking.TrackingProviderId
+
+@Composable
+fun LibraryListTab.localizedMembershipTitle(): String {
+    val provider = when (TrackingProviderId.fromStorage(trackingProviderId)) {
+        TrackingProviderId.TRAKT -> stringResource(R.string.trakt_name)
+        TrackingProviderId.SIMKL -> stringResource(R.string.simkl_name)
+        TrackingProviderId.MDBLIST -> stringResource(R.string.mdblist_name)
+        null -> null
+    }
+    return provider?.let { "$it · ${localizedTitle()}" } ?: localizedTitle()
+}
 
 @Composable
 fun LibraryListTab.localizedTitle(): String {

--- a/app/src/main/java/com/nuvio/tv/domain/model/LibraryModels.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/LibraryModels.kt
@@ -17,6 +17,7 @@ data class LibraryEntry(
     val genres: List<String>,
     val addonBaseUrl: String?,
     val listKeys: Set<String> = emptySet(),
+    val listRanks: Map<String, Int> = emptyMap(),
     val listedAt: Long = 0L,
     val traktRank: Int? = null,
     val imdbId: String? = null,
@@ -54,17 +55,18 @@ data class LibraryEntry(
 enum class LibrarySourceMode {
     LOCAL,
     TRAKT,
-    SIMKL
+    SIMKL,
+    MDBLIST
 }
 
-enum class TraktListPrivacy(val apiValue: String) {
+enum class LibraryListPrivacy(val apiValue: String) {
     PRIVATE("private"),
     LINK("link"),
     FRIENDS("friends"),
     PUBLIC("public");
 
     companion object {
-        fun fromApi(value: String?): TraktListPrivacy {
+        fun fromApi(value: String?): LibraryListPrivacy {
             return entries.firstOrNull { it.apiValue.equals(value, ignoreCase = true) } ?: PRIVATE
         }
     }
@@ -78,7 +80,7 @@ data class LibraryListTab(
     val traktListId: Long? = null,
     val slug: String? = null,
     val description: String? = null,
-    val privacy: TraktListPrivacy? = null,
+    val privacy: LibraryListPrivacy? = null,
     val sortBy: String? = null,
     val sortHow: String? = null,
     val trackingProviderId: String? = null,

--- a/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/model/WatchProgress.kt
@@ -30,7 +30,9 @@ data class WatchProgress(
     val simklPlaybackId: Long? = null,
     override val trackingProviderId: String? = null,
     override val trackingProviderItemId: String? = null,
-    override val trackingSourceUrl: String? = null
+    override val trackingSourceUrl: String? = null,
+    val completionThresholdOverride: Float? = null,
+    val excludedNextUpSeasons: Set<Int> = emptySet()
 ) : TrackingAttributedItem {
     override val trackingContentId: String
         get() = contentId
@@ -41,6 +43,8 @@ data class WatchProgress(
         const val SOURCE_TRAKT_HISTORY = "trakt_history"
         const val SOURCE_TRAKT_SHOW_PROGRESS = "trakt_show_progress"
         const val SOURCE_SIMKL_PLAYBACK = "simkl_playback"
+        const val SOURCE_REMOTE_PLAYBACK = "remote_playback"
+        const val SOURCE_REMOTE_HISTORY = "remote_history"
         const val STARTED_THRESHOLD = 0.02f
         const val COMPLETED_THRESHOLD = 0.90f
         const val SIMKL_COMPLETED_THRESHOLD = 0.80f
@@ -69,7 +73,8 @@ data class WatchProgress(
         progressPercentage >= startThreshold && progressPercentage < endThreshold
 
     private fun completionThreshold(): Float =
-        if (source == SOURCE_SIMKL_PLAYBACK) SIMKL_COMPLETED_THRESHOLD else COMPLETED_THRESHOLD
+        completionThresholdOverride?.takeIf { it.isFinite() && it > 0f && it <= 1f }
+            ?: if (source == SOURCE_SIMKL_PLAYBACK) SIMKL_COMPLETED_THRESHOLD else COMPLETED_THRESHOLD
 
     /**
      * Returns the remaining time in milliseconds

--- a/app/src/main/java/com/nuvio/tv/domain/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/domain/repository/LibraryRepository.kt
@@ -6,7 +6,7 @@ import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.ListMembershipSnapshot
-import com.nuvio.tv.domain.model.TraktListPrivacy
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import com.nuvio.tv.core.tracking.TrackingMembershipApplyResult
 import com.nuvio.tv.core.tracking.TrackingProviderId
 import kotlinx.coroutines.flow.Flow
@@ -35,17 +35,19 @@ interface LibraryRepository {
     suspend fun createPersonalList(
         name: String,
         description: String?,
-        privacy: TraktListPrivacy
+        privacy: LibraryListPrivacy,
+        source: LibrarySourceMode
     )
 
     suspend fun updatePersonalList(
         listId: String,
         name: String,
         description: String?,
-        privacy: TraktListPrivacy
+        privacy: LibraryListPrivacy,
+        source: LibrarySourceMode
     )
 
-    suspend fun deletePersonalList(listId: String)
-    suspend fun reorderPersonalLists(orderedListIds: List<String>)
+    suspend fun deletePersonalList(listId: String, source: LibrarySourceMode)
+    suspend fun reorderPersonalLists(orderedListIds: List<String>, source: LibrarySourceMode)
     suspend fun refreshNow()
 }

--- a/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/posteroptions/PosterOptionsDialog.kt
@@ -31,7 +31,7 @@ import com.nuvio.tv.core.tracking.TrackingMembershipRemovalConfirmation
 import com.nuvio.tv.core.tracking.LOCAL_LIBRARY_LIST_KEY
 import com.nuvio.tv.core.tracking.supportsMembershipFor
 import com.nuvio.tv.domain.model.LibraryListTab
-import com.nuvio.tv.domain.model.localizedTitle
+import com.nuvio.tv.domain.model.localizedMembershipTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.ui.components.NuvioDialog
 
@@ -159,7 +159,7 @@ fun PosterListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "✓ ${tab.localizedTitle()}" else tab.localizedTitle()
+                val titleText = if (selected) "✓ ${tab.localizedMembershipTitle()}" else tab.localizedMembershipTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/detail/MetaDetailsScreen.kt
@@ -101,7 +101,7 @@ import com.nuvio.tv.domain.model.DetailImdbRatingsVisibility
 import com.nuvio.tv.domain.model.EpisodeOptionsOverlayStyle
 import com.nuvio.tv.domain.model.HomeImdbRatingsVisibility
 import com.nuvio.tv.domain.model.LibraryListTab
-import com.nuvio.tv.domain.model.localizedTitle
+import com.nuvio.tv.domain.model.localizedMembershipTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.Meta
 import com.nuvio.tv.domain.model.MetaCastMember
@@ -2540,7 +2540,7 @@ private fun LibraryListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "\u2713 ${tab.localizedTitle()}" else tab.localizedTitle()
+                val titleText = if (selected) "\u2713 ${tab.localizedMembershipTitle()}" else tab.localizedMembershipTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeScreen.kt
@@ -47,7 +47,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.domain.model.HomeLayout
 import com.nuvio.tv.domain.model.LibraryListTab
-import com.nuvio.tv.domain.model.localizedTitle
+import com.nuvio.tv.domain.model.localizedMembershipTitle
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.MetaPreview
 import com.nuvio.tv.ui.components.ErrorState
@@ -819,7 +819,7 @@ private fun HomeLibraryListPickerDialog(
         ) {
             items(tabs, key = { it.key }) { tab ->
                 val selected = membership[tab.key] == true
-                val titleText = if (selected) "\u2713 ${tab.localizedTitle()}" else tab.localizedTitle()
+                val titleText = if (selected) "\u2713 ${tab.localizedMembershipTitle()}" else tab.localizedMembershipTitle()
                 Button(
                     onClick = { onToggle(tab.key) },
                     enabled = !isPending,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/HomeViewModelContinueWatching.kt
@@ -2221,7 +2221,7 @@ private const val CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7
 internal fun isNextUpEpisodeUnaired(releaseDate: LocalDate?, today: LocalDate): Boolean =
     releaseDate == null || releaseDate.isAfter(today)
 
-private fun resolveNextUpVideoFromMeta(
+internal fun resolveNextUpVideoFromMeta(
     progress: WatchProgress,
     meta: CwMetaSummary,
     showUnairedNextUp: Boolean
@@ -2274,6 +2274,7 @@ private fun resolveNextUpVideoFromMeta(
     val todayLocal = LocalDate.now(ZoneId.systemDefault())
     val watchedEpisodeSeason = episodes[watchedIndex].season
     val nextVideo = episodes.drop(watchedIndex + 1).firstOrNull { video ->
+        if (video.season in progress.excludedNextUpSeasons) return@firstOrNull false
         val releaseDate = parseEpisodeReleaseDate(video.released)
         val isSeasonRollover = video.season != watchedEpisodeSeason
         if (isSeasonRollover) {
@@ -2533,7 +2534,7 @@ private fun buildLightweightEpisodeVideoId(
     episode: Int
 ): String = "$contentId:$season:$episode"
 
-private fun buildNextUpSeedCacheKey(
+internal fun buildNextUpSeedCacheKey(
     progress: WatchProgress,
     showUnairedNextUp: Boolean
 ): String {
@@ -2545,6 +2546,10 @@ private fun buildNextUpSeedCacheKey(
         append(progress.episode ?: -1)
         append("|unaired=")
         append(showUnairedNextUp)
+        if (progress.excludedNextUpSeasons.isNotEmpty()) {
+            append("|excluded=")
+            append(progress.excludedNextUpSeasons.sorted().joinToString(","))
+        }
     }
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryListDialogs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryListDialogs.kt
@@ -1,0 +1,355 @@
+package com.nuvio.tv.ui.screens.library
+
+import android.view.KeyEvent as AndroidKeyEvent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import kotlinx.coroutines.delay
+import com.nuvio.tv.domain.model.localizedTitle
+import com.nuvio.tv.ui.components.NuvioDialog
+import com.nuvio.tv.ui.theme.NuvioTheme
+import androidx.compose.ui.res.stringResource
+import com.nuvio.tv.R
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+internal fun ManageListsDialog(
+    tabs: List<LibraryListTab>,
+    capabilities: TrackingListManagementCapabilities,
+    selectedKey: String?,
+    errorMessage: String?,
+    pending: Boolean,
+    onSelect: (String) -> Unit,
+    onCreate: () -> Unit,
+    onEdit: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val personalTabs = remember(tabs) { tabs.filter { it.type == LibraryListTab.Type.PERSONAL } }
+    val firstFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(personalTabs.size, pending) {
+        if (pending) return@LaunchedEffect
+        val target = firstFocusRequester
+        val focused = runCatching { target.requestFocus() }.isSuccess
+        if (!focused) {
+            delay(16)
+            runCatching { target.requestFocus() }
+        }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .width(620.dp)
+                .background(NuvioTheme.colors.BackgroundElevated, RoundedCornerShape(NuvioTheme.radii.xl))
+                .padding(NuvioTheme.spacing.xl)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                Text(
+                    text = stringResource(R.string.library_manage_lists),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = NuvioTheme.colors.TextPrimary
+                )
+
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color(0xFFFFB6B6)
+                    )
+                }
+
+                if (personalTabs.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.library_no_lists),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = NuvioTheme.extendedColors.textSecondary
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(220.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        items(personalTabs, key = { it.key }) { tab ->
+                            val selected = tab.key == selectedKey
+                            Button(
+                                onClick = { onSelect(tab.key) },
+                                enabled = !pending,
+                                modifier = if (tab.key == personalTabs.firstOrNull()?.key) {
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(firstFocusRequester)
+                                } else {
+                                    Modifier.fillMaxWidth()
+                                },
+                                colors = ButtonDefaults.colors(
+                                    containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
+                                    contentColor = NuvioTheme.colors.TextPrimary
+                                )
+                            ) {
+                                Text(
+                                    text = tab.localizedTitle(),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Button(
+                        onClick = onCreate,
+                        modifier = if (personalTabs.isEmpty()) Modifier.focusRequester(firstFocusRequester) else Modifier,
+                        enabled = !pending,
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioTheme.colors.BackgroundCard,
+                            contentColor = NuvioTheme.colors.TextPrimary
+                        )
+                    ) { Text(stringResource(R.string.library_list_create)) }
+                    Button(
+                        onClick = onEdit,
+                        enabled = !pending && selectedKey != null,
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioTheme.colors.BackgroundCard,
+                            contentColor = NuvioTheme.colors.TextPrimary
+                        )
+                    ) { Text(stringResource(R.string.library_list_edit)) }
+                    if (capabilities.supportsReordering) {
+                        Button(
+                            onClick = onMoveUp,
+                            enabled = !pending && selectedKey != null,
+                            colors = ButtonDefaults.colors(
+                                containerColor = NuvioTheme.colors.BackgroundCard,
+                                contentColor = NuvioTheme.colors.TextPrimary
+                            )
+                        ) { Text(stringResource(R.string.library_list_move_up)) }
+                        Button(
+                            onClick = onMoveDown,
+                            enabled = !pending && selectedKey != null,
+                            colors = ButtonDefaults.colors(
+                                containerColor = NuvioTheme.colors.BackgroundCard,
+                                contentColor = NuvioTheme.colors.TextPrimary
+                            )
+                        ) { Text(stringResource(R.string.library_list_move_down)) }
+                    }
+                }
+
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Button(
+                        onClick = onDelete,
+                        enabled = !pending && selectedKey != null,
+                        colors = ButtonDefaults.colors(
+                            containerColor = Color(0xFF4A2323),
+                            contentColor = NuvioTheme.colors.TextPrimary
+                        )
+                    ) { Text(stringResource(R.string.library_list_delete)) }
+                    Button(
+                        onClick = onDismiss,
+                        enabled = !pending,
+                        colors = ButtonDefaults.colors(
+                            containerColor = NuvioTheme.colors.BackgroundCard,
+                            contentColor = NuvioTheme.colors.TextPrimary
+                        )
+                    ) { Text(stringResource(R.string.library_list_close)) }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+internal fun ListEditorDialog(
+    state: LibraryListEditorState,
+    capabilities: TrackingListManagementCapabilities,
+    pending: Boolean,
+    onNameChanged: (String) -> Unit,
+    onDescriptionChanged: (String) -> Unit,
+    onPrivacyChanged: (LibraryListPrivacy) -> Unit,
+    onSave: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val nameFocusRequester = remember { FocusRequester() }
+    val descriptionFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    var nameEditing by remember { mutableStateOf(false) }
+    var descriptionEditing by remember { mutableStateOf(false) }
+
+    fun isSelectKey(keyCode: Int): Boolean {
+        return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
+            keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
+            keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
+    }
+
+    LaunchedEffect(Unit) {
+        nameFocusRequester.requestFocus()
+    }
+
+    NuvioDialog(
+        onDismiss = onCancel,
+        title = if (state.mode == LibraryListEditorState.Mode.CREATE) stringResource(R.string.library_list_create_dialog_title) else stringResource(R.string.library_list_edit_dialog_title),
+        width = 560.dp
+    ) {
+        androidx.compose.material3.OutlinedTextField(
+            value = state.name,
+            onValueChange = onNameChanged,
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(nameFocusRequester)
+                .onFocusChanged {
+                    if (!it.isFocused) {
+                        nameEditing = false
+                    }
+                }
+                .onPreviewKeyEvent { event ->
+                    val native = event.nativeKeyEvent
+                    if (native.action == AndroidKeyEvent.ACTION_DOWN && isSelectKey(native.keyCode)) {
+                        nameEditing = true
+                        descriptionEditing = false
+                        keyboardController?.show()
+                    }
+                    false
+                },
+            enabled = !pending,
+            readOnly = !nameEditing,
+            singleLine = true,
+            maxLines = 1,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    nameEditing = false
+                    keyboardController?.hide()
+                }
+            ),
+            label = { androidx.compose.material3.Text(stringResource(R.string.library_list_name_label)) },
+            colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                focusedTextColor = NuvioTheme.colors.TextPrimary,
+                unfocusedTextColor = NuvioTheme.colors.TextPrimary,
+                focusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                focusedBorderColor = NuvioTheme.colors.FocusRing,
+                unfocusedBorderColor = NuvioTheme.colors.Border,
+                focusedLabelColor = NuvioTheme.colors.TextSecondary,
+                unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
+                cursorColor = NuvioTheme.colors.FocusRing
+            )
+        )
+
+        if (capabilities.supportsDescription) {
+            androidx.compose.material3.OutlinedTextField(
+                value = state.description,
+                onValueChange = onDescriptionChanged,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(descriptionFocusRequester)
+                    .onFocusChanged {
+                        if (!it.isFocused) {
+                            descriptionEditing = false
+                        }
+                    }
+                    .onPreviewKeyEvent { event ->
+                        val native = event.nativeKeyEvent
+                        if (native.action == AndroidKeyEvent.ACTION_DOWN && isSelectKey(native.keyCode)) {
+                            descriptionEditing = true
+                            nameEditing = false
+                            keyboardController?.show()
+                        }
+                        false
+                    },
+                enabled = !pending,
+                readOnly = !descriptionEditing,
+                minLines = 3,
+                maxLines = 5,
+                label = { androidx.compose.material3.Text(stringResource(R.string.library_list_description_label)) },
+                colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = NuvioTheme.colors.TextPrimary,
+                    unfocusedTextColor = NuvioTheme.colors.TextPrimary,
+                    focusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                    unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
+                    focusedBorderColor = NuvioTheme.colors.FocusRing,
+                    unfocusedBorderColor = NuvioTheme.colors.Border,
+                    focusedLabelColor = NuvioTheme.colors.TextSecondary,
+                    unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
+                    cursorColor = NuvioTheme.colors.FocusRing
+                )
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.library_list_privacy),
+            style = MaterialTheme.typography.bodyMedium,
+            color = NuvioTheme.extendedColors.textSecondary
+        )
+
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            items(capabilities.privacyOptions, key = { it.name }) { privacy ->
+                val selected = privacy == state.privacy
+                Button(
+                    onClick = { onPrivacyChanged(privacy) },
+                    enabled = !pending,
+                    colors = ButtonDefaults.colors(
+                        containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
+                        contentColor = NuvioTheme.colors.TextPrimary
+                    )
+                ) {
+                    Text(privacy.apiValue.replaceFirstChar { it.uppercase() })
+                }
+            }
+        }
+
+        Button(
+            onClick = onSave,
+            enabled = !pending,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.colors(
+                containerColor = NuvioTheme.colors.BackgroundCard,
+                contentColor = NuvioTheme.colors.TextPrimary
+            )
+        ) {
+            Text(if (pending) stringResource(R.string.action_saving) else stringResource(R.string.action_save))
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -38,15 +37,15 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MenuDefaults
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -67,7 +66,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
@@ -87,7 +85,6 @@ import com.nuvio.tv.core.cloud.CloudLibraryPlaybackInfo
 import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.PosterShape
-import com.nuvio.tv.domain.model.TraktListPrivacy
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.ui.components.EmptyScreenState
 import com.nuvio.tv.ui.components.GridContentCard
@@ -101,7 +98,6 @@ import com.nuvio.tv.domain.model.localizedTitle
 import com.nuvio.tv.ui.components.LoadingIndicator
 import com.nuvio.tv.ui.components.NuvioDialog
 import com.nuvio.tv.ui.theme.NuvioTheme
-import com.nuvio.tv.ui.util.formatAddonTypeLabel
 import com.nuvio.tv.ui.util.localizedContentType
 import com.nuvio.tv.ui.util.localizedGenreLabel
 import kotlinx.coroutines.delay
@@ -134,7 +130,7 @@ fun LibraryScreen(
     val watchedSeriesIds by viewModel.watchedSeriesIds.collectAsState()
     val activityContext = LocalContext.current
     val scope = rememberCoroutineScope()
-    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember(uiState.showManageDialog) { mutableStateOf(false) }
     var expandedPicker by remember { mutableStateOf<String?>(null) }
     var viewMode by rememberSaveable { mutableStateOf(LibraryViewMode.Saved) }
     var activeCloudItem by remember { mutableStateOf<CloudLibraryItem?>(null) }
@@ -302,6 +298,7 @@ fun LibraryScreen(
                         viewMode == LibraryViewMode.Cloud -> stringResource(R.string.library_source_cloud).uppercase()
                         uiState.sourceMode == LibrarySourceMode.TRAKT -> "TRAKT"
                         uiState.sourceMode == LibrarySourceMode.SIMKL -> "SIMKL"
+                        uiState.sourceMode == LibrarySourceMode.MDBLIST -> "MDBLIST"
                         uiState.isNuvioAccount -> "NUVIO"
                         else -> stringResource(R.string.library_source_local)
                     },
@@ -395,12 +392,12 @@ fun LibraryScreen(
                 )
             }
 
-            if (uiState.sourceMode == LibrarySourceMode.TRAKT && uiState.isTrackingAuthenticated) {
+            if (uiState.listManagement != null && uiState.isTrackingAuthenticated) {
                 item(span = { GridItemSpan(maxLineSpan) }) {
                     LibraryActionsRow(
                         pending = uiState.pendingOperation,
                         isSyncing = uiState.isSyncing,
-                        showManageLists = uiState.sourceMode == LibrarySourceMode.TRAKT,
+                        showManageLists = uiState.listManagement != null,
                         onManageLists = viewModel::onOpenManageLists,
                         onRefresh = viewModel::onRefresh
                     )
@@ -413,14 +410,14 @@ fun LibraryScreen(
                     val title = when {
                         uiState.sourceMode == LibrarySourceMode.TRAKT && !uiState.isTrackingAuthenticated -> stringResource(R.string.library_empty_trakt_not_auth_title)
                         uiState.sourceMode == LibrarySourceMode.SIMKL && !uiState.isTrackingAuthenticated -> stringResource(R.string.library_empty_simkl_not_auth_title)
-                        uiState.sourceMode == LibrarySourceMode.TRAKT -> stringResource(R.string.library_empty_trakt_title, selectedTypeLabel)
+                        uiState.sourceMode == LibrarySourceMode.TRAKT || uiState.sourceMode == LibrarySourceMode.MDBLIST -> stringResource(R.string.library_empty_trakt_title, selectedTypeLabel)
                         uiState.sourceMode == LibrarySourceMode.SIMKL -> stringResource(R.string.library_empty_simkl_title, selectedTypeLabel)
                         else -> stringResource(R.string.library_empty_local_title, selectedTypeLabel)
                     }
                     val subtitle = when {
                         uiState.sourceMode == LibrarySourceMode.TRAKT && !uiState.isTrackingAuthenticated -> stringResource(R.string.library_empty_trakt_not_auth_subtitle)
                         uiState.sourceMode == LibrarySourceMode.SIMKL && !uiState.isTrackingAuthenticated -> stringResource(R.string.library_empty_simkl_not_auth_subtitle)
-                        uiState.sourceMode == LibrarySourceMode.TRAKT -> stringResource(R.string.library_empty_trakt_subtitle)
+                        uiState.sourceMode == LibrarySourceMode.TRAKT || uiState.sourceMode == LibrarySourceMode.MDBLIST -> stringResource(R.string.library_empty_trakt_subtitle)
                         uiState.sourceMode == LibrarySourceMode.SIMKL -> stringResource(R.string.library_empty_simkl_subtitle)
                         else -> stringResource(R.string.library_empty_local_subtitle)
                     }
@@ -546,8 +543,9 @@ fun LibraryScreen(
         item(span = { GridItemSpan(maxLineSpan) }) { Spacer(modifier = Modifier.height(NuvioTheme.spacing.sm)) }
     }
 
-    if (uiState.showManageDialog && uiState.sourceMode == LibrarySourceMode.TRAKT) {
+    if (uiState.showManageDialog && uiState.listManagement != null) {
         ManageListsDialog(
+            capabilities = requireNotNull(uiState.listManagement),
             tabs = uiState.listTabs,
             selectedKey = uiState.manageSelectedListKey,
             errorMessage = uiState.errorMessage,
@@ -562,7 +560,7 @@ fun LibraryScreen(
         )
     }
 
-    if (showDeleteConfirm) {
+    if (showDeleteConfirm && uiState.showManageDialog) {
         ConfirmDeleteDialog(
             pending = uiState.pendingOperation,
             onConfirm = {
@@ -574,8 +572,9 @@ fun LibraryScreen(
     }
 
     val listEditor = uiState.listEditorState
-    if (listEditor != null && uiState.showManageDialog) {
+    if (listEditor != null && uiState.showManageDialog && uiState.listManagement != null) {
         ListEditorDialog(
+            capabilities = requireNotNull(uiState.listManagement),
             state = listEditor,
             pending = uiState.pendingOperation,
             onNameChanged = viewModel::onUpdateEditorName,
@@ -1454,306 +1453,6 @@ private fun LibraryActionsRow(
             )
         ) {
             Text(if (isSyncing) stringResource(R.string.library_syncing_btn) else stringResource(R.string.library_sync_btn))
-        }
-    }
-}
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun ManageListsDialog(
-    tabs: List<LibraryListTab>,
-    selectedKey: String?,
-    errorMessage: String?,
-    pending: Boolean,
-    onSelect: (String) -> Unit,
-    onCreate: () -> Unit,
-    onEdit: () -> Unit,
-    onMoveUp: () -> Unit,
-    onMoveDown: () -> Unit,
-    onDelete: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    val personalTabs = remember(tabs) { tabs.filter { it.type == LibraryListTab.Type.PERSONAL } }
-    val firstFocusRequester = remember { FocusRequester() }
-    val closeFocusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(personalTabs.size) {
-        val target = if (personalTabs.isNotEmpty()) firstFocusRequester else closeFocusRequester
-        val focused = runCatching { target.requestFocus() }.isSuccess
-        if (!focused) {
-            delay(16)
-            runCatching { target.requestFocus() }
-        }
-    }
-
-    Dialog(onDismissRequest = onDismiss) {
-        Box(
-            modifier = Modifier
-                .width(620.dp)
-                .background(NuvioTheme.colors.BackgroundElevated, RoundedCornerShape(NuvioTheme.radii.xl))
-                .padding(NuvioTheme.spacing.xl)
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-                Text(
-                    text = stringResource(R.string.library_manage_trakt_lists),
-                    style = MaterialTheme.typography.titleLarge,
-                    color = NuvioTheme.colors.TextPrimary
-                )
-
-                if (errorMessage != null) {
-                    Text(
-                        text = errorMessage,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color(0xFFFFB6B6)
-                    )
-                }
-
-                if (personalTabs.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.library_no_lists),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = NuvioTheme.extendedColors.textSecondary
-                    )
-                } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(220.dp),
-                        verticalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        items(personalTabs, key = { it.key }) { tab ->
-                            val selected = tab.key == selectedKey
-                            Button(
-                                onClick = { onSelect(tab.key) },
-                                enabled = !pending,
-                                modifier = if (tab.key == personalTabs.firstOrNull()?.key) {
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .focusRequester(firstFocusRequester)
-                                } else {
-                                    Modifier.fillMaxWidth()
-                                },
-                                colors = ButtonDefaults.colors(
-                                    containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
-                                    contentColor = NuvioTheme.colors.TextPrimary
-                                )
-                            ) {
-                                Text(
-                                    text = tab.localizedTitle(),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                        }
-                    }
-                }
-
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Button(
-                        onClick = onCreate,
-                        enabled = !pending,
-                        colors = ButtonDefaults.colors(
-                            containerColor = NuvioTheme.colors.BackgroundCard,
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_create)) }
-                    Button(
-                        onClick = onEdit,
-                        enabled = !pending && selectedKey != null,
-                        colors = ButtonDefaults.colors(
-                            containerColor = NuvioTheme.colors.BackgroundCard,
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_edit)) }
-                    Button(
-                        onClick = onMoveUp,
-                        enabled = !pending && selectedKey != null,
-                        colors = ButtonDefaults.colors(
-                            containerColor = NuvioTheme.colors.BackgroundCard,
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_move_up)) }
-                    Button(
-                        onClick = onMoveDown,
-                        enabled = !pending && selectedKey != null,
-                        colors = ButtonDefaults.colors(
-                            containerColor = NuvioTheme.colors.BackgroundCard,
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_move_down)) }
-                }
-
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Button(
-                        onClick = onDelete,
-                        enabled = !pending && selectedKey != null,
-                        colors = ButtonDefaults.colors(
-                            containerColor = Color(0xFF4A2323),
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_delete)) }
-                    Button(
-                        onClick = onDismiss,
-                        enabled = !pending,
-                        modifier = Modifier.focusRequester(closeFocusRequester),
-                        colors = ButtonDefaults.colors(
-                            containerColor = NuvioTheme.colors.BackgroundCard,
-                            contentColor = NuvioTheme.colors.TextPrimary
-                        )
-                    ) { Text(stringResource(R.string.library_list_close)) }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun ListEditorDialog(
-    state: LibraryListEditorState,
-    pending: Boolean,
-    onNameChanged: (String) -> Unit,
-    onDescriptionChanged: (String) -> Unit,
-    onPrivacyChanged: (TraktListPrivacy) -> Unit,
-    onSave: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val nameFocusRequester = remember { FocusRequester() }
-    val descriptionFocusRequester = remember { FocusRequester() }
-    val keyboardController = LocalSoftwareKeyboardController.current
-    var nameEditing by remember { mutableStateOf(false) }
-    var descriptionEditing by remember { mutableStateOf(false) }
-
-    fun isSelectKey(keyCode: Int): Boolean {
-        return keyCode == AndroidKeyEvent.KEYCODE_DPAD_CENTER ||
-            keyCode == AndroidKeyEvent.KEYCODE_ENTER ||
-            keyCode == AndroidKeyEvent.KEYCODE_NUMPAD_ENTER
-    }
-
-    LaunchedEffect(Unit) {
-        nameFocusRequester.requestFocus()
-    }
-
-    NuvioDialog(
-        onDismiss = onCancel,
-        title = if (state.mode == LibraryListEditorState.Mode.CREATE) stringResource(R.string.library_list_create_dialog_title) else stringResource(R.string.library_list_edit_dialog_title),
-        width = 560.dp
-    ) {
-        androidx.compose.material3.OutlinedTextField(
-            value = state.name,
-            onValueChange = onNameChanged,
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(nameFocusRequester)
-                .onFocusChanged {
-                    if (!it.isFocused) {
-                        nameEditing = false
-                    }
-                }
-                .onPreviewKeyEvent { event ->
-                    val native = event.nativeKeyEvent
-                    if (native.action == AndroidKeyEvent.ACTION_DOWN && isSelectKey(native.keyCode)) {
-                        nameEditing = true
-                        descriptionEditing = false
-                        keyboardController?.show()
-                    }
-                    false
-                },
-            enabled = !pending,
-            readOnly = !nameEditing,
-            singleLine = true,
-            maxLines = 1,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    nameEditing = false
-                    keyboardController?.hide()
-                }
-            ),
-            label = { androidx.compose.material3.Text(stringResource(R.string.library_list_name_label)) },
-            colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
-                focusedTextColor = NuvioTheme.colors.TextPrimary,
-                unfocusedTextColor = NuvioTheme.colors.TextPrimary,
-                focusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                focusedBorderColor = NuvioTheme.colors.FocusRing,
-                unfocusedBorderColor = NuvioTheme.colors.Border,
-                focusedLabelColor = NuvioTheme.colors.TextSecondary,
-                unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
-                cursorColor = NuvioTheme.colors.FocusRing
-            )
-        )
-
-        androidx.compose.material3.OutlinedTextField(
-            value = state.description,
-            onValueChange = onDescriptionChanged,
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(descriptionFocusRequester)
-                .onFocusChanged {
-                    if (!it.isFocused) {
-                        descriptionEditing = false
-                    }
-                }
-                .onPreviewKeyEvent { event ->
-                    val native = event.nativeKeyEvent
-                    if (native.action == AndroidKeyEvent.ACTION_DOWN && isSelectKey(native.keyCode)) {
-                        descriptionEditing = true
-                        nameEditing = false
-                        keyboardController?.show()
-                    }
-                    false
-                },
-            enabled = !pending,
-            readOnly = !descriptionEditing,
-            minLines = 3,
-            maxLines = 5,
-            label = { androidx.compose.material3.Text(stringResource(R.string.library_list_description_label)) },
-            colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
-                focusedTextColor = NuvioTheme.colors.TextPrimary,
-                unfocusedTextColor = NuvioTheme.colors.TextPrimary,
-                focusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                unfocusedContainerColor = NuvioTheme.colors.BackgroundCard,
-                focusedBorderColor = NuvioTheme.colors.FocusRing,
-                unfocusedBorderColor = NuvioTheme.colors.Border,
-                focusedLabelColor = NuvioTheme.colors.TextSecondary,
-                unfocusedLabelColor = NuvioTheme.colors.TextTertiary,
-                cursorColor = NuvioTheme.colors.FocusRing
-            )
-        )
-
-        Text(
-            text = stringResource(R.string.library_list_privacy),
-            style = MaterialTheme.typography.bodyMedium,
-            color = NuvioTheme.extendedColors.textSecondary
-        )
-
-        LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            items(TraktListPrivacy.entries.toList(), key = { it.name }) { privacy ->
-                val selected = privacy == state.privacy
-                Button(
-                    onClick = { onPrivacyChanged(privacy) },
-                    enabled = !pending,
-                    colors = ButtonDefaults.colors(
-                        containerColor = if (selected) NuvioTheme.colors.FocusBackground else NuvioTheme.colors.BackgroundCard,
-                        contentColor = NuvioTheme.colors.TextPrimary
-                    )
-                ) {
-                    Text(privacy.apiValue.replaceFirstChar { it.uppercase() })
-                }
-            }
-        }
-
-        Button(
-            onClick = onSave,
-            enabled = !pending,
-            modifier = Modifier.fillMaxWidth(),
-            colors = ButtonDefaults.colors(
-                containerColor = NuvioTheme.colors.BackgroundCard,
-                contentColor = NuvioTheme.colors.TextPrimary
-            )
-        ) {
-            Text(if (pending) stringResource(R.string.action_saving) else stringResource(R.string.action_save))
         }
     }
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/library/LibraryViewModel.kt
@@ -17,6 +17,7 @@ import com.nuvio.tv.core.player.ExternalPlaybackTracker
 import com.nuvio.tv.core.debrid.DebridProviderCapability
 import com.nuvio.tv.core.debrid.DebridProviders
 import com.nuvio.tv.core.debrid.supports
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
 import com.nuvio.tv.core.tracking.TrackingLibraryProviderRegistry
 import com.nuvio.tv.core.tracking.providerId
 import com.nuvio.tv.data.local.DebridSettingsDataStore
@@ -24,12 +25,11 @@ import com.nuvio.tv.data.local.LayoutPreferenceDataStore
 import com.nuvio.tv.data.local.LibraryPreferences
 import com.nuvio.tv.data.local.PlayerPreference
 import com.nuvio.tv.data.local.PlayerSettingsDataStore
-import com.nuvio.tv.data.repository.TraktLibraryService
 import com.nuvio.tv.domain.model.AuthState
 import com.nuvio.tv.domain.model.LibraryEntry
 import com.nuvio.tv.domain.model.LibraryListTab
 import com.nuvio.tv.domain.model.LibrarySourceMode
-import com.nuvio.tv.domain.model.TraktListPrivacy
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import com.nuvio.tv.domain.repository.LibraryRepository
 import android.content.Context
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -98,7 +98,7 @@ data class LibraryListEditorState(
     val listId: String? = null,
     val name: String = "",
     val description: String = "",
-    val privacy: TraktListPrivacy = TraktListPrivacy.PRIVATE
+    val privacy: LibraryListPrivacy = LibraryListPrivacy.PRIVATE
 ) {
     enum class Mode {
         CREATE,
@@ -142,6 +142,7 @@ data class LibraryUiState(
     val isSyncing: Boolean = false,
     val errorMessage: String? = null,
     val transientMessage: String? = null,
+    val listManagement: TrackingListManagementCapabilities? = null,
     val showManageDialog: Boolean = false,
     val manageSelectedListKey: String? = null,
     val listEditorState: LibraryListEditorState? = null,
@@ -175,6 +176,8 @@ class LibraryViewModel @Inject constructor(
     val watchedMovieIds: StateFlow<Set<String>> = _watchedMovieIds.asStateFlow()
     val watchedSeriesIds: StateFlow<Set<String>> = watchedSeriesStateHolder.fullyWatchedSeriesIds
 
+    private class ListManagementContext(val profileId: Int, val source: LibrarySourceMode)
+    private var listManagementContext: ListManagementContext? = null
     private var messageClearJob: Job? = null
     private var cloudRefreshJob: Job? = null
 
@@ -182,6 +185,9 @@ class LibraryViewModel @Inject constructor(
         posterOptions.bind(viewModelScope)
         observeLayoutPreferences()
         observeLibraryData()
+        viewModelScope.launch {
+            profileManager.activeProfileId.collect { onCloseManageLists() }
+        }
         observeCloudLibrarySettings()
         viewModelScope.launch {
             watchProgressRepository.observeWatchedMovieIds()
@@ -434,76 +440,65 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun onOpenManageLists() {
-        _uiState.update { current ->
-            if (current.sourceMode != LibrarySourceMode.TRAKT) {
-                return@update current
-            }
-            current.copy(
+        val current = _uiState.value
+        if (current.listManagement == null || !current.isTrackingAuthenticated) return
+        listManagementContext = ListManagementContext(profileManager.activeProfileId.value, current.sourceMode)
+        _uiState.update {
+            it.copy(
                 showManageDialog = true,
-                manageSelectedListKey = current.manageSelectedListKey
-                    ?: current.listTabs.firstOrNull { it.type == LibraryListTab.Type.PERSONAL }?.key
+                manageSelectedListKey = it.manageSelectedListKey
+                    ?: it.listTabs.firstOrNull { tab -> tab.type == LibraryListTab.Type.PERSONAL }?.key
             )
         }
     }
 
     fun onCloseManageLists() {
-        _uiState.update { current ->
-            current.copy(
-                showManageDialog = false,
-                listEditorState = null,
-                errorMessage = null
-            )
-        }
+        listManagementContext = null
+        _uiState.update { it.copy(showManageDialog = false, listEditorState = null, pendingOperation = false, errorMessage = null) }
     }
 
     fun onSelectManageList(listKey: String) {
+        if (_uiState.value.pendingOperation) return
         _uiState.update { it.copy(manageSelectedListKey = listKey) }
     }
 
     fun onStartCreateList() {
+        if (!isListManagementCurrent()) return
         _uiState.update {
-            it.copy(
-                listEditorState = LibraryListEditorState(mode = LibraryListEditorState.Mode.CREATE),
-                errorMessage = null
-            )
+            it.copy(listEditorState = LibraryListEditorState(mode = LibraryListEditorState.Mode.CREATE), errorMessage = null)
         }
     }
 
     fun onStartEditList() {
+        if (!isListManagementCurrent()) return
         val selected = selectedManagePersonalList() ?: return
         _uiState.update {
             it.copy(
                 listEditorState = LibraryListEditorState(
                     mode = LibraryListEditorState.Mode.EDIT,
-                    listId = selected.traktListId?.toString(),
+                    listId = selected.key,
                     name = selected.title,
                     description = selected.description.orEmpty(),
-                    privacy = selected.privacy ?: TraktListPrivacy.PRIVATE
+                    privacy = selected.privacy ?: LibraryListPrivacy.PRIVATE
                 ),
                 errorMessage = null
             )
         }
     }
 
-    fun onUpdateEditorName(value: String) {
-        _uiState.update { current ->
-            val editor = current.listEditorState ?: return@update current
-            current.copy(listEditorState = editor.copy(name = value))
-        }
-    }
+    fun onUpdateEditorName(value: String) = updateListEditor { copy(name = value) }
 
     fun onUpdateEditorDescription(value: String) {
-        _uiState.update { current ->
-            val editor = current.listEditorState ?: return@update current
-            current.copy(listEditorState = editor.copy(description = value))
-        }
+        if (_uiState.value.listManagement?.supportsDescription == true) updateListEditor { copy(description = value) }
     }
 
-    fun onUpdateEditorPrivacy(value: TraktListPrivacy) {
-        _uiState.update { current ->
-            val editor = current.listEditorState ?: return@update current
-            current.copy(listEditorState = editor.copy(privacy = value))
-        }
+    fun onUpdateEditorPrivacy(value: LibraryListPrivacy) {
+        if (value in _uiState.value.listManagement?.privacyOptions.orEmpty()) updateListEditor { copy(privacy = value) }
+    }
+
+    private fun updateListEditor(update: LibraryListEditorState.() -> LibraryListEditorState) {
+        if (!isListManagementCurrent() || _uiState.value.pendingOperation) return
+        _uiState.update { current -> current.copy(listEditorState = current.listEditorState?.update()) }
     }
 
     fun onCancelEditor() {
@@ -517,70 +512,58 @@ class LibraryViewModel @Inject constructor(
             setError(context.getString(R.string.library_error_list_name_required))
             return
         }
-        if (_uiState.value.pendingOperation) return
-
-        viewModelScope.launch {
-            _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
-            runCatching {
-                when (editor.mode) {
-                    LibraryListEditorState.Mode.CREATE -> {
-                        libraryRepository.createPersonalList(
-                            name = name,
-                            description = editor.description.trim().ifBlank { null },
-                            privacy = editor.privacy
-                        )
-                        setTransientMessage(context.getString(R.string.library_list_created))
-                    }
-                    LibraryListEditorState.Mode.EDIT -> {
-                        val listId = editor.listId
-                            ?: throw IllegalStateException(context.getString(R.string.library_error_invalid_list))
-                        libraryRepository.updatePersonalList(
-                            listId = listId,
-                            name = name,
-                            description = editor.description.trim().ifBlank { null },
-                            privacy = editor.privacy
-                        )
-                        setTransientMessage(context.getString(R.string.library_list_updated))
-                    }
-                }
-            }.onSuccess {
-                _uiState.update { it.copy(listEditorState = null, pendingOperation = false) }
-            }.onFailure { error ->
-                _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: context.getString(R.string.library_error_save_list_failed))
+        val message = if (editor.mode == LibraryListEditorState.Mode.CREATE) R.string.library_list_created else R.string.library_list_updated
+        runListOperation(message, R.string.library_error_save_list_failed) { source ->
+            val description = editor.description.trim().takeIf { _uiState.value.listManagement?.supportsDescription == true && it.isNotBlank() }
+            when (editor.mode) {
+                LibraryListEditorState.Mode.CREATE -> libraryRepository.createPersonalList(name, description, editor.privacy, source)
+                LibraryListEditorState.Mode.EDIT -> libraryRepository.updatePersonalList(
+                    requireNotNull(editor.listId), name, description, editor.privacy, source
+                )
             }
         }
     }
 
     fun onDeleteSelectedList() {
-        val selected = selectedManagePersonalList() ?: return
-        val listId = selected.traktListId?.toString() ?: return
-        if (_uiState.value.pendingOperation) return
-
-        viewModelScope.launch {
-            _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
-            runCatching {
-                libraryRepository.deletePersonalList(listId)
-                setTransientMessage(context.getString(R.string.library_list_deleted))
-            }.onSuccess {
-                _uiState.update { it.copy(pendingOperation = false) }
-            }.onFailure { error ->
-                _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: context.getString(R.string.library_error_delete_list_failed))
-            }
+        val key = selectedManagePersonalList()?.key ?: return
+        runListOperation(R.string.library_list_deleted, R.string.library_error_delete_list_failed) { source ->
+            libraryRepository.deletePersonalList(key, source)
         }
     }
 
-    fun onMoveSelectedListUp() {
-        reorderSelectedList(moveUp = true)
-    }
+    fun onMoveSelectedListUp() = reorderSelectedList(moveUp = true)
 
-    fun onMoveSelectedListDown() {
-        reorderSelectedList(moveUp = false)
-    }
+    fun onMoveSelectedListDown() = reorderSelectedList(moveUp = false)
 
     fun onClearTransientMessage() {
         _uiState.update { it.copy(transientMessage = null) }
+    }
+
+    private fun isListManagementCurrent(expected: ListManagementContext? = listManagementContext): Boolean =
+        expected != null && expected == listManagementContext && expected.profileId == profileManager.activeProfileId.value &&
+            expected.source == _uiState.value.sourceMode && _uiState.value.showManageDialog &&
+            _uiState.value.isTrackingAuthenticated && _uiState.value.listManagement != null
+
+    private fun runListOperation(successMessage: Int, errorMessage: Int, action: suspend (LibrarySourceMode) -> Unit) {
+        if (!isListManagementCurrent() || _uiState.value.pendingOperation) return
+        val operationContext = requireNotNull(listManagementContext)
+        _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
+        viewModelScope.launch {
+            try {
+                if (!isListManagementCurrent(operationContext)) return@launch
+                action(operationContext.source)
+                if (isListManagementCurrent(operationContext)) {
+                    _uiState.update { it.copy(listEditorState = null) }
+                    setTransientMessage(context.getString(successMessage))
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                if (isListManagementCurrent(operationContext)) setError(error.message ?: context.getString(errorMessage))
+            } finally {
+                if (operationContext == listManagementContext) _uiState.update { it.copy(pendingOperation = false) }
+            }
+        }
     }
 
     private fun observeLibraryData() {
@@ -625,6 +608,7 @@ class LibraryViewModel @Inject constructor(
                 )
             }.collectLatest { bundle ->
                 val (sourceMode, isSyncing, items, listTabs, persistedSortKey, authState, isTrackingAuthenticated, persistedListKey, persistedTypeKey) = bundle
+                if (_uiState.value.sourceMode != sourceMode || !isTrackingAuthenticated) onCloseManageLists()
                 _uiState.update { current ->
                     val nextSelectedList = when {
                         sourceMode.providerId != null && isTrackingAuthenticated -> {
@@ -664,6 +648,7 @@ class LibraryViewModel @Inject constructor(
 
                     val updated = current.copy(
                         sourceMode = sourceMode,
+                        listManagement = sourceMode.providerId?.let(trackingProviderRegistry::provider)?.listManager?.capabilities,
                         allItems = items,
                         listTabs = listTabs,
                         availableSortOptions = sortOptions,
@@ -785,34 +770,15 @@ class LibraryViewModel @Inject constructor(
 
     private fun reorderSelectedList(moveUp: Boolean) {
         val state = _uiState.value
-        if (state.pendingOperation) return
-
+        if (state.listManagement?.supportsReordering != true) return
         val personalTabs = state.listTabs.filter { it.type == LibraryListTab.Type.PERSONAL }
-        val selectedKey = state.manageSelectedListKey ?: return
-        val selectedIndex = personalTabs.indexOfFirst { it.key == selectedKey }
+        val selectedIndex = personalTabs.indexOfFirst { it.key == state.manageSelectedListKey }
         if (selectedIndex < 0) return
-
         val targetIndex = if (moveUp) selectedIndex - 1 else selectedIndex + 1
         if (targetIndex !in personalTabs.indices) return
-
-        val reordered = personalTabs.toMutableList().apply {
-            add(targetIndex, removeAt(selectedIndex))
-        }
-        val orderedIds = reordered.mapNotNull { tab ->
-            tab.traktListId?.toString() ?: tab.key.removePrefix(TraktLibraryService.PERSONAL_KEY_PREFIX)
-        }
-
-        viewModelScope.launch {
-            _uiState.update { it.copy(pendingOperation = true, errorMessage = null) }
-            runCatching {
-                libraryRepository.reorderPersonalLists(orderedIds)
-                setTransientMessage(context.getString(R.string.library_list_order_updated))
-            }.onSuccess {
-                _uiState.update { it.copy(pendingOperation = false) }
-            }.onFailure { error ->
-                _uiState.update { it.copy(pendingOperation = false) }
-                setError(error.message ?: context.getString(R.string.library_error_reorder_lists_failed))
-            }
+        val reordered = personalTabs.toMutableList().apply { add(targetIndex, removeAt(selectedIndex)) }
+        runListOperation(R.string.library_list_order_updated, R.string.library_error_reorder_lists_failed) { source ->
+            libraryRepository.reorderPersonalLists(reordered.map { it.key }, source)
         }
     }
 
@@ -953,7 +919,7 @@ class LibraryViewModel @Inject constructor(
         val sorted = when (selectedSortOption) {
             LibrarySortOption.DEFAULT -> if (sourceMode.providerId != null) {
                 watchedFiltered.sortedWith(
-                    compareBy<LibraryEntry> { it.traktRank ?: Int.MAX_VALUE }
+                    compareBy<LibraryEntry> { it.listRanks[selectedListKey] ?: it.traktRank ?: Int.MAX_VALUE }
                         .thenByDescending { it.listedAt }
                         .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name.ifBlank { it.id } }
                         .thenBy { it.id }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MdbListAccountDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MdbListAccountDialog.kt
@@ -1,0 +1,60 @@
+package com.nuvio.tv.ui.screens.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.nuvio.tv.R
+import com.nuvio.tv.ui.components.NuvioDialog
+
+@Composable
+internal fun MdbListAccountDialog(
+    state: MdbListTrackerUiState,
+    onStartConnection: () -> Unit,
+    onRetryPolling: () -> Unit,
+    onSync: () -> Unit,
+    onDisconnect: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val logo = rememberRawSvgPainter(R.raw.mdblist_logo, 150.dp)
+    if (state.isConnected) {
+        ConnectedTrackingAccountDialog(TrackingDialogBrand.MDBLIST, logo, onDismiss) {
+            ConnectedTrackingAccountContent(
+                brand = TrackingDialogBrand.MDBLIST,
+                logo = logo,
+                logoContentDescription = stringResource(R.string.mdblist_name),
+                connectedLabel = stringResource(R.string.mdblist_connected_as, state.username ?: stringResource(R.string.mdblist_account_fallback)),
+                connectedDescription = stringResource(R.string.mdblist_tracking_description),
+                statusMessage = state.statusMessage,
+                errorMessage = state.errorMessage,
+                isLoading = state.isLoading || state.isSyncing,
+                onDisconnect = onDisconnect,
+                onSync = onSync
+            )
+        }
+    } else {
+        NuvioDialog(onDismiss = onDismiss, title = "", width = 720.dp, titleTextAlign = TextAlign.Center, suppressFirstKeyUp = false) {
+            TrackingDeviceAuthContent(
+                providerName = stringResource(R.string.mdblist_name),
+                logo = logo,
+                logoContentDescription = stringResource(R.string.mdblist_name),
+                logoLabel = stringResource(R.string.mdblist_name),
+                qrContentDescription = stringResource(R.string.mdblist_qr_description),
+                instruction = stringResource(R.string.mdblist_awaiting_instruction),
+                userCode = state.session?.userCode,
+                displayUrl = state.session?.verificationUri,
+                qrUrl = state.session?.verificationUriComplete,
+                expiresAtEpochMs = state.session?.expiresAtEpochMs,
+                isLoading = state.isLoading,
+                isPolling = state.isPolling,
+                credentialsConfigured = state.credentialsConfigured,
+                statusMessage = state.statusMessage,
+                errorMessage = state.errorMessage,
+                missingCredentialsMessage = stringResource(R.string.mdblist_missing_client),
+                onStartConnection = onStartConnection,
+                onRetryPolling = onRetryPolling,
+                onDismiss = onDismiss
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/MdbListTrackerViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/MdbListTrackerViewModel.kt
@@ -1,0 +1,201 @@
+package com.nuvio.tv.ui.screens.settings
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.R
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.data.mdblist.MdbListAuthError
+import com.nuvio.tv.data.mdblist.MdbListAuthException
+import com.nuvio.tv.data.mdblist.MdbListAuthRepository
+import com.nuvio.tv.data.mdblist.MdbListAuthScope
+import com.nuvio.tv.data.mdblist.MdbListAuthStore
+import com.nuvio.tv.data.mdblist.MdbListDevicePollResult
+import com.nuvio.tv.data.mdblist.MdbListDeviceSession
+import com.nuvio.tv.data.mdblist.MdbListSyncError
+import com.nuvio.tv.data.mdblist.MdbListSyncRepository
+import com.nuvio.tv.data.mdblist.toMdbListSyncError
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+data class MdbListTrackerUiState(
+    val isConnected: Boolean = false,
+    val username: String? = null,
+    val session: MdbListDeviceSession? = null,
+    val credentialsConfigured: Boolean = true,
+    val isLoading: Boolean = false,
+    val isPolling: Boolean = false,
+    val isSyncing: Boolean = false,
+    val statusMessage: String? = null,
+    val errorMessage: String? = null
+)
+
+private data class MdbListTrackerAction(
+    val scope: MdbListAuthScope? = null,
+    val loading: Boolean = false,
+    val polling: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class MdbListTrackerViewModel @Inject constructor(
+    private val auth: MdbListAuthRepository,
+    private val authStore: MdbListAuthStore,
+    private val sync: MdbListSyncRepository,
+    private val profiles: ProfileManager,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+    private val action = MutableStateFlow(MdbListTrackerAction())
+    private var connectionJob: Job? = null
+    private var disconnectJob: Job? = null
+    val uiState = combine(authStore.state, sync.state, action, profiles.activeProfileId) { authorization, syncState, action, profileId ->
+        val current = authorization.scope.profileId == profileId
+        val transient = action.takeIf { it.scope == authorization.scope && current } ?: MdbListTrackerAction()
+        val currentSync = syncState.takeIf { it.scope == authorization.scope && current }
+        val connected = current && authorization.isAuthenticated
+        MdbListTrackerUiState(
+            isConnected = connected,
+            username = authorization.user?.username.takeIf { current },
+            session = authorization.session.takeIf { current },
+            credentialsConfigured = auth.hasRequiredCredentials(),
+            isLoading = transient.loading,
+            isPolling = transient.polling,
+            isSyncing = currentSync?.isLoading == true,
+            statusMessage = when {
+                currentSync?.isLoading == true -> context.getString(R.string.mdblist_status_syncing)
+                connected && currentSync?.snapshot?.checkedAtEpochMs != null -> context.getString(
+                    R.string.mdblist_last_synced,
+                    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault())
+                        .format(Instant.ofEpochMilli(currentSync.snapshot.checkedAtEpochMs))
+                )
+                current && authorization.session != null -> context.getString(R.string.mdblist_status_enter_code)
+                else -> null
+            },
+            errorMessage = transient.error ?: authorization.error?.takeIf { current }?.message()
+                ?: currentSync?.error?.message()
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, MdbListTrackerUiState(credentialsConfigured = auth.hasRequiredCredentials()))
+
+    init {
+        var previousProfile = profiles.activeProfileId.value
+        viewModelScope.launch {
+            profiles.activeProfileId.collect { profileId ->
+                if (profileId != previousProfile) {
+                    connectionJob?.cancel()
+                    action.value = MdbListTrackerAction()
+                    previousProfile = profileId
+                }
+            }
+        }
+    }
+
+    fun onConnect() {
+        if (connectionJob?.isActive == true || disconnectJob?.isActive == true) return
+        val requestedScope = authStore.scope()
+        if (requestedScope.profileId != profiles.activeProfileId.value || authStore.state.value.isAuthenticated) return
+        action.value = MdbListTrackerAction(requestedScope, loading = true)
+        connectionJob = viewModelScope.launch(Dispatchers.IO) {
+            var scope = requestedScope
+            try {
+                authStore.checkScope(scope)
+                if (scope.profileId != profiles.activeProfileId.value) return@launch
+                val session = authStore.state.value.session
+                if (session == null || session.expiresAtEpochMs <= System.currentTimeMillis()) auth.startDeviceAuthorization(scope)
+                scope = authStore.scope()
+                if (scope.profileId != requestedScope.profileId || scope.profileId != profiles.activeProfileId.value) return@launch
+                action.value = MdbListTrackerAction(scope, polling = true)
+                while (isActive && authStore.isCurrent(scope) && scope.profileId == profiles.activeProfileId.value) {
+                    val pending = authStore.state.value.session ?: break
+                    delay((pending.nextPollAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L))
+                    if (scope.profileId != profiles.activeProfileId.value) break
+                    when (auth.pollDeviceAuthorization(scope)) {
+                        MdbListDevicePollResult.Pending -> Unit
+                        MdbListDevicePollResult.Authorized -> {
+                            action.value = MdbListTrackerAction(authStore.scope())
+                            sync.refresh(TrackingRefreshIntent.USER_INITIATED)
+                            break
+                        }
+                        MdbListDevicePollResult.Expired, MdbListDevicePollResult.Denied -> break
+                    }
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                if (authStore.isCurrent(scope)) action.value = MdbListTrackerAction(scope, error = error.messageForUser())
+            } finally {
+                val current = action.value
+                if (current.scope == scope) action.value = current.copy(loading = false, polling = false)
+            }
+        }
+    }
+
+    fun onRetryPolling() = onConnect()
+
+    fun onCancel() {
+        connectionJob?.cancel()
+        val scope = authStore.scope()
+        action.value = MdbListTrackerAction()
+        viewModelScope.launch(Dispatchers.IO) { authStore.cancelSession(scope = scope) }
+    }
+
+    fun onDisconnect() {
+        if (disconnectJob?.isActive == true) return
+        connectionJob?.cancel()
+        val profileId = profiles.activeProfileId.value
+        val requestedScope = authStore.scope()
+        if (requestedScope.profileId != profileId) return
+        action.value = MdbListTrackerAction(requestedScope, loading = true)
+        disconnectJob = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                if (profiles.activeProfileId.value != profileId) return@launch
+                val revoked = auth.disconnect(requestedScope)
+                sync.ensureLoaded()
+                if (profiles.activeProfileId.value == profileId) action.value = MdbListTrackerAction(
+                    authStore.scope(), error = if (revoked) null else context.getString(R.string.mdblist_revoke_failed)
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                if (profiles.activeProfileId.value == profileId) action.value = MdbListTrackerAction(authStore.scope(), error = error.messageForUser())
+            }
+        }
+    }
+
+    fun onSyncNow() = sync.refreshAsync(TrackingRefreshIntent.USER_INITIATED)
+    fun onAccountOpened() = sync.refreshAsync(TrackingRefreshIntent.AUTOMATIC)
+
+    private fun Exception.messageForUser(): String =
+        if (this is MdbListAuthException) error.message() else toMdbListSyncError().message()
+
+    private fun MdbListAuthError.message(): String = context.getString(when (this) {
+        MdbListAuthError.MISSING_CLIENT_ID -> R.string.mdblist_missing_client
+        MdbListAuthError.INVALID_RESPONSE -> R.string.mdblist_invalid_response
+        MdbListAuthError.INSUFFICIENT_SCOPE -> R.string.mdblist_insufficient_scope
+        MdbListAuthError.CODE_EXPIRED -> R.string.mdblist_code_expired
+        MdbListAuthError.ACCESS_DENIED -> R.string.mdblist_access_denied
+        MdbListAuthError.AUTHORIZATION_REVOKED -> R.string.mdblist_authorization_revoked
+    })
+
+    private fun MdbListSyncError.message(): String = context.getString(when (this) {
+        MdbListSyncError.UNAVAILABLE -> R.string.mdblist_unavailable
+        MdbListSyncError.INVALID_RESPONSE -> R.string.mdblist_invalid_response
+        MdbListSyncError.RATE_LIMIT -> R.string.mdblist_rate_limited
+        MdbListSyncError.AUTHORIZATION_REVOKED -> R.string.mdblist_authorization_revoked
+    })
+}

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/SettingsScreen.kt
@@ -1218,7 +1218,7 @@ private fun IntegrationSettingsContent(
                             }
                             item(key = "integration_hub_mdblist") {
                                 SettingsActionRow(
-                                    title = "MDBList",
+                                    title = stringResource(R.string.mdblist_title),
                                     subtitle = stringResource(R.string.settings_mdblist_subtitle),
                                     onClick = { onSelectSection(IntegrationSettingsSection.MdbList) }
                                 )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingProviderDialogs.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingProviderDialogs.kt
@@ -266,7 +266,7 @@ internal fun SimklAccountDialog(
 }
 
 @Composable
-private fun TrackingDeviceAuthContent(
+internal fun TrackingDeviceAuthContent(
     providerName: String,
     logo: Painter,
     logoContentDescription: String,
@@ -284,9 +284,10 @@ private fun TrackingDeviceAuthContent(
     missingCredentialsMessage: String,
     onStartConnection: () -> Unit,
     onRetryPolling: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    logoLabel: String? = null
 ) {
-    TrackingProviderWordmark(logo, logoContentDescription)
+    TrackingProviderWordmark(logo, logoContentDescription, logoLabel)
     when {
         isLoading -> {
             Row(
@@ -441,7 +442,7 @@ private fun TrackingDeviceAuthContent(
 }
 
 @Composable
-private fun ConnectedTrackingAccountDialog(
+internal fun ConnectedTrackingAccountDialog(
     brand: TrackingDialogBrand,
     glyph: Painter,
     onDismiss: () -> Unit,
@@ -475,7 +476,7 @@ private fun ConnectedTrackingAccountDialog(
 }
 
 @Composable
-private fun ConnectedTrackingAccountContent(
+internal fun ConnectedTrackingAccountContent(
     brand: TrackingDialogBrand,
     logo: Painter,
     logoContentDescription: String,
@@ -651,6 +652,13 @@ private fun TrackingConnectedWordmark(
     logo: Painter,
     contentDescription: String
 ) {
+    if (brand == TrackingDialogBrand.MDBLIST) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Image(painter = logo, contentDescription = null, modifier = Modifier.size(40.dp))
+            Text(stringResource(R.string.mdblist_name), color = Color.White, style = MaterialTheme.typography.headlineSmall)
+        }
+        return
+    }
     Image(
         painter = logo,
         contentDescription = contentDescription,
@@ -661,6 +669,7 @@ private fun TrackingConnectedWordmark(
             TrackingDialogBrand.SIMKL -> Modifier
                 .width(124.dp)
                 .height(30.dp)
+            TrackingDialogBrand.MDBLIST -> Modifier.size(40.dp)
         },
         contentScale = ContentScale.Fit,
         alignment = Alignment.CenterStart
@@ -789,8 +798,20 @@ private fun TrackingBrandMessage(
 @Composable
 private fun TrackingProviderWordmark(
     logo: Painter,
-    contentDescription: String
+    contentDescription: String,
+    label: String? = null
 ) {
+    if (label != null) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally)
+        ) {
+            Image(painter = logo, contentDescription = null, modifier = Modifier.size(40.dp))
+            Text(label, color = NuvioTheme.colors.TextPrimary, style = MaterialTheme.typography.headlineSmall)
+        }
+        return
+    }
     Image(
         painter = logo,
         contentDescription = contentDescription,
@@ -801,9 +822,10 @@ private fun TrackingProviderWordmark(
     )
 }
 
-private enum class TrackingDialogBrand {
+internal enum class TrackingDialogBrand {
     TRAKT,
-    SIMKL
+    SIMKL,
+    MDBLIST
 }
 
 private fun TrackingDialogBrand.cardBrush(): Brush = when (this) {
@@ -812,6 +834,9 @@ private fun TrackingDialogBrand.cardBrush(): Brush = when (this) {
     )
     TrackingDialogBrand.SIMKL -> Brush.linearGradient(
         colors = listOf(Color(0xFF050505), Color(0xFF292929), Color(0xFF111111))
+    )
+    TrackingDialogBrand.MDBLIST -> Brush.linearGradient(
+        colors = listOf(Color(0xFF173D69), Color(0xFF225C97), Color(0xFF16385D))
     )
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
@@ -714,6 +714,7 @@ private fun watchProgressSourceLabel(source: WatchProgressSource): String = when
 private fun librarySourceLabel(mode: LibrarySourceMode): String = when (mode) {
     LibrarySourceMode.TRAKT -> stringResource(R.string.trakt_name)
     LibrarySourceMode.SIMKL -> stringResource(R.string.simkl_name)
+    LibrarySourceMode.MDBLIST -> stringResource(R.string.mdblist_name)
     LibrarySourceMode.LOCAL -> stringResource(R.string.trakt_library_source_nuvio)
 }
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsScreen.kt
@@ -44,14 +44,17 @@ import kotlinx.coroutines.delay
 fun TrackingSettingsScreen(
     traktViewModel: TraktViewModel = hiltViewModel(),
     simklViewModel: SimklSettingsViewModel = hiltViewModel(),
+    mdbListViewModel: MdbListTrackerViewModel = hiltViewModel(),
     trackingViewModel: TrackingSettingsViewModel = hiltViewModel(),
     onBackPress: () -> Unit
 ) {
     val traktState by traktViewModel.uiState.collectAsStateWithLifecycle()
     val simklState by simklViewModel.uiState.collectAsStateWithLifecycle()
+    val mdbListState by mdbListViewModel.uiState.collectAsStateWithLifecycle()
     val trackingState by trackingViewModel.uiState.collectAsStateWithLifecycle()
     val traktFocusRequester = remember { FocusRequester() }
     val simklFocusRequester = remember { FocusRequester() }
+    val mdbListFocusRequester = remember { FocusRequester() }
     val libraryFocusRequester = remember { FocusRequester() }
     val watchProgressFocusRequester = remember { FocusRequester() }
     val continueWatchingFocusRequester = remember { FocusRequester() }
@@ -88,11 +91,13 @@ fun TrackingSettingsScreen(
         activeProvider,
         dismissOnConnected,
         traktState.mode,
-        simklState.mode
+        simklState.mode,
+        mdbListState.isConnected
     ) {
         val connected = when (dismissOnConnected) {
             TrackingProviderId.TRAKT -> traktState.mode == TraktConnectionMode.CONNECTED
             TrackingProviderId.SIMKL -> simklState.mode == SimklConnectionMode.CONNECTED
+            TrackingProviderId.MDBLIST -> mdbListState.isConnected
             null -> false
         }
         if (activeProvider == dismissOnConnected && connected) {
@@ -109,6 +114,7 @@ fun TrackingSettingsScreen(
             when (target) {
                 TrackingFocusTarget.TRAKT -> traktFocusRequester.requestFocus()
                 TrackingFocusTarget.SIMKL -> simklFocusRequester.requestFocus()
+                TrackingFocusTarget.MDBLIST -> mdbListFocusRequester.requestFocus()
                 TrackingFocusTarget.LIBRARY -> libraryFocusRequester.requestFocus()
                 TrackingFocusTarget.WATCH_PROGRESS -> watchProgressFocusRequester.requestFocus()
                 TrackingFocusTarget.CONTINUE_WATCHING -> continueWatchingFocusRequester.requestFocus()
@@ -122,6 +128,7 @@ fun TrackingSettingsScreen(
         restoreFocusTarget = when (provider) {
             TrackingProviderId.TRAKT -> TrackingFocusTarget.TRAKT
             TrackingProviderId.SIMKL -> TrackingFocusTarget.SIMKL
+            TrackingProviderId.MDBLIST -> TrackingFocusTarget.MDBLIST
         }
         activeProvider = provider
         disconnectProvider = null
@@ -146,21 +153,33 @@ fun TrackingSettingsScreen(
                     }
                 }
             }
+            TrackingProviderId.MDBLIST -> {
+                if (mdbListState.isConnected) {
+                    dismissOnConnected = null
+                    mdbListViewModel.onAccountOpened()
+                } else {
+                    dismissOnConnected = provider
+                    mdbListViewModel.onConnect()
+                }
+            }
         }
     }
 
     TrackingSettingsOverview(
         traktState = traktState,
         simklState = simklState,
+        mdbListState = mdbListState,
         trackingState = trackingState,
         traktFocusRequester = traktFocusRequester,
         simklFocusRequester = simklFocusRequester,
+        mdbListFocusRequester = mdbListFocusRequester,
         libraryFocusRequester = libraryFocusRequester,
         watchProgressFocusRequester = watchProgressFocusRequester,
         continueWatchingFocusRequester = continueWatchingFocusRequester,
         moreLikeThisFocusRequester = moreLikeThisFocusRequester,
         onTraktClick = { openProvider(TrackingProviderId.TRAKT) },
         onSimklClick = { openProvider(TrackingProviderId.SIMKL) },
+        onMdbListClick = { openProvider(TrackingProviderId.MDBLIST) },
         onLibrarySourceClick = {
             restoreFocusTarget = TrackingFocusTarget.LIBRARY
             showLibrarySourceDialog = true
@@ -223,21 +242,46 @@ fun TrackingSettingsScreen(
                 }
             )
         }
+        TrackingProviderId.MDBLIST -> {
+            MdbListAccountDialog(
+                state = mdbListState,
+                onStartConnection = mdbListViewModel::onConnect,
+                onRetryPolling = mdbListViewModel::onRetryPolling,
+                onSync = mdbListViewModel::onSyncNow,
+                onDisconnect = {
+                    activeProvider = null
+                    dismissOnConnected = null
+                    disconnectProvider = TrackingProviderId.MDBLIST
+                },
+                onDismiss = {
+                    if (!mdbListState.isConnected) mdbListViewModel.onCancel()
+                    activeProvider = null
+                    dismissOnConnected = null
+                }
+            )
+        }
         null -> Unit
     }
 
     disconnectProvider?.let { provider ->
-        val isTrakt = provider == TrackingProviderId.TRAKT
         NuvioDialog(
             onDismiss = {
                 disconnectProvider = null
                 activeProvider = provider
             },
             title = stringResource(
-                if (isTrakt) R.string.trakt_disconnect_title else R.string.simkl_disconnect_title
+                when (provider) {
+                    TrackingProviderId.TRAKT -> R.string.trakt_disconnect_title
+                    TrackingProviderId.SIMKL -> R.string.simkl_disconnect_title
+                    TrackingProviderId.MDBLIST -> R.string.mdblist_disconnect_title
+                }
             ),
             subtitle = stringResource(
-                if (isTrakt) R.string.trakt_disconnect_subtitle else R.string.simkl_disconnect_subtitle
+                when (provider) {
+                    TrackingProviderId.TRAKT -> R.string.trakt_disconnect_subtitle
+                    TrackingProviderId.SIMKL -> R.string.simkl_disconnect_subtitle
+                    TrackingProviderId.MDBLIST -> R.string.mdblist_disconnect_subtitle
+                }
             ),
             width = 520.dp,
             suppressFirstKeyUp = false
@@ -254,10 +298,10 @@ fun TrackingSettingsScreen(
                     text = stringResource(R.string.trakt_disconnect),
                     onClick = {
                         disconnectProvider = null
-                        if (isTrakt) {
-                            traktViewModel.onDisconnectClick()
-                        } else {
-                            simklViewModel.onDisconnect()
+                        when (provider) {
+                            TrackingProviderId.TRAKT -> traktViewModel.onDisconnectClick()
+                            TrackingProviderId.SIMKL -> simklViewModel.onDisconnect()
+                            TrackingProviderId.MDBLIST -> mdbListViewModel.onDisconnect()
                         }
                     },
                     primary = true
@@ -390,15 +434,18 @@ fun TrackingSettingsScreen(
 internal fun TrackingSettingsOverview(
     traktState: TraktUiState,
     simklState: SimklSettingsUiState,
+    mdbListState: MdbListTrackerUiState,
     trackingState: TrackingSettingsUiState,
     traktFocusRequester: FocusRequester,
     simklFocusRequester: FocusRequester,
+    mdbListFocusRequester: FocusRequester,
     libraryFocusRequester: FocusRequester,
     watchProgressFocusRequester: FocusRequester,
     continueWatchingFocusRequester: FocusRequester,
     moreLikeThisFocusRequester: FocusRequester,
     onTraktClick: () -> Unit,
     onSimklClick: () -> Unit,
+    onMdbListClick: () -> Unit,
     onLibrarySourceClick: () -> Unit,
     onWatchProgressClick: () -> Unit,
     onContinueWatchingWindowClick: () -> Unit,
@@ -409,6 +456,7 @@ internal fun TrackingSettingsOverview(
     val listState = rememberLazyListState()
     val traktPresentation = traktConnectionPresentation(traktState)
     val simklPresentation = simklConnectionPresentation(simklState)
+    val mdbListPresentation = mdbListConnectionPresentation(mdbListState)
     val traktConnected = traktState.mode == TraktConnectionMode.CONNECTED
     val traktProgressActive = trackingState.watchProgressSource == WatchProgressSource.TRAKT
 
@@ -462,6 +510,18 @@ internal fun TrackingSettingsOverview(
                                 modifier = Modifier
                                     .focusRequester(simklFocusRequester)
                                     .testTag(TrackingSettingsTestTags.SIMKL_PROVIDER)
+                            )
+                            SettingsActionRow(
+                                title = stringResource(R.string.mdblist_name),
+                                subtitle = mdbListPresentation.subtitle,
+                                value = mdbListPresentation.value,
+                                valueColor = mdbListPresentation.color,
+                                leadingRawIconRes = R.raw.mdblist_logo,
+                                leadingArtworkSize = 40.dp,
+                                onClick = onMdbListClick,
+                                modifier = Modifier
+                                    .focusRequester(mdbListFocusRequester)
+                                    .testTag(TrackingSettingsTestTags.MDBLIST_PROVIDER)
                             )
                         }
                     }
@@ -623,9 +683,30 @@ private fun simklConnectionPresentation(state: SimklSettingsUiState): TrackingCo
 }
 
 @Composable
+private fun mdbListConnectionPresentation(state: MdbListTrackerUiState): TrackingConnectionPresentation = when {
+    state.isLoading && !state.isConnected -> TrackingConnectionPresentation(
+        stringResource(R.string.tracking_connecting_provider, stringResource(R.string.mdblist_name)),
+        stringResource(R.string.tracking_status_connecting), NuvioTheme.colors.Info
+    )
+    state.isConnected -> TrackingConnectionPresentation(
+        stringResource(R.string.mdblist_connected_as, state.username ?: stringResource(R.string.mdblist_account_fallback)),
+        stringResource(R.string.tracking_status_connected), NuvioTheme.colors.Success
+    )
+    state.session != null -> TrackingConnectionPresentation(
+        state.errorMessage ?: stringResource(R.string.tracking_finish_connection),
+        stringResource(R.string.tracking_status_waiting), NuvioTheme.colors.Warning
+    )
+    else -> TrackingConnectionPresentation(
+        state.errorMessage ?: stringResource(R.string.mdblist_tracking_description),
+        stringResource(R.string.tracking_status_disconnected), NuvioTheme.colors.TextSecondary
+    )
+}
+
+@Composable
 private fun watchProgressSourceLabel(source: WatchProgressSource): String = when (source) {
     WatchProgressSource.TRAKT -> stringResource(R.string.trakt_name)
     WatchProgressSource.SIMKL -> stringResource(R.string.simkl_name)
+    WatchProgressSource.MDBLIST -> stringResource(R.string.mdblist_name)
     WatchProgressSource.NUVIO_SYNC -> stringResource(R.string.trakt_watch_progress_source_nuvio)
 }
 
@@ -661,6 +742,7 @@ private fun animeIdPreferenceLabel(preference: SimklAnimeIdPreference): String =
 private enum class TrackingFocusTarget {
     TRAKT,
     SIMKL,
+    MDBLIST,
     LIBRARY,
     WATCH_PROGRESS,
     CONTINUE_WATCHING,
@@ -671,6 +753,7 @@ internal object TrackingSettingsTestTags {
     const val OVERVIEW_LIST = "tracking_overview_list"
     const val TRAKT_PROVIDER = "tracking_provider_trakt"
     const val SIMKL_PROVIDER = "tracking_provider_simkl"
+    const val MDBLIST_PROVIDER = "tracking_provider_mdblist"
     const val LIBRARY_SOURCE = "tracking_source_library"
     const val WATCH_PROGRESS_SOURCE = "tracking_source_watch_progress"
     const val CONTINUE_WATCHING = "tracking_trakt_continue_watching"

--- a/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModel.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.nuvio.tv.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.tracking.TrackingProviderId
 import com.nuvio.tv.core.tracking.TrackingSourceController
 import com.nuvio.tv.core.tracking.TrackingSourceSelection
@@ -14,6 +15,7 @@ import com.nuvio.tv.data.local.WatchProgressSource
 import com.nuvio.tv.data.simkl.SimklAnimeIdPreference
 import com.nuvio.tv.data.simkl.SimklAuthRepository
 import com.nuvio.tv.data.simkl.SimklSyncRepository
+import com.nuvio.tv.data.mdblist.MdbListAuthStore
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -44,24 +46,29 @@ class TrackingSettingsViewModel @Inject constructor(
     private val settingsDataStore: TraktSettingsDataStore,
     private val simklSyncRepository: SimklSyncRepository,
     traktAuthDataStore: TraktAuthDataStore,
-    simklAuthRepository: SimklAuthRepository
+    simklAuthRepository: SimklAuthRepository,
+    mdbListAuth: MdbListAuthStore,
+    profiles: ProfileManager
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TrackingSettingsUiState())
     val uiState: StateFlow<TrackingSettingsUiState> = _uiState.asStateFlow()
 
     init {
         viewModelScope.launch {
+            val connected = combine(traktAuthDataStore.state, simklAuthRepository.state, mdbListAuth.state, profiles.activeProfileId) { trakt, simkl, mdblist, profileId ->
+                if (mdblist.scope.profileId != profileId) null else buildSet<TrackingProviderId> {
+                    if (trakt.isAuthenticated) add(TrackingProviderId.TRAKT)
+                    if (simkl.isAuthenticated) add(TrackingProviderId.SIMKL)
+                    if (mdblist.isAuthenticated) add(TrackingProviderId.MDBLIST)
+                }
+            }
             combine(
                 sourceController.watchProgressSource,
                 sourceController.librarySourceMode,
-                traktAuthDataStore.state,
-                simklAuthRepository.state,
+                connected,
                 settingsDataStore.simklAnimeIdPreference
-            ) { watchProgressSource, librarySourceMode, traktState, simklState, animeIdPref ->
-                val connectedProviderIds = buildSet {
-                    if (traktState.isAuthenticated) add(TrackingProviderId.TRAKT)
-                    if (simklState.isAuthenticated) add(TrackingProviderId.SIMKL)
-                }
+            ) { watchProgressSource, librarySourceMode, connectedProviderIds, animeIdPref ->
+                if (connectedProviderIds == null) return@combine TrackingSettingsUiState()
                 val effective = effectiveTrackingSourceSelection(
                     requested = TrackingSourceSelection(watchProgressSource, librarySourceMode),
                     connectedProviderIds = connectedProviderIds
@@ -75,7 +82,9 @@ class TrackingSettingsViewModel @Inject constructor(
                 )
             }.collect { state ->
                 _uiState.value = state
-                sourceController.reconcileConnectedProviders(state.connectedProviderIds)
+                if (state.isReady && mdbListAuth.scope().profileId == profiles.activeProfileId.value) {
+                    sourceController.reconcileConnectedProviders(state.connectedProviderIds)
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,7 +424,7 @@
     <string name="licenses_attributions_torbox_title">TorBox</string>
     <string name="licenses_attributions_torbox_body">Nuvio connects to TorBox for account authentication, cloud library access, cache checks, and cloud playback features. Nuvio is not affiliated with or endorsed by TorBox.</string>
     <string name="licenses_attributions_mdblist_title">MDBList</string>
-    <string name="licenses_attributions_mdblist_body">Nuvio uses MDBList for ratings and external score provider data. Nuvio is not affiliated with or endorsed by MDBList.</string>
+    <string name="licenses_attributions_mdblist_body">Nuvio uses MDBList for ratings, watched history and playback tracking. Nuvio is not affiliated with or endorsed by MDBList.</string>
     <string name="licenses_attributions_introdb_title">IntroDB</string>
     <string name="licenses_attributions_introdb_body">Nuvio uses the IntroDB API for community-provided intro, recap, credits, and preview timestamps used by skip controls. Nuvio is not affiliated with or endorsed by IntroDB.</string>
     <string name="licenses_attributions_imdb_title">IMDb Non-Commercial Datasets</string>
@@ -454,7 +454,7 @@
     <string name="settings_playback_subtitle">Player, subtitles, and auto-play</string>
     <string name="settings_trakt_subtitle">Open Trakt connection screen</string>
     <string name="settings_tracking_title">Tracking</string>
-    <string name="settings_tracking_subtitle">Manage Trakt and Simkl connections</string>
+    <string name="settings_tracking_subtitle">Manage your tracking accounts</string>
     <string name="settings_tracking_description">Connect tracking providers and choose which one powers your Library and Continue Watching.</string>
     <string name="tracking_accounts_title">Accounts</string>
     <string name="tracking_accounts_subtitle">Connect and manage tracking services</string>
@@ -1111,6 +1111,26 @@
     <string name="layout_custom">Custom</string>
 
 
+    <string name="mdblist_name">MDBList</string>
+    <string name="mdblist_tracking_description">Sync watched history and playback progress across devices</string>
+    <string name="mdblist_connected_as">Connected as %1$s</string>
+    <string name="mdblist_account_fallback">MDBList user</string>
+    <string name="mdblist_insufficient_scope">MDBList did not grant permission to update watch history. Reconnect and allow write access.</string>
+    <string name="mdblist_awaiting_instruction">Scan the QR code, or enter this code at the address below.</string>
+    <string name="mdblist_qr_description">QR code to connect your MDBList account</string>
+    <string name="mdblist_status_enter_code">Approve the connection in your MDBList account.</string>
+    <string name="mdblist_status_syncing">Syncing watched history and playback progress…</string>
+    <string name="mdblist_last_synced">Last synced %1$s</string>
+    <string name="mdblist_disconnect_title">Disconnect MDBList?</string>
+    <string name="mdblist_disconnect_subtitle">Stop sending watch updates from this profile. Your MDBList history is kept.</string>
+    <string name="mdblist_missing_client">MDBList connection is unavailable in this build.</string>
+    <string name="mdblist_invalid_response">MDBList returned an incomplete response. Please try again.</string>
+    <string name="mdblist_code_expired">This code has expired. Try again to get a new code.</string>
+    <string name="mdblist_access_denied">Connection was declined. Try again to connect your account.</string>
+    <string name="mdblist_authorization_revoked">Your MDBList connection has expired or been revoked. Connect again to resume syncing.</string>
+    <string name="mdblist_unavailable">Could not sync with MDBList. Please try again.</string>
+    <string name="mdblist_rate_limited">MDBList’s request limit has been reached. Syncing will resume after the limit resets.</string>
+    <string name="mdblist_revoke_failed">Disconnected on this device. Remove this app in your MDBList account settings to revoke its access.</string>
     <string name="mdblist_title">MDBList Ratings</string>
     <string name="mdblist_subtitle">Configure external ratings shown in the detail hero</string>
     <string name="mdblist_enable_title">Enable MDBList Ratings</string>

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingLibrarySourceControllerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingLibrarySourceControllerTest.kt
@@ -1,0 +1,46 @@
+package com.nuvio.tv.core.tracking
+
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.domain.model.LibrarySourceMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class TrackingLibrarySourceControllerTest {
+    @Test
+    fun `each library source refreshes its registered provider after selection`() = runTest {
+        for (mode in listOf(LibrarySourceMode.TRAKT, LibrarySourceMode.SIMKL, LibrarySourceMode.MDBLIST)) {
+            val settings = mockk<TraktSettingsDataStore>(relaxed = true)
+            coEvery { settings.getLibrarySourceMode(1) } returns LibrarySourceMode.LOCAL
+            val provider = mockk<TrackingLibraryProvider>(relaxed = true) { every { providerId } returns requireNotNull(mode.providerId) }
+            val profiles = MutableStateFlow(1)
+            val controller = controller(settings, provider, profiles)
+            controller.selectLibrarySourceMode(mode)
+            coVerify(exactly = 1) { settings.setLibrarySourceMode(mode, 1) }
+            coVerify(exactly = 1) { provider.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        }
+    }
+
+    @Test
+    fun `changing profiles during source selection cannot refresh the new profile provider`() = runTest {
+        val profiles = MutableStateFlow(1)
+        val settings = mockk<TraktSettingsDataStore>(relaxed = true)
+        coEvery { settings.getLibrarySourceMode(1) } returns LibrarySourceMode.LOCAL
+        coEvery { settings.setLibrarySourceMode(LibrarySourceMode.MDBLIST, 1) } answers { profiles.value = 2 }
+        val provider = mockk<TrackingLibraryProvider>(relaxed = true) { every { providerId } returns TrackingProviderId.MDBLIST }
+        controller(settings, provider, profiles).selectLibrarySourceMode(LibrarySourceMode.MDBLIST)
+        coVerify(exactly = 0) { provider.refresh(any()) }
+    }
+
+    private fun controller(settings: TraktSettingsDataStore, provider: TrackingLibraryProvider, profiles: MutableStateFlow<Int>) =
+        TrackingSourceController(
+            settings, TrackingProgressProviderRegistry(emptySet()), TrackingLibraryProviderRegistry(setOf(provider)),
+            mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true),
+            mockk(relaxed = true), mockk(relaxed = true), mockk<ProfileManager> { every { activeProfileId } returns profiles }
+        )
+}

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingScrobbleCoordinatorTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingScrobbleCoordinatorTest.kt
@@ -9,6 +9,7 @@ class TrackingScrobbleCoordinatorTest {
     fun `fanout isolates a provider failure`() = runTest {
         val successful = FakeScrobbler(TrackingProviderId.TRAKT)
         val failing = FakeScrobbler(TrackingProviderId.SIMKL, IllegalStateException("offline"))
+        val mdblist = FakeScrobbler(TrackingProviderId.MDBLIST)
         val event = TrackingScrobbleEvent(
             media = TrackingMediaReference(
                 kind = TrackingMediaKind.MOVIE,
@@ -18,13 +19,14 @@ class TrackingScrobbleCoordinatorTest {
         )
 
         val failures = dispatchTrackingScrobble(
-            scrobblers = listOf(successful, failing),
+            scrobblers = listOf(successful, failing, mdblist),
             action = TrackingScrobbleAction.PAUSE,
             event = event
         )
 
         assertEquals(1, successful.callCount)
         assertEquals(1, failing.callCount)
+        assertEquals(listOf(TrackingScrobbleAction.PAUSE), mdblist.actions)
         assertEquals(listOf(TrackingScrobbleAction.PAUSE), successful.actions)
         assertEquals(listOf(TrackingScrobbleAction.PAUSE), failing.actions)
         assertEquals(listOf(TrackingProviderId.SIMKL), failures.map { it.providerId })
@@ -37,6 +39,7 @@ class TrackingScrobbleCoordinatorTest {
             seekPolicy = TrackingSeekScrobblePolicy.STOP_AND_RESTART
         )
         val simkl = FakeScrobbler(TrackingProviderId.SIMKL)
+        val mdblist = FakeScrobbler(TrackingProviderId.MDBLIST)
         val event = TrackingScrobbleEvent(
             media = TrackingMediaReference(
                 kind = TrackingMediaKind.MOVIE,
@@ -46,13 +49,14 @@ class TrackingScrobbleCoordinatorTest {
         )
 
         dispatchTrackingSeekScrobble(
-            scrobblers = listOf(trakt, simkl),
+            scrobblers = listOf(trakt, simkl, mdblist),
             action = TrackingScrobbleAction.STOP,
             event = event
         )
 
         assertEquals(1, trakt.callCount)
         assertEquals(0, simkl.callCount)
+        assertEquals(0, mdblist.callCount)
     }
 
     private class FakeScrobbler(

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingSourcesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingSourcesTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class TrackingSourcesTest {
     @Test
-    fun `MDBList is a watch source and does not change library selection`() {
+    fun `MDBList is available independently for watch and library sources`() {
         val connected = setOf(TrackingProviderId.TRAKT, TrackingProviderId.SIMKL, TrackingProviderId.MDBLIST)
         assertEquals(WatchProgressSource.MDBLIST, WatchProgressSource.fromStorage("MDBLIST"))
         assertEquals(TrackingProviderId.MDBLIST, WatchProgressSource.MDBLIST.providerId)
@@ -17,7 +17,7 @@ class TrackingSourcesTest {
             availableWatchProgressSources(connected)
         )
         assertEquals(
-            listOf(LibrarySourceMode.LOCAL, LibrarySourceMode.TRAKT, LibrarySourceMode.SIMKL),
+            listOf(LibrarySourceMode.LOCAL, LibrarySourceMode.TRAKT, LibrarySourceMode.SIMKL, LibrarySourceMode.MDBLIST),
             availableLibrarySourceModes(connected)
         )
         val selection = TrackingSourceSelection(WatchProgressSource.MDBLIST, LibrarySourceMode.TRAKT)

--- a/app/src/test/java/com/nuvio/tv/core/tracking/TrackingSourcesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/tracking/TrackingSourcesTest.kt
@@ -8,6 +8,27 @@ import org.junit.Test
 
 class TrackingSourcesTest {
     @Test
+    fun `MDBList is a watch source and does not change library selection`() {
+        val connected = setOf(TrackingProviderId.TRAKT, TrackingProviderId.SIMKL, TrackingProviderId.MDBLIST)
+        assertEquals(WatchProgressSource.MDBLIST, WatchProgressSource.fromStorage("MDBLIST"))
+        assertEquals(TrackingProviderId.MDBLIST, WatchProgressSource.MDBLIST.providerId)
+        assertEquals(
+            listOf(WatchProgressSource.NUVIO_SYNC, WatchProgressSource.TRAKT, WatchProgressSource.SIMKL, WatchProgressSource.MDBLIST),
+            availableWatchProgressSources(connected)
+        )
+        assertEquals(
+            listOf(LibrarySourceMode.LOCAL, LibrarySourceMode.TRAKT, LibrarySourceMode.SIMKL),
+            availableLibrarySourceModes(connected)
+        )
+        val selection = TrackingSourceSelection(WatchProgressSource.MDBLIST, LibrarySourceMode.TRAKT)
+        assertEquals(selection, effectiveTrackingSourceSelection(selection, connected))
+        assertEquals(
+            selection.copy(watchProgressSource = WatchProgressSource.NUVIO_SYNC),
+            effectiveTrackingSourceSelection(selection, connected - TrackingProviderId.MDBLIST)
+        )
+    }
+
+    @Test
     fun `legacy source names retain their stored meaning`() {
         assertEquals(WatchProgressSource.TRAKT, WatchProgressSource.fromStorage("TRAKT"))
         assertEquals(WatchProgressSource.NUVIO_SYNC, WatchProgressSource.fromStorage("NUVIO_SYNC"))

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListApiClientTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListApiClientTest.kt
@@ -9,6 +9,26 @@ import org.junit.Test
 
 class MdbListApiClientTest {
     @Test
+    fun `list update and delete preserve scope and never retry ambiguous failures`() = runTest {
+        for (method in listOf(MdbListHttpMethod.PUT, MdbListHttpMethod.DELETE)) {
+            for (status in listOf(204, 500)) {
+                val harness = MdbListTestHarness()
+                harness.connected()
+                harness.reply(status, "")
+                val request: suspend () -> MdbListHttpResponse = {
+                    if (method == MdbListHttpMethod.PUT) harness.api.put("/lists/42", "list-body")
+                    else harness.api.delete("/lists/42")
+                }
+                if (status == 204) assertEquals(204, request().status)
+                else assertEquals(status, expectMdbListFailure<MdbListApiException> { request() }.status)
+                assertEquals(1, harness.engine.requests.size)
+                assertEquals(method, harness.engine.requests.single().method)
+                assertFalse(harness.engine.requests.single().retrySafe)
+            }
+        }
+    }
+
+    @Test
     fun `initial user response quota follows the newly identified account`() = runTest {
         val harness = MdbListTestHarness()
         harness.connected()

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListApiClientTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListApiClientTest.kt
@@ -1,0 +1,114 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListApiClientTest {
+    @Test
+    fun `initial user response quota follows the newly identified account`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.reply(body = """{"user_id":42,"username":"viewer"}""", headers = mapOf(
+            "X-RateLimit-Remaining" to "0",
+            "X-RateLimit-Reset" to ((harness.now + 60_000L) / 1_000L).toString()
+        ))
+
+        harness.api.refreshUser()
+        expectMdbListFailure<MdbListApiException> { harness.api.get("/sync/playback") }
+
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `valid token reads user once and stores identity`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.reply(body = """{"user_id":42,"username":"viewer","is_supporter":true,"unknown":"field"}""")
+
+        val user = harness.api.refreshUser()
+
+        assertEquals(42L, user.id)
+        assertEquals("viewer", harness.store.state.value.user?.username)
+        assertTrue(user.isSupporter)
+        assertEquals(1, harness.engine.requests.size)
+        assertEquals("access-one", harness.engine.requests.single().accessToken)
+        assertTrue(harness.engine.requests.single().query.isEmpty())
+    }
+
+    @Test
+    fun `rejected access token refreshes then replays original request exactly once`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.reply(401)
+        harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE)
+        harness.reply(body = """{"added":{"movies":1}}""")
+
+        harness.api.post("/sync/watched", "movie-body")
+
+        assertEquals(listOf("/sync/watched", "/oauth/token/", "/sync/watched"), harness.engine.requests.map { it.path })
+        assertEquals("access-two", harness.engine.requests.last().accessToken)
+        assertEquals("movie-body", harness.engine.requests.last().body)
+    }
+
+    @Test
+    fun `second unauthorized response ends connection instead of refreshing forever`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.reply(401)
+        harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE)
+        harness.reply(401)
+
+        expectMdbListFailure<MdbListAuthException> { harness.api.get("/sync/playback") }
+
+        assertEquals(3, harness.engine.requests.size)
+        assertFalse(harness.store.state.value.isAuthenticated)
+    }
+
+    @Test
+    fun `unrelated HTTP failures do not clear connection`() = runTest {
+        for (status in listOf(400, 403, 404, 409)) {
+            val harness = MdbListTestHarness()
+            harness.connected()
+            harness.reply(status)
+
+            assertEquals(status, expectMdbListFailure<MdbListApiException> { harness.api.get("/sync/playback") }.status)
+            assertTrue(harness.store.state.value.isAuthenticated)
+            assertEquals(1, harness.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `stale profile response cannot update or clear another account`() = runTest {
+        for (status in listOf(200, 401)) {
+            val harness = MdbListTestHarness()
+            harness.connected()
+            harness.reply(status, """{"user_id":42,"username":"old-user"}""")
+            harness.engine.intercept = {
+                harness.store.selectProfile(2)
+                harness.connected("profile-two-access", "profile-two-refresh")
+            }
+
+            expectMdbListFailure<CancellationException> { harness.api.refreshUser() }
+
+            assertEquals("profile-two-access", harness.store.authorization()?.tokens?.accessToken)
+            assertEquals(null, harness.store.state.value.user)
+            assertEquals(1, harness.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `malformed user response never overwrites cached identity`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.store.saveUser(MdbListUser(42, "existing"), harness.store.scope())
+        harness.reply(body = "{}")
+
+        expectMdbListFailure<MdbListAuthException> { harness.api.refreshUser() }
+
+        assertEquals("existing", harness.store.state.value.user?.username)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthRepositoryTest.kt
@@ -75,6 +75,7 @@ class MdbListAuthRepositoryTest {
         assertEquals("/oauth/token/", request.path)
         assertEquals("device-secret", request.form?.get("device_code"))
         assertEquals("urn:ietf:params:oauth:grant-type:device_code", request.form?.get("grant_type"))
+        assertEquals("write", request.form?.get("scope"))
         assertEquals(harness.now + 5_000L, harness.store.state.value.session?.nextPollAtEpochMs)
     }
 
@@ -141,6 +142,17 @@ class MdbListAuthRepositoryTest {
     }
 
     @Test
+    fun `read only token cannot silently enable watched writes`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+        harness.now += 5_000L
+        harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE.replace("\"scope\":\"write\"", "\"scope\":\"read\""))
+        val error = expectMdbListFailure<MdbListAuthException> { harness.auth.pollDeviceAuthorization() }
+        assertEquals(MdbListAuthError.INSUFFICIENT_SCOPE, error.error)
+        assertFalse(harness.store.state.value.isAuthenticated)
+    }
+
+    @Test
     fun `profile change and cancellation reject late device and token responses`() = runTest {
         for (approve in listOf(false, true)) {
             val harness = MdbListTestHarness()
@@ -165,6 +177,21 @@ class MdbListAuthRepositoryTest {
         harness.engine.intercept = { harness.auth.cancelDeviceAuthorization() }
         expectMdbListFailure<CancellationException> { harness.auth.startDeviceAuthorization() }
         assertNull(harness.store.state.value.session)
+    }
+
+    @Test
+    fun `queued account actions cannot use another profile or a replaced session`() = runTest {
+        for (switchProfile in listOf(false, true)) {
+            val harness = MdbListTestHarness()
+            val scope = harness.store.scope()
+            if (switchProfile) harness.store.selectProfile(2) else harness.store.cancelSession()
+            expectMdbListFailure<CancellationException> { harness.auth.startDeviceAuthorization(scope) }
+            expectMdbListFailure<CancellationException> { harness.auth.pollDeviceAuthorization(scope) }
+            harness.connected()
+            expectMdbListFailure<CancellationException> { harness.auth.disconnect(scope) }
+            assertTrue(harness.store.state.value.isAuthenticated)
+            assertTrue(harness.engine.requests.isEmpty())
+        }
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthRepositoryTest.kt
@@ -1,0 +1,223 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListAuthRepositoryTest {
+    @Test
+    fun `device flow uses form encoded public client and stores both verification links`() = runTest {
+        val harness = MdbListTestHarness()
+        val session = harness.pending()
+        val request = harness.engine.requests.single()
+
+        assertEquals("/oauth/device-authorization/", request.path)
+        assertEquals(mapOf("client_id" to "public-client", "scope" to "write"), request.form)
+        assertNull(request.accessToken)
+        assertFalse(request.retrySafe)
+        assertEquals("ABCD-EFGH", session.userCode)
+        assertEquals("https://mdblist.com/oauth/device/?user_code=ABCD-EFGH", session.verificationUriComplete)
+        assertEquals(harness.now + 300_000L, session.expiresAtEpochMs)
+        assertFalse(harness.store.state.value.isAuthenticated)
+    }
+
+    @Test
+    fun `missing client fails before network access`() = runTest {
+        val harness = MdbListTestHarness()
+        val auth = MdbListAuthRepository(harness.http, harness.configuration.copy(clientId = ""), harness.store)
+
+        val error = expectMdbListFailure<MdbListAuthException> { auth.startDeviceAuthorization() }
+
+        assertEquals(MdbListAuthError.MISSING_CLIENT_ID, error.error)
+        assertTrue(harness.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `untrusted verification destination and invalid response do not persist authorization`() = runTest {
+        for (body in listOf(
+            "{}", "not-json",
+            MdbListTestHarness.DEVICE_RESPONSE.replace("https://mdblist.com", "https://example.com"),
+            MdbListTestHarness.DEVICE_RESPONSE.replace("\"expires_in\":300", "\"expires_in\":-1"),
+            MdbListTestHarness.DEVICE_RESPONSE.replace("\"interval\":5", "\"interval\":0")
+        )) {
+            val harness = MdbListTestHarness()
+            harness.reply(body = body)
+            expectMdbListFailure<MdbListAuthException> { harness.auth.startDeviceAuthorization() }
+            assertNull(harness.store.state.value.session)
+        }
+    }
+
+    @Test
+    fun `polling before server interval makes no request`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+
+        repeat(3) { assertEquals(MdbListDevicePollResult.Pending, harness.auth.pollDeviceAuthorization()) }
+
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `pending response preserves device code and schedules next poll`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+        harness.now += 5_000L
+        harness.reply(400, """{"error":"authorization_pending"}""")
+
+        assertEquals(MdbListDevicePollResult.Pending, harness.auth.pollDeviceAuthorization())
+
+        val request = harness.engine.requests.last()
+        assertEquals("/oauth/token/", request.path)
+        assertEquals("device-secret", request.form?.get("device_code"))
+        assertEquals("urn:ietf:params:oauth:grant-type:device_code", request.form?.get("grant_type"))
+        assertEquals(harness.now + 5_000L, harness.store.state.value.session?.nextPollAtEpochMs)
+    }
+
+    @Test
+    fun `slow down permanently increases polling interval`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+        harness.now += 5_000L
+        harness.reply(400, """{"error":"slow_down"}""")
+        harness.auth.pollDeviceAuthorization()
+
+        assertEquals(10, harness.store.state.value.session?.intervalSeconds)
+        harness.now += 5_000L
+        harness.auth.pollDeviceAuthorization()
+        assertEquals(2, harness.engine.requests.size)
+        harness.now += 5_000L
+        harness.reply(400, """{"error":"slow_down"}""")
+        harness.auth.pollDeviceAuthorization()
+        assertEquals(15, harness.store.state.value.session?.intervalSeconds)
+    }
+
+    @Test
+    fun `expired local session ends without polling`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+        harness.now += 300_000L
+
+        assertEquals(MdbListDevicePollResult.Expired, harness.auth.pollDeviceAuthorization())
+        assertNull(harness.store.state.value.session)
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `denial and server expiry clear pending secret`() = runTest {
+        for ((code, expected) in listOf(
+            "access_denied" to MdbListDevicePollResult.Denied,
+            "expired_token" to MdbListDevicePollResult.Expired
+        )) {
+            val harness = MdbListTestHarness()
+            harness.pending()
+            harness.now += 5_000L
+            harness.reply(400, """{"error":"$code"}""")
+
+            assertEquals(expected, harness.auth.pollDeviceAuthorization())
+            assertNull(harness.store.deviceCode(harness.store.scope()))
+            assertFalse(harness.store.state.value.isAuthenticated)
+        }
+    }
+
+    @Test
+    fun `approval stores renewable credentials without an extra identity or sync request`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.pending()
+        harness.now += 5_000L
+        harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE)
+
+        assertEquals(MdbListDevicePollResult.Authorized, harness.auth.pollDeviceAuthorization())
+
+        assertEquals("access-two", harness.store.authorization()?.tokens?.accessToken)
+        assertEquals("refresh-two", harness.store.authorization()?.tokens?.refreshToken)
+        assertNull(harness.store.state.value.session)
+        assertNull(harness.store.deviceCode(harness.store.scope()))
+        assertEquals(2, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `profile change and cancellation reject late device and token responses`() = runTest {
+        for (approve in listOf(false, true)) {
+            val harness = MdbListTestHarness()
+            if (approve) {
+                harness.pending()
+                harness.now += 5_000L
+                harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE)
+            } else {
+                harness.reply(body = MdbListTestHarness.DEVICE_RESPONSE)
+            }
+            harness.engine.intercept = { harness.store.selectProfile(2) }
+            expectMdbListFailure<CancellationException> {
+                if (approve) harness.auth.pollDeviceAuthorization() else harness.auth.startDeviceAuthorization()
+            }
+            assertFalse(harness.store.state.value.isAuthenticated)
+            assertNull(harness.store.state.value.session)
+            harness.store.selectProfile(1)
+            assertFalse(harness.store.state.value.isAuthenticated)
+        }
+        val harness = MdbListTestHarness()
+        harness.reply(body = MdbListTestHarness.DEVICE_RESPONSE)
+        harness.engine.intercept = { harness.auth.cancelDeviceAuthorization() }
+        expectMdbListFailure<CancellationException> { harness.auth.startDeviceAuthorization() }
+        assertNull(harness.store.state.value.session)
+    }
+
+    @Test
+    fun `simultaneous requests refresh expiring tokens only once`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected(expiresIn = 30_000L)
+        val scope = harness.store.scope()
+        harness.reply(body = MdbListTestHarness.TOKEN_RESPONSE)
+
+        val results = List(8) { async { harness.auth.authorization(scope) } }.map { it.await() }
+
+        assertTrue(results.all { it.tokens.accessToken == "access-two" })
+        assertEquals(1, harness.engine.requests.size)
+        assertEquals("refresh_token", harness.engine.requests.single().form?.get("grant_type"))
+        assertEquals("refresh-two", harness.store.authorization()?.tokens?.refreshToken)
+    }
+
+    @Test
+    fun `refresh response may retain previous refresh token`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected(expiresIn = 1)
+        harness.reply(body = """{"access_token":"renewed","token_type":"bearer","expires_in":300}""")
+
+        val current = harness.auth.authorization(harness.store.scope())
+
+        assertEquals("refresh-one", current.tokens.refreshToken)
+    }
+
+    @Test
+    fun `invalid grant disconnects while transient refresh errors keep credentials`() = runTest {
+        for (status in listOf(400, 503)) {
+            val harness = MdbListTestHarness()
+            harness.connected(expiresIn = 1)
+            harness.reply(status, if (status == 400) """{"error":"invalid_grant"}""" else "{}")
+
+            expectMdbListFailure<Exception> { harness.auth.authorization(harness.store.scope()) }
+
+            assertEquals(status != 400, harness.store.state.value.isAuthenticated)
+            assertEquals(1, harness.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `disconnect removes local credentials even when revocation fails`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.reply(503)
+
+        assertFalse(harness.auth.disconnect())
+
+        assertFalse(harness.store.state.value.isAuthenticated)
+        assertNull(harness.store.authorization())
+        assertEquals("/oauth/revoke_token/", harness.engine.requests.single().path)
+        assertEquals("refresh_token", harness.engine.requests.single().form?.get("token_type_hint"))
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthStoreTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListAuthStoreTest.kt
@@ -1,0 +1,101 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListAuthStoreTest {
+    @Test
+    fun `profile switches load isolated credentials and reject stale scope after switching back`() {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        val first = harness.store.scope()
+        harness.store.selectProfile(2)
+        assertFalse(harness.store.state.value.isAuthenticated)
+        harness.connected("second", "second-refresh")
+        harness.store.selectProfile(1)
+
+        assertEquals("access-one", harness.store.authorization()?.tokens?.accessToken)
+        assertFalse(harness.store.isCurrent(first))
+        assertFalse(harness.store.saveUser(MdbListUser(99, "stale"), first))
+        assertFalse(harness.store.clearAuth(first))
+    }
+
+    @Test
+    fun `credentials survive process restart through persistence`() {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.store.saveUser(MdbListUser(42, "viewer"), harness.store.scope())
+
+        val reloaded = MdbListAuthStore(harness.persistence)
+
+        assertEquals("access-one", reloaded.authorization()?.tokens?.accessToken)
+        assertEquals("refresh-one", reloaded.authorization()?.tokens?.refreshToken)
+        assertEquals(42L, reloaded.state.value.user?.id)
+    }
+
+    @Test
+    fun `failed durable write never publishes connection`() {
+        val harness = MdbListTestHarness()
+        harness.persistence.failWrites = true
+
+        assertThrows(IOException::class.java) { harness.connected() }
+
+        assertFalse(harness.store.state.value.isAuthenticated)
+        assertNull(harness.store.authorization())
+    }
+
+    @Test
+    fun `removing a profile deletes only that profiles credentials`() {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.store.selectProfile(2)
+        harness.connected("second", "second-refresh")
+
+        harness.store.removeProfile(1)
+
+        assertTrue(harness.store.state.value.isAuthenticated)
+        assertEquals(setOf(2), harness.persistence.profiles.keys)
+        harness.store.removeProfile(2)
+        assertFalse(harness.store.state.value.isAuthenticated)
+        assertTrue(harness.persistence.profiles.isEmpty())
+    }
+
+    @Test
+    fun `account cleanup deletes every profile and invalidates current operations`() {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        harness.store.selectProfile(2)
+        harness.connected("second", "second-refresh")
+        val scope = harness.store.scope()
+
+        harness.store.clearAllProfiles()
+
+        assertTrue(harness.persistence.profiles.isEmpty())
+        assertFalse(harness.store.state.value.isAuthenticated)
+        assertFalse(harness.store.isCurrent(scope))
+    }
+
+    @Test
+    fun `late unauthorized response for rotated token cannot clear new credentials`() {
+        val harness = MdbListTestHarness()
+        harness.connected()
+        val original = requireNotNull(harness.store.authorization())
+        harness.store.refreshTokens(MdbListTokens("new", "new-refresh", harness.now + 600_000L), original)
+
+        assertFalse(harness.store.clearAuth(original.scope, expectedAccessToken = "access-one"))
+        assertEquals("new", harness.store.authorization()?.tokens?.accessToken)
+    }
+
+    @Test
+    fun `corrupt persisted state does not appear connected`() {
+        val persistence = MdbListTestPersistence()
+        persistence.profiles[1] = "invalid"
+
+        assertFalse(MdbListAuthStore(persistence).state.value.isAuthenticated)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListHistoryServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListHistoryServiceTest.kt
@@ -1,0 +1,131 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingHistoryItem
+import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingMediaKind
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListHistoryServiceTest {
+    @Test
+    fun `confirmed history is saved without refreshing unrelated buckets`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":1},"plays":[{"type":"movie","ids":{"imdb":"tt1","tmdb":1,"mdblist":"public"},"watched_at":"2026-09-06T00:00:00Z","added":true}]}""")
+
+        val result = service(harness).add(harness.repository.currentScope(), listOf(item(1)))
+
+        assertTrue(result.isComplete)
+        assertEquals("public", harness.repository.currentSnapshot()?.watched?.single()?.media?.ids?.mdblist)
+        assertEquals(1, harness.http.engine.requests.size)
+        assertEquals(mapOf("report_added" to "true"), harness.http.engine.requests.single().query)
+        assertTrue(harness.repository.currentSnapshot()?.invalidatedBuckets?.isEmpty() == true)
+        assertTrue(harness.remote.calls.isEmpty())
+    }
+
+    @Test
+    fun `large history batches respect receipt and show entry limits`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":100}}""")
+        harness.http.reply(body = """{"updated":{"movies":100}}""")
+        harness.http.reply(body = """{"updated":{"movies":1}}""")
+
+        val result = service(harness).add(harness.repository.currentScope(), (1L..201L).map(::item))
+
+        assertTrue(result.isComplete)
+        assertEquals(201, harness.repository.currentSnapshot()?.watched?.size)
+        assertEquals(listOf(100, 100, 1), harness.http.engine.requests.map { mdbListResponseElement(it.body).objectValue().arrayValue("movies").size })
+    }
+
+    @Test
+    fun `duplicate history input does not produce duplicate writes or false failures`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":1}}""")
+        val result = service(harness).add(harness.repository.currentScope(), listOf(item(1), item(1)))
+        assertTrue(result.isComplete)
+        assertEquals(1, harness.repository.currentSnapshot()?.watched?.size)
+        assertEquals(1, mdbListResponseElement(harness.http.engine.requests.single().body).objectValue().arrayValue("movies").size)
+    }
+
+    @Test
+    fun `partial results only project confirmed items and request reconciliation`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":1},"not_found":{"movies":[{"ids":{"imdb":"tt2"}}]},"plays":[{"type":"movie","ids":{"imdb":"tt1"},"watched_at":"2026-09-06T00:00:00Z","added":false}]}""")
+
+        val result = service(harness).add(harness.repository.currentScope(), listOf(item(1), item(2)))
+
+        assertFalse(result.isComplete)
+        assertEquals(1, result.notFoundCount)
+        assertEquals(listOf("tt1"), harness.repository.currentSnapshot()?.watched?.map { it.media.ids.imdb })
+        assertTrue(MdbListSyncBucket.WATCHED in harness.repository.currentSnapshot()!!.invalidatedBuckets)
+    }
+
+    @Test
+    fun `removing history keeps paused playback and never calls clear or list endpoints`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed(harness.snapshot().copy(playback = listOf(mdbListTestPlayback(timestamp = "2026-09-06T01:00:00Z"))))
+        harness.http.reply(body = """{"deleted":{"movies":1},"not_found":{}}""")
+
+        val result = service(harness).remove(harness.repository.currentScope(), listOf(item(1).media))
+
+        assertTrue(result.isComplete)
+        assertTrue(harness.repository.currentSnapshot()?.watched?.isEmpty() == true)
+        assertEquals(1, harness.repository.currentSnapshot()?.playback?.size)
+        assertEquals(listOf("/sync/watched/remove"), harness.http.engine.requests.map { it.path })
+    }
+
+    @Test
+    fun `a later failed batch preserves already confirmed writes and is not retried`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":100}}""")
+        harness.http.reply(503)
+
+        expectMdbListFailure<MdbListApiException> {
+            service(harness).add(harness.repository.currentScope(), (1L..101L).map(::item))
+        }
+
+        assertEquals(100, harness.repository.currentSnapshot()?.watched?.size)
+        assertEquals(2, harness.http.engine.requests.size)
+        assertTrue(MdbListSyncBucket.WATCHED in harness.repository.currentSnapshot()!!.invalidatedBuckets)
+    }
+
+    @Test
+    fun `malformed success cannot fabricate watched items`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = "{}")
+        expectMdbListFailure<MdbListDecodingException> { service(harness).add(harness.repository.currentScope(), listOf(item(1))) }
+        assertTrue(harness.repository.currentSnapshot()?.watched?.isEmpty() == true)
+        assertEquals(1, harness.http.engine.requests.size)
+    }
+
+    @Test
+    fun `unsupported IDs make no requests and report unresolved items`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val unresolved = item(1).copy(media = item(1).media.copy(ids = TrackingExternalIds(mal = 100)))
+        val result = service(harness).add(harness.repository.currentScope(), listOf(unresolved))
+        assertFalse(result.isComplete)
+        assertEquals(1, result.notFoundCount)
+        assertTrue(harness.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `late history response cannot write into another profile`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"updated":{"movies":1}}""")
+        harness.http.engine.intercept = { harness.switch(2, 84) }
+        val scope = harness.repository.currentScope()
+        expectMdbListFailure<CancellationException> { service(harness).add(scope, listOf(item(1))) }
+        assertEquals(1, harness.http.engine.requests.size)
+        assertEquals(null, harness.storage.profiles[2])
+    }
+
+    private fun service(harness: MdbListSyncTestHarness) = MdbListHistoryService(harness.http.api, harness.repository)
+    private fun item(id: Long) = TrackingHistoryItem(
+        TrackingMediaReference(TrackingMediaKind.MOVIE, "Movie $id", ids = TrackingExternalIds(imdb = "tt$id")),
+        mdbListTimestamp(MDBLIST_TEST_TIME)
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListHttpClientTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListHttpClientTest.kt
@@ -1,0 +1,157 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListHttpClientTest {
+    @Test
+    fun `read retries transient failures with bounded backoff`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(503)
+        harness.reply(502)
+        harness.reply(body = "response")
+
+        val result = harness.http.execute(get())
+
+        assertEquals("response", result.body)
+        assertEquals(listOf(1_000L, 2_000L), harness.sleeps)
+        assertEquals(3, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `write failures never retry uncertain mutations`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(503)
+
+        assertEquals(503, harness.http.execute(post()).status)
+        assertEquals(1, harness.engine.requests.size)
+        assertTrue(harness.sleeps.isEmpty())
+
+        harness.engine.intercept = { throw IOException("Bearer should-not-leak") }
+        val error = expectMdbListFailure<MdbListApiException> { harness.http.execute(post()) }
+
+        assertEquals(2, harness.engine.requests.size)
+        assertFalse(error.toString().contains("should-not-leak"))
+        assertEquals(null, error.cause)
+    }
+
+    @Test
+    fun `daily quota blocks subsequent calls without holding the coroutine until tomorrow`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(429, headers = mapOf("Retry-After" to "3600"))
+
+        val first = expectMdbListFailure<MdbListApiException> { harness.http.execute(get()) }
+        val second = expectMdbListFailure<MdbListApiException> { harness.http.execute(get()) }
+
+        assertEquals(harness.now + 3_600_000L, first.retryAtEpochMs)
+        assertEquals(first.retryAtEpochMs, second.retryAtEpochMs)
+        assertEquals(1, harness.engine.requests.size)
+        assertTrue(harness.sleeps.isEmpty())
+        harness.now += 3_600_000L
+        harness.reply()
+        assertEquals(200, harness.http.execute(get()).status)
+    }
+
+    @Test
+    fun `successful last allowed request blocks later reads until reset`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(headers = mapOf(
+            "x-ratelimit-remaining" to "0",
+            "x-ratelimit-reset" to ((harness.now + 60_000L) / 1_000L).toString()
+        ))
+
+        assertEquals(200, harness.http.execute(get()).status)
+        expectMdbListFailure<MdbListApiException> { harness.http.execute(get()) }
+
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `one account rate limit does not prevent another account request`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(429)
+        expectMdbListFailure<MdbListApiException> { harness.http.execute(get("first")) }
+        harness.reply()
+
+        assertEquals(200, harness.http.execute(get("second")).status)
+    }
+
+    @Test
+    fun `long server retry after returns immediately`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.reply(503, headers = mapOf("Retry-After" to "120"))
+
+        val error = expectMdbListFailure<MdbListApiException> { harness.http.execute(get()) }
+
+        assertEquals(harness.now + 120_000L, error.retryAtEpochMs)
+        assertTrue(harness.sleeps.isEmpty())
+    }
+
+    @Test
+    fun `cancellation is propagated without retry`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.engine.intercept = { throw CancellationException("cancelled") }
+
+        expectMdbListFailure<CancellationException> { harness.http.execute(get()) }
+
+        assertEquals(1, harness.engine.requests.size)
+        assertTrue(harness.sleeps.isEmpty())
+    }
+
+    @Test
+    fun `queued old profile request is discarded before network dispatch`() = runTest {
+        val harness = MdbListTestHarness()
+        val scope = harness.store.scope()
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        harness.reply()
+        harness.engine.intercept = { started.complete(Unit); release.await() }
+        val first = async { harness.http.execute(get()) }
+        started.await()
+        val second = async {
+            expectMdbListFailure<CancellationException> {
+                harness.http.execute(get(), checkScope = { harness.store.checkScope(scope) })
+            }
+        }
+        runCurrent()
+        harness.store.selectProfile(2)
+        release.complete(Unit)
+        first.await()
+        second.await()
+
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `response and request diagnostics redact credentials and body`() {
+        val request = MdbListHttpRequest(
+            MdbListHttpMethod.POST, "/oauth/token/", body = "private-body", accessToken = "private-token",
+            form = mapOf("device_code" to "private-code")
+        )
+        val response = MdbListHttpResponse(400, "private-body", mapOf("Authorization" to "private-token"))
+
+        assertFalse(request.toString().contains("private"))
+        assertFalse(response.toString().contains("private"))
+    }
+
+    @Test
+    fun `retry after supports HTTP dates and rejects invalid or overflowing values`() {
+        assertEquals(1_000L, retryAfterEpochMs("1", 0))
+        assertEquals(1_445_412_480_000L, retryAfterEpochMs("Wed, 21 Oct 2015 07:28:00 GMT", 0))
+        assertEquals(null, retryAfterEpochMs("-1", 0))
+        assertEquals(null, retryAfterEpochMs(Long.MAX_VALUE.toString(), 0))
+        assertEquals(null, retryAfterEpochMs("invalid", 0))
+    }
+
+    private fun get(limitKey: String = "account") = MdbListHttpRequest(MdbListHttpMethod.GET, "/sync/playback", limitKey = limitKey)
+    private fun post() = MdbListHttpRequest(MdbListHttpMethod.POST, "/scrobble/stop")
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryDecoderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryDecoderTest.kt
@@ -1,0 +1,109 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListLibraryDecoderTest {
+    @Test
+    fun `only owned explicitly static movie and show lists become editable tabs`() {
+        val rows = listOf(
+            """{"id":1,"user_id":42,"type":"static","private":false,"name":"Movies","mediatype":"movie"}""",
+            """{"ids":[2],"user_id":42,"type":"static","dynamic":false,"private":true,"name":"Mixed"}""",
+            """{"id":3,"user_id":43,"type":"static","private":false,"name":"Another user"}""",
+            """{"id":4,"type":"dynamic","dynamic":true,"name":"Rules"}""",
+            """{"id":5,"type":"feed","dynamic":false,"name":"Feed"}""",
+            """{"id":6,"type":"external","name":"External"}""",
+            """{"id":7,"type":"official","name":"Official"}""",
+            """{"id":8,"dynamic":false,"name":"Unknown"}""",
+            """{"id":9,"type":"static","mediatype":"episode","name":"Episodes"}""",
+            """{"id":10,"type":"static","dynamic":true,"name":"Inconsistent"}"""
+        )
+        val lists = decodeMdbListLibraryLists(rows.joinToString(",", "[", "]"), 42)
+        assertEquals(listOf(1L, 2L), lists.map { it.id })
+        assertEquals(setOf("movie"), lists[0].tab().supportedContentTypes)
+        assertEquals(setOf("movie", "series"), lists[1].tab().supportedContentTypes)
+        assertEquals(LibraryListPrivacy.PUBLIC, lists[0].tab().privacy)
+        assertEquals(LibraryListPrivacy.PRIVATE, lists[1].tab().privacy)
+    }
+
+    @Test
+    fun `sparse invalid or ambiguous static list responses cannot clear the cache`() = runTest {
+        for (body in listOf("{}", "null", """[{"type":"static","private":true,"name":"Missing ID"}]""",
+            """[{"id":7,"type":"static","name":"Missing privacy"}]""",
+            """[{"ids":[7,8],"type":"static","private":true,"name":"Ambiguous"}]""")) {
+            expectMdbListFailure<MdbListDecodingException> { decodeMdbListLibraryLists(body, 42) }
+        }
+        assertTrue(decodeMdbListLibraryLists("[]", 42).isEmpty())
+    }
+
+    @Test
+    fun `list payloads merge nested and legacy external IDs with bundled metadata`() {
+        val page = decodeMdbListLibraryPage("""{
+          "movies":[{"id":278,"imdb_id":"tt0111161","ids":{"mdblist":"a0","tvdb":190,"imdb":null},
+          "title":"Shawshank","release_year":1994,"poster":"/poster.jpg","description":"Plot","genres":["crime",{"name":"Drama"}],"rank":2}],
+          "shows":[{"id":1396,"imdb_id":"tt0903747","mediatype":"show","title":"Breaking Bad","rank":1}],
+          "episodes":[{}],"seasons":[{}],"pagination":{"next_cursor":"cursor-one","has_more":true}
+        }""")
+        assertEquals(2, page.items.size)
+        val movie = page.items.first()
+        assertEquals(MdbListIds("tt0111161", 278, 190, mdblist = "a0"), movie.media.ids)
+        assertEquals("https://image.tmdb.org/t/p/w500/poster.jpg", movie.media.poster)
+        assertEquals(1994, movie.media.year)
+        assertEquals(listOf("crime", "Drama"), movie.genres)
+        assertEquals("Plot", movie.description)
+        assertEquals(MdbListItemType.SHOW, page.items.last().type)
+        assertEquals("cursor-one", page.nextCursor)
+    }
+
+    @Test
+    fun `unified items retain their media namespaces and ignore episodes`() {
+        for (body in listOf("""[{"id":1,"mediatype":"movie"},{"id":1,"mediatype":"show"},{"mediatype":"episode"}]""",
+            """{"items":[{"id":1,"mediatype":"movie"},{"id":1,"mediatype":"show"}]}""")) {
+            val page = decodeMdbListLibraryPage(body)
+            assertEquals(listOf(MdbListItemType.MOVIE, MdbListItemType.SHOW), page.items.map { it.type })
+            assertFalse(page.items[0].matches(page.items[1]))
+        }
+    }
+
+    @Test
+    fun `malformed pages and conflicting media types fail without inventing items`() = runTest {
+        for (body in listOf("{}", "null", "[] junk", """{"movies":[{}]}""", """{"movies":[{"id":0}]}""",
+            """[{"id":1}]""", """{"movies":[{"id":1,"mediatype":"show"}]}""", """{"movies":[{"id":1,"mediatype":"unknown"}]}""")) {
+            expectMdbListFailure<MdbListDecodingException> { decodeMdbListLibraryPage(body) }
+        }
+    }
+
+    @Test
+    fun `pagination derives a next offset only when the server proves more items exist`() = runTest {
+        val prefix = """{"movies":[],"pagination": """
+        assertEquals(1000, decodeMdbListLibraryPage(prefix + """{"offset":0,"limit":1000,"total":1001}}""").nextOffset)
+        assertEquals(null, decodeMdbListLibraryPage(prefix + """{"offset":0,"limit":1000,"total":1000}}""").nextOffset)
+        expectMdbListFailure<MdbListDecodingException> {
+            decodeMdbListLibraryPage(prefix + """{"has_more":true}}""")
+        }
+    }
+
+    @Test
+    fun `projection merges aliases across lists while preserving per-list order and movie show identity`() {
+        val movie = MdbListLibraryItem(MdbListItemType.MOVIE, MdbListMedia(MdbListIds(tmdb = 1), "Movie"), rank = 4)
+        val aliased = movie.copy(media = movie.media.copy(ids = MdbListIds("tt1", 1, mdblist = "a1")), rank = 8)
+        val show = movie.copy(type = MdbListItemType.SHOW, media = movie.media.copy(title = "Show"))
+        val projection = MdbListLibraryProjection(MdbListLibrarySnapshot(itemsByList = mapOf(
+            MDBLIST_WATCHLIST_KEY to listOf(movie, show), MDBLIST_TEST_LIST_KEY to listOf(aliased)
+        )))
+        assertEquals(2, projection.entries.size)
+        val entry = projection.entries.first { it.type == "movie" }
+        assertEquals("tt1", entry.id)
+        assertEquals("a1", entry.trackingProviderItemId)
+        assertEquals(mapOf(MDBLIST_WATCHLIST_KEY to 4, MDBLIST_TEST_LIST_KEY to 8), entry.listRanks)
+        for (alias in listOf("tt1", "imdb:tt1", "tmdb:1", "mdblist:a1")) {
+            assertEquals(setOf(MDBLIST_WATCHLIST_KEY, MDBLIST_TEST_LIST_KEY), projection.membership(alias, "movie"))
+        }
+        assertEquals(setOf(MDBLIST_WATCHLIST_KEY), projection.membership("tmdb:1", "anime"))
+        assertTrue(projection.membership("tt1", "series").isEmpty())
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryServiceTest.kt
@@ -1,0 +1,234 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListLibraryServiceTest {
+    @Test
+    fun `unresolved provider IDs do not break the shared membership picker`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val membership = h.libraryService(backgroundScope).getMembershipSnapshot(LibraryEntryInput("simkl:123", "anime", "Anime"))
+        assertEquals(setOf(MDBLIST_WATCHLIST_KEY, MDBLIST_TEST_LIST_KEY), membership.listMembership.keys)
+        assertTrue(membership.listMembership.values.none { it })
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `disk read failure is surfaced by manual refresh and does not crash automatic refresh`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.storage.failLoad = true
+        val service = h.libraryService(backgroundScope)
+        service.refresh(TrackingRefreshIntent.AUTOMATIC)
+        expectMdbListFailure<java.io.IOException> { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        assertFalse(service.isRefreshing.first())
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `cold library uses three requests for a watchlist and one static list and persists them`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.http.reply(body = mdbListLibraryListsBody())
+        h.http.reply(body = MDBLIST_LIBRARY_MOVIE_PAGE)
+        h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE)
+        val service = h.libraryService(backgroundScope)
+        service.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertEquals(listOf("/lists/user", "/watchlist/items", "/lists/7/items"), h.http.engine.requests.map { it.path })
+        assertEquals("false", h.http.engine.requests.first().query["unified"])
+        val persisted = Json.decodeFromString<MdbListSyncSnapshot>(h.storage.profiles.getValue(1))
+        assertEquals(h.repository.currentSnapshot()!!.library, persisted.library)
+        assertEquals(listOf("Shawshank"), service.items.first().map { it.name })
+        assertEquals(2, service.tabs.first().size)
+        runCurrent()
+        assertEquals(3, h.http.engine.requests.size)
+        assertTrue(h.remote.calls.isEmpty())
+    }
+
+    @Test
+    fun `cached library membership and repeated browsing make no requests`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val service = h.libraryService(backgroundScope)
+        repeat(5) {
+            service.refresh(TrackingRefreshIntent.AUTOMATIC)
+            service.getMembershipSnapshot(LibraryEntryInput("tt1", "movie", "Movie"))
+            service.tabs.first()
+            service.items.first()
+        }
+        runCurrent()
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `unchanged list versions need only metadata and watchlist requests after fifteen minutes`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val service = h.libraryService(backgroundScope)
+        service.refresh(TrackingRefreshIntent.AUTOMATIC)
+        h.http.now += MdbListSyncRepository.AUTOMATIC_INTERVAL_MS
+        h.http.reply(body = mdbListLibraryListsBody())
+        h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE)
+        service.refresh(TrackingRefreshIntent.AUTOMATIC)
+        assertEquals(listOf("/lists/user", "/watchlist/items"), h.http.engine.requests.map { it.path })
+    }
+
+    @Test
+    fun `changed or missing versions refetch contents even when item counts stay equal`() = runTest {
+        for (version in listOf("v2", null)) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.seedLibrary()
+            h.http.reply(body = mdbListLibraryListsBody(version))
+            h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE)
+            h.http.reply(body = MDBLIST_LIBRARY_MOVIE_PAGE)
+            h.libraryService(backgroundScope).refresh(TrackingRefreshIntent.USER_INITIATED)
+            assertEquals(3, h.http.engine.requests.size)
+            assertEquals(1, h.repository.currentSnapshot()!!.library!!.itemsByList.getValue(MDBLIST_TEST_LIST_KEY).size)
+        }
+    }
+
+    @Test
+    fun `removed or no longer static lists disappear with their membership`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        val movie = decodeMdbListLibraryPage(MDBLIST_LIBRARY_MOVIE_PAGE).items
+        h.seedLibrary(mdbListLibrarySnapshot(h.http.now).copy(itemsByList = mapOf(MDBLIST_TEST_LIST_KEY to movie)))
+        h.http.reply(body = """[{"id":7,"type":"dynamic","name":"Changed"}]""")
+        h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE)
+        val service = h.libraryService(backgroundScope)
+        service.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertEquals(listOf(MDBLIST_WATCHLIST_KEY), service.tabs.first().map { it.key })
+        assertTrue(service.items.first().isEmpty())
+    }
+
+    @Test
+    fun `cursor and offset pagination preserve every page with bundled metadata`() = runTest {
+        for (cursor in listOf(true, false)) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.http.reply(body = """{"movies":[{"id":1}],"pagination":${if (cursor) """{"next_cursor":"page-two","has_more":true}""" else """{"offset":0,"limit":1,"total":2}"""}}""")
+            h.http.reply(body = """{"movies":[{"id":2}],"pagination":{"has_more":false}}""")
+            val result = MdbListLibraryRemote(h.http.api, h.repository.currentScope()).items(MDBLIST_TEST_LIST_KEY)
+            assertEquals(listOf(1L, 2L), result.map { it.media.ids.tmdb })
+            val queries = h.http.engine.requests.map { it.query }
+            assertEquals(if (cursor) "page-two" else "1", queries[1][if (cursor) "cursor" else "offset"])
+            assertTrue(queries.all { it["limit"] == "1000" && it["append_to_response"] == "poster,description,genres" })
+        }
+    }
+
+    @Test
+    fun `repeated cursors and unpageable has-more headers never silently truncate`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        repeat(2) { h.http.reply(body = """{"movies":[{"id":1}],"pagination":{"next_cursor":"same"}}""") }
+        expectMdbListFailure<MdbListDecodingException> {
+            MdbListLibraryRemote(h.http.api, h.repository.currentScope()).items(MDBLIST_TEST_LIST_KEY)
+        }
+        assertEquals(2, h.http.engine.requests.size)
+        h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE, headers = mapOf("X-Has-More" to "true"))
+        expectMdbListFailure<MdbListDecodingException> {
+            MdbListLibraryRemote(h.http.api, h.repository.currentScope()).items(MDBLIST_TEST_LIST_KEY)
+        }
+    }
+
+    @Test
+    fun `failed refresh retains the entire cached library and automatic attempts back off`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.reply(body = mdbListLibraryListsBody("v2"))
+        h.http.reply(body = MDBLIST_LIBRARY_MOVIE_PAGE)
+        h.http.reply(body = "{}")
+        val service = h.libraryService(backgroundScope)
+        expectMdbListFailure<MdbListDecodingException> { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        assertEquals(mdbListLibrarySnapshot(h.http.now), h.repository.currentSnapshot()!!.library)
+        repeat(3) { service.refresh(TrackingRefreshIntent.AUTOMATIC) }
+        assertEquals(3, h.http.engine.requests.size)
+        assertFalse(service.isRefreshing.first())
+    }
+
+    @Test
+    fun `rate-limited refresh respects reset even when the user requests another refresh`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.reply(429, "{}", mapOf("Retry-After" to "3600"))
+        val service = h.libraryService(backgroundScope)
+        repeat(3) { expectMdbListFailure<MdbListApiException> { service.refresh(TrackingRefreshIntent.USER_INITIATED) } }
+        assertEquals(1, h.http.engine.requests.size)
+        assertEquals(mdbListLibrarySnapshot(h.http.now), h.repository.currentSnapshot()!!.library)
+    }
+
+    @Test
+    fun `overlapping refreshes coalesce to one request set`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        h.http.engine.intercept = { if (it.path == "/lists/user") { entered.complete(Unit); release.await() } }
+        h.http.reply(body = "[]")
+        h.http.reply(body = MDBLIST_EMPTY_LIBRARY_PAGE)
+        val service = h.libraryService(backgroundScope)
+        val first = async { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        entered.await()
+        val second = async { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        release.complete(Unit)
+        first.await()
+        second.await()
+        assertEquals(2, h.http.engine.requests.size)
+    }
+
+    @Test
+    fun `profile switch during refresh cannot publish or persist the previous account library`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.reply(body = mdbListLibraryListsBody("v2"))
+        h.http.engine.intercept = { h.switch(2, 84) }
+        val service = h.libraryService(backgroundScope)
+        expectMdbListFailure<CancellationException> { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        h.http.engine.intercept = {}
+        h.repository.ensureLoaded()
+        assertEquals(84L, h.repository.currentSnapshot()?.accountId)
+        assertEquals(null, h.repository.currentSnapshot()?.library)
+        val old = Json.decodeFromString<MdbListSyncSnapshot>(h.storage.profiles.getValue(1))
+        assertEquals("v1", old.library!!.lists.single().updatedAt)
+    }
+
+    @Test
+    fun `disconnect hides cached items and membership before further account requests`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary(mdbListLibrarySnapshot(h.http.now).copy(itemsByList = mapOf(MDBLIST_WATCHLIST_KEY to decodeMdbListLibraryPage(MDBLIST_LIBRARY_MOVIE_PAGE).items)))
+        val service = h.libraryService(backgroundScope)
+        h.repository.ensureLoaded()
+        assertEquals(1, service.items.first().size)
+        h.http.store.clearAuth(h.http.store.scope())
+        assertTrue(service.items.first().isEmpty())
+        assertTrue(service.tabs.first().isEmpty())
+        assertTrue(service.observeMembership("tt0111161", "movie").first().isEmpty())
+        runCurrent()
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `cancelled refresh clears loading and keeps cached data`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.engine.intercept = { awaitCancellation() }
+        val service = h.libraryService(backgroundScope)
+        val job = launch { service.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        assertTrue(service.isRefreshing.first())
+        job.cancel()
+        job.join()
+        assertFalse(service.isRefreshing.first())
+        assertEquals(mdbListLibrarySnapshot(h.http.now), h.repository.currentSnapshot()?.library)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryTestFixtures.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryTestFixtures.kt
@@ -1,0 +1,25 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.coroutines.CoroutineScope
+
+internal const val MDBLIST_TEST_LIST_KEY = "mdblist:list:7"
+internal const val MDBLIST_EMPTY_LIBRARY_PAGE = """{"movies":[],"shows":[],"pagination":{"offset":0,"limit":1000,"total":0,"has_more":false}}"""
+internal const val MDBLIST_LIBRARY_MOVIE_PAGE = """{"movies":[{"id":278,"imdb_id":"tt0111161","title":"Shawshank","release_year":1994,"rank":1}],"shows":[]}"""
+
+internal fun mdbListLibraryListsBody(version: String? = "v1", count: Int = 0) = """[
+    {"id":7,"user_id":42,"name":"Favourites","type":"static","private":true,"items":$count,"last_updated_at":${version?.let { "\"$it\"" } ?: "null"}}
+]"""
+
+internal fun mdbListLibrarySnapshot(now: Long) = MdbListLibrarySnapshot(
+    lists = listOf(MdbListLibraryList(7, "Favourites", true, updatedAt = "v1")),
+    itemsByList = mapOf(MDBLIST_WATCHLIST_KEY to emptyList(), MDBLIST_TEST_LIST_KEY to emptyList()),
+    checkedAtEpochMs = now
+)
+
+internal fun MdbListSyncTestHarness.libraryService(coroutineScope: CoroutineScope) = MdbListLibraryService(
+    http.api, repository, http.store, activeProfile, coroutineScope, { http.now }
+)
+
+internal fun MdbListSyncTestHarness.seedLibrary(library: MdbListLibrarySnapshot = mdbListLibrarySnapshot(http.now)) {
+    seed(snapshot().copy(library = library))
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryWriterTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListLibraryWriterTest.kt
@@ -1,0 +1,246 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.domain.model.LibraryEntryInput
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.ListMembershipChanges
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListLibraryWriterTest {
+    private val movie = LibraryEntryInput("tt1", "movie", "Movie", tmdbId = 1)
+
+    @Test
+    fun `unchecked MDBList destinations do not fail edits for titles known only to another provider`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val unknown = movie.copy(itemId = "simkl:123", itemType = "anime", tmdbId = null)
+        writer(h).applyMembershipChanges(h.repository.currentScope(), unknown, changes(false, false))
+        assertTrue(h.http.engine.requests.isEmpty())
+        expectMdbListFailure<IllegalArgumentException> {
+            writer(h).applyMembershipChanges(h.repository.currentScope(), unknown, changes(true, false))
+        }
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `watchlist and static lists use their different ID payloads and retain other memberships`() = runTest {
+        for (type in listOf("movie", "series", "anime")) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.seedLibrary()
+            val input = movie.copy(itemType = type)
+            val bucket = if (type == "movie") "movies" else "shows"
+            h.http.reply(body = """{"added":1,"existing":0,"not_found":0}""")
+            h.http.reply(body = """{"added":{"$bucket":1},"existing":{"$bucket":0},"not_found":{"$bucket":0}}""")
+            val writer = writer(h)
+            writer.applyMembershipChanges(h.repository.currentScope(), input, changes(true, true))
+            assertEquals(listOf("/watchlist/items/add", "/lists/7/items/add"), h.http.engine.requests.map { it.path })
+            val bodies = h.http.engine.requests.map { mdbListResponseElement(it.body).objectValue().arrayValue(bucket).single().objectValue() }
+            assertEquals(1L, bodies[0].objectValue("ids")!!.number("tmdb"))
+            assertEquals(1L, bodies[1].number("tmdb"))
+            assertFalse(bodies[1].containsKey("ids"))
+            h.http.reply(body = """{"removed":1,"not_found":0}""")
+            writer.applyMembershipChanges(h.repository.currentScope(), input, ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to false)))
+            val library = h.repository.currentSnapshot()!!.library!!
+            assertTrue(library.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).isEmpty())
+            assertEquals(1, library.itemsByList.getValue(MDBLIST_TEST_LIST_KEY).size)
+            assertEquals(3, h.http.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `already correct membership makes no network writes`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        writer(h).applyMembershipChanges(h.repository.currentScope(), movie, changes(false, false))
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `server already-added receipt reconciles stale local membership`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.reply(body = """{"added":0,"existing":1,"not_found":0}""")
+        writer(h).applyMembershipChanges(h.repository.currentScope(), movie, ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to true)))
+        assertEquals(1, h.repository.currentSnapshot()!!.library!!.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).size)
+    }
+
+    @Test
+    fun `partial success is persisted when another list write fails and is not replayed`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.reply(body = """{"added":1,"existing":0,"not_found":0}""")
+        h.http.reply(500)
+        expectMdbListFailure<MdbListApiException> {
+            writer(h).applyMembershipChanges(h.repository.currentScope(), movie, changes(true, true))
+        }
+        val library = h.repository.currentSnapshot()!!.library!!
+        assertEquals(1, library.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).size)
+        assertTrue(library.itemsByList.getValue(MDBLIST_TEST_LIST_KEY).isEmpty())
+        assertTrue(library.invalidated)
+        assertEquals(2, h.http.engine.requests.size)
+        assertEquals(library, Json.decodeFromString<MdbListSyncSnapshot>(h.storage.profiles.getValue(1)).library)
+    }
+
+    @Test
+    fun `unresolved or malformed mutation receipts do not fabricate membership`() = runTest {
+        for (body in listOf("{}", """{"added":0,"existing":0,"not_found":1}""", """{"added":2}""", """{"added":-1,"existing":2}""")) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.seedLibrary()
+            h.http.reply(body = body)
+            expectMdbListFailure<MdbListDecodingException> {
+                writer(h).applyMembershipChanges(h.repository.currentScope(), movie, ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to true)))
+            }
+            assertTrue(h.repository.currentSnapshot()!!.library!!.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).isEmpty())
+            assertTrue(h.repository.currentSnapshot()!!.library!!.invalidated)
+            assertEquals(1, h.http.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `foreign keys nonexistent lists and incompatible item types are rejected before writes`() = runTest {
+        for (key in listOf("watchlist", "personal:7", "mdblist:list:../8", "mdblist:list:8")) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.seedLibrary()
+            expectMdbListFailure<IllegalArgumentException> {
+                writer(h).applyMembershipChanges(h.repository.currentScope(), movie, ListMembershipChanges(mapOf(key to true)))
+            }
+            assertTrue(h.http.engine.requests.isEmpty())
+        }
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary(mdbListLibrarySnapshot(h.http.now).copy(lists = listOf(MdbListLibraryList(7, "Shows", true, mediaType = MdbListItemType.SHOW))))
+        expectMdbListFailure<IllegalArgumentException> {
+            writer(h).applyMembershipChanges(h.repository.currentScope(), movie, ListMembershipChanges(mapOf(MDBLIST_TEST_LIST_KEY to true)))
+        }
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `create rename privacy and delete update cached tabs after confirmed responses`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val writer = writer(h)
+        h.http.reply(201, """{"id":8,"slug":"new-list"}""")
+        writer.createList(" New list ", null, LibraryListPrivacy.PRIVATE)
+        assertEquals("New list", h.repository.currentSnapshot()!!.library!!.lists.last().name)
+        h.http.reply(body = """{"success":true,"id":8,"name":"Renamed","private":false}""")
+        writer.updateList("mdblist:list:8", "Renamed", null, LibraryListPrivacy.PUBLIC)
+        assertFalse(h.repository.currentSnapshot()!!.library!!.lists.last().private)
+        h.http.reply(body = """{"success":true,"id":8,"name":"Renamed"}""")
+        writer.deleteList("mdblist:list:8")
+        assertEquals(listOf(7L), h.repository.currentSnapshot()!!.library!!.lists.map { it.id })
+        assertFalse(h.repository.currentSnapshot()!!.library!!.itemsByList.containsKey("mdblist:list:8"))
+        assertEquals(listOf(MdbListHttpMethod.POST, MdbListHttpMethod.PUT, MdbListHttpMethod.DELETE), h.http.engine.requests.map { it.method })
+        assertEquals("""{"name":"New list","private":true}""", h.http.engine.requests.first().body)
+        assertEquals(3, h.http.engine.requests.size)
+    }
+
+    @Test
+    fun `unsupported description privacy and ordering cannot silently discard user choices`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        val writer = writer(h)
+        assertFalse(writer.capabilities.supportsDescription)
+        assertFalse(writer.capabilities.supportsReordering)
+        for (privacy in listOf(LibraryListPrivacy.LINK, LibraryListPrivacy.FRIENDS)) {
+            expectMdbListFailure<IllegalArgumentException> { writer.createList("List", null, privacy) }
+        }
+        expectMdbListFailure<IllegalArgumentException> { writer.createList("List", "Description", LibraryListPrivacy.PRIVATE) }
+        expectMdbListFailure<IllegalArgumentException> { writer.createList(" ", null, LibraryListPrivacy.PRIVATE) }
+        expectMdbListFailure<UnsupportedOperationException> { writer.reorderLists(listOf(MDBLIST_TEST_LIST_KEY)) }
+        assertTrue(h.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `account list limit and forbidden changes retain lists without retrying the write`() = runTest {
+        for (status in listOf(400, 403, 404, 429, 500)) {
+            val h = MdbListSyncTestHarness(backgroundScope)
+            h.seedLibrary()
+            h.http.reply(status, "{}", if (status == 429) mapOf("Retry-After" to "600") else emptyMap())
+            expectMdbListFailure<MdbListApiException> { writer(h).createList("List", null, LibraryListPrivacy.PRIVATE) }
+            assertEquals(listOf(7L), h.repository.currentSnapshot()!!.library!!.lists.map { it.id })
+            assertTrue(h.repository.currentSnapshot()!!.library!!.invalidated)
+            assertEquals(1, h.http.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `false or mismatched metadata confirmations cannot rename or delete cached lists`() = runTest {
+        for (body in listOf("{}", """{"success":false,"id":7}""", """{"success":true,"id":8}""")) {
+            for (delete in listOf(true, false)) {
+                val h = MdbListSyncTestHarness(backgroundScope)
+                h.seedLibrary()
+                h.http.reply(body = body)
+                expectMdbListFailure<MdbListDecodingException> {
+                    if (delete) writer(h).deleteList(MDBLIST_TEST_LIST_KEY)
+                    else writer(h).updateList(MDBLIST_TEST_LIST_KEY, "Changed", null, LibraryListPrivacy.PUBLIC)
+                }
+                assertEquals("Favourites", h.repository.currentSnapshot()!!.library!!.lists.single().name)
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent duplicate additions send one write and keep one cached item`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        h.http.engine.intercept = { entered.complete(Unit); release.await() }
+        h.http.reply(body = """{"added":1,"existing":0,"not_found":0}""")
+        val writer = writer(h)
+        val scope = h.repository.currentScope()
+        val changes = ListMembershipChanges(mapOf(MDBLIST_WATCHLIST_KEY to true))
+        val first = async { writer.applyMembershipChanges(scope, movie, changes) }
+        entered.await()
+        val second = async { writer.applyMembershipChanges(scope, movie, changes) }
+        runCurrent()
+        release.complete(Unit)
+        first.await()
+        second.await()
+        assertEquals(1, h.http.engine.requests.size)
+        assertEquals(1, h.repository.currentSnapshot()!!.library!!.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).size)
+    }
+
+    @Test
+    fun `switching profiles after server acceptance cannot write the new profile cache`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.engine.intercept = { h.switch(2, 84) }
+        h.http.reply(201, """{"id":8}""")
+        expectMdbListFailure<CancellationException> { writer(h).createList("List", null, LibraryListPrivacy.PRIVATE) }
+        h.repository.ensureLoaded()
+        assertEquals(84L, h.repository.currentSnapshot()?.accountId)
+        assertEquals(null, h.repository.currentSnapshot()?.library)
+        assertFalse(h.storage.profiles.containsKey(2))
+        assertEquals(1, h.http.engine.requests.size)
+    }
+
+    @Test
+    fun `cancellation invalidates uncertain membership for later reconciliation`() = runTest {
+        val h = MdbListSyncTestHarness(backgroundScope)
+        h.seedLibrary()
+        h.http.engine.intercept = { awaitCancellation() }
+        val job = launch { writer(h).applyMembershipChanges(h.repository.currentScope(), movie, changes(true, false)) }
+        runCurrent()
+        job.cancel()
+        job.join()
+        assertTrue(h.repository.currentSnapshot()!!.library!!.invalidated)
+        assertTrue(h.repository.currentSnapshot()!!.library!!.itemsByList.getValue(MDBLIST_WATCHLIST_KEY).isEmpty())
+    }
+
+    private fun writer(h: MdbListSyncTestHarness) = MdbListLibraryWriter(h.http.api, h.repository) { h.http.now }
+
+    private fun changes(watchlist: Boolean, personal: Boolean) = ListMembershipChanges(linkedMapOf(
+        MDBLIST_WATCHLIST_KEY to watchlist, MDBLIST_TEST_LIST_KEY to personal
+    ))
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListMutationTargetTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListMutationTargetTest.kt
@@ -1,0 +1,83 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingEpisode
+import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingMediaKind
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import com.nuvio.tv.core.tracking.parseTrackingExternalIds
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListMutationTargetTest {
+    private val snapshot = MdbListSyncSnapshot(42)
+
+    @Test
+    fun `native MDBList identifiers survive the provider-neutral media boundary`() {
+        val ids = parseTrackingExternalIds("mdblist:public:1:2").mergeMissing(TrackingExternalIds(tmdb = 50))
+        assertEquals("public", ids.mdblist)
+        assertTrue(ids.hasAny)
+        assertEquals("public", ids.toMdbListIds()?.mdblist)
+        val target = snapshot.mutationTarget(movie().copy(ids = ids))!!
+        assertEquals("public", target.scrobbleBody(10.0).objectValue("movie")?.objectValue("ids")?.text("mdblist"))
+    }
+
+    @Test
+    fun `unresolved anime identifiers are rejected instead of guessed from title`() {
+        val reference = TrackingMediaReference(TrackingMediaKind.ANIME, "Series", ids = TrackingExternalIds(mal = 100), episode = TrackingEpisode(null, 1))
+        assertNull(snapshot.mutationTarget(reference))
+        assertNull(snapshot.mutationTarget(reference.copy(ids = TrackingExternalIds(imdb = "tt1"))))
+    }
+
+    @Test
+    fun `movie scrobbles contain only resolvable media IDs and progress`() {
+        val payload = snapshot.mutationTarget(movie())!!.scrobbleBody(12.5)
+        assertEquals(setOf("movie", "progress"), payload.keys)
+        assertEquals("tt1", payload.objectValue("movie")?.objectValue("ids")?.text("imdb"))
+        assertEquals("12.5", payload.text("progress"))
+    }
+
+    @Test
+    fun `episode history sends episode IDs separately from parent show IDs`() {
+        val target = snapshot.mutationTarget(series().copy(episode = TrackingEpisode(1, 2, tvdbId = 700, tmdbId = 600)))!!
+        val payload = mdbListResponseElement(mdbListHistoryPayload(listOf(MdbListHistoryChange(target, MDBLIST_TEST_TIME)))).jsonObject
+        assertEquals(setOf("episodes"), payload.keys)
+        val item = payload.arrayValue("episodes").single().objectValue()
+        assertEquals(600L, item.objectValue("ids")?.number("tmdb"))
+        assertEquals(700L, item.objectValue("ids")?.number("tvdb"))
+        assertEquals(null, item.objectValue("ids")?.text("imdb"))
+    }
+
+    @Test
+    fun `unresolved episode IDs use exact nested coordinates and never expand the whole season`() {
+        val target = snapshot.mutationTarget(series())!!
+        val payload = mdbListResponseElement(mdbListHistoryPayload(listOf(MdbListHistoryChange(target, MDBLIST_TEST_TIME)))).jsonObject
+        val show = payload.arrayValue("shows").single().objectValue()
+        val season = show.arrayValue("seasons").single().objectValue()
+        val episode = season.arrayValue("episodes").single().objectValue()
+        assertEquals("tt1", show.objectValue("ids")?.text("imdb"))
+        assertEquals(1, season.integer("number"))
+        assertEquals(2, episode.integer("number"))
+        assertEquals(MDBLIST_TEST_TIME, episode.text("watched_at"))
+        assertFalse(show.containsKey("watched_at"))
+        assertFalse(season.containsKey("watched_at"))
+    }
+
+    @Test
+    fun `known episode mapping resolves TVDB coordinates to MDBList coordinates`() {
+        val known = mdbListTestEpisode(2, 4).copy(episodeTmdbId = 600, episodeTvdbId = 700)
+        val reference = series().copy(episode = TrackingEpisode(1, 15, tvdbId = 700, usesTvdbSeasonMapping = true))
+        val target = snapshot.copy(watched = listOf(known)).mutationTarget(reference)!!
+        assertEquals(2, target.season)
+        assertEquals(4, target.episode)
+        assertTrue(target.scrobbleCoordinatesResolved)
+        assertEquals(600L, target.episodeTmdbId)
+        assertFalse(snapshot.mutationTarget(reference)!!.scrobbleCoordinatesResolved)
+    }
+
+    private fun movie() = TrackingMediaReference(TrackingMediaKind.MOVIE, ids = TrackingExternalIds(imdb = "tt1"))
+    private fun series() = TrackingMediaReference(TrackingMediaKind.SHOW, ids = TrackingExternalIds(imdb = "tt1"), episode = TrackingEpisode(1, 2))
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListMutationTargetTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListMutationTargetTest.kt
@@ -41,6 +41,26 @@ class MdbListMutationTargetTest {
     }
 
     @Test
+    fun `player percentages use at most two decimal places without crossing the watched threshold`() {
+        val samples = listOf(
+            64.321533203125 to 64.32,
+            0.20450681447982788 to 0.20,
+            50.45989227294922 to 50.45,
+            79.999999 to 79.99,
+            80.0 to 80.0,
+            100.0 to 100.0
+        )
+        for (reference in listOf(movie(), series())) {
+            val target = snapshot.mutationTarget(reference)!!
+            for ((progress, expected) in samples) {
+                val encoded = target.scrobbleBody(progress).text("progress")!!
+                assertEquals(expected, encoded.toDouble(), 0.0)
+                assertTrue(encoded.substringAfter('.', "").length <= 2)
+            }
+        }
+    }
+
+    @Test
     fun `episode history sends episode IDs separately from parent show IDs`() {
         val target = snapshot.mutationTarget(series().copy(episode = TrackingEpisode(1, 2, tvdbId = 700, tmdbId = 600)))!!
         val payload = mdbListResponseElement(mdbListHistoryPayload(listOf(MdbListHistoryChange(target, MDBLIST_TEST_TIME)))).jsonObject

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListProgressProjectionTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListProgressProjectionTest.kt
@@ -1,0 +1,129 @@
+package com.nuvio.tv.data.mdblist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListProgressProjectionTest {
+    @Test
+    fun `resume uses actual duration instead of assuming catalog runtime matches the stream`() {
+        val playback = mdbListTestPlayback(40f).copy(runtimeMinutes = 100)
+        val progress = projection(playback = listOf(playback)).progress.single()
+        assertEquals(0L, progress.position)
+        assertEquals(6_000_000L, progress.duration)
+        assertEquals(1_920_000L, progress.resolveResumePosition(4_800_000L))
+        assertEquals("mdblist", progress.trackingProviderId)
+    }
+
+    @Test
+    fun `unknown runtime retains percentage progress and resume remains available`() {
+        val progress = projection(playback = listOf(mdbListTestPlayback(30f))).progress.single()
+        assertEquals(0L, progress.duration)
+        assertTrue(progress.isInProgress())
+        assertEquals(1_080_000L, progress.resolveResumePosition(3_600_000L))
+    }
+
+    @Test
+    fun `eighty percent is completed and never projected as paused progress`() {
+        for (percent in listOf(0f, 1.99f, 2f, 79.99f, 80f, 99f, 100f)) {
+            val projection = projection(playback = listOf(mdbListTestPlayback(percent)))
+            assertEquals(percent < 80f, projection.progress.isNotEmpty())
+            if (percent < 80f) assertEquals(percent >= 2f, projection.progress.single().isInProgress())
+        }
+        val progress = projection(playback = listOf(mdbListTestPlayback(79f))).progress.single().copy(progressPercent = 80f)
+        assertTrue(progress.isCompleted())
+        assertFalse(progress.isInProgress())
+    }
+
+    @Test
+    fun `completed history suppresses stale sessions but allows a later rewatch`() {
+        val watched = listOf(mdbListTestMovie())
+        val stale = projection(watched, listOf(mdbListTestPlayback(timestamp = "2026-09-05T00:00:00Z")))
+        val rewatch = projection(watched, listOf(mdbListTestPlayback(timestamp = "2026-09-06T00:10:00Z")))
+        assertTrue(stale.progress.isEmpty())
+        assertEquals(1, rewatch.progress.size)
+        assertTrue(rewatch.isWatched("tt1", null, null))
+    }
+
+    @Test
+    fun `exact episode history is available through every parent alias`() {
+        val projection = projection(watched = listOf(mdbListTestEpisode(2, 3)))
+        for (id in listOf("tt1", "imdb:tt1", "tmdb:1")) {
+            assertTrue(projection.isWatched(id, 2, 3))
+            assertFalse(projection.isWatched(id, 2, 4))
+            assertEquals(setOf(2 to 3), projection.watchedShowEpisodes[id])
+            assertTrue(projection.showIdSiblings[id].orEmpty().contains("tmdb:1"))
+        }
+        assertEquals(1, projection.watchedItems.size)
+    }
+
+    @Test
+    fun `next up respects furthest episode and most recently watched preferences`() {
+        val projection = projection(watched = listOf(
+            mdbListTestEpisode(1, 2, "2026-09-06T00:00:00Z"),
+            mdbListTestEpisode(3, 7, "2026-09-05T00:00:00Z")
+        ))
+        assertEquals(3, projection.nextUp(true).single().season)
+        assertEquals(7, projection.nextUp(true).single().episode)
+        assertEquals(1, projection.nextUp(false).single().season)
+        assertEquals(2, projection.nextUp(false).single().episode)
+    }
+
+    @Test
+    fun `dropped show suppresses progress and next up through aliases while keeping history`() {
+        val projection = projection(
+            watched = listOf(mdbListTestEpisode()),
+            playback = listOf(mdbListTestPlayback(timestamp = "2026-09-06T01:00:00Z").copy(type = MdbListItemType.EPISODE, season = 1, episode = 2)),
+            dropped = listOf(MdbListDroppedRecord(MdbListIds(tmdb = 1)))
+        )
+        assertTrue(projection.isHidden("tt1"))
+        assertTrue(projection.progress.isEmpty())
+        assertTrue(projection.nextUp(true).isEmpty())
+        assertTrue(projection.isWatched("tt1", 1, 1))
+    }
+
+    @Test
+    fun `dropped seasons exclude next up candidates without inventing watched episodes`() {
+        val projection = projection(
+            watched = listOf(mdbListTestEpisode()),
+            dropped = listOf(MdbListDroppedRecord(MdbListIds(tmdb = 1), 2))
+        )
+        assertFalse(projection.isHidden("tt1"))
+        assertEquals(setOf(2), projection.nextUp(true).single().excludedNextUpSeasons)
+        assertFalse(projection.isWatched("tt1", 2, 1))
+        assertEquals(setOf(1 to 1), projection.watchedShowEpisodes["tt1"])
+    }
+
+    @Test
+    fun `show and season markers never fabricate exact episodes or completed badges`() {
+        val show = mdbListTestMovie().copy(type = MdbListItemType.SHOW)
+        val season = show.copy(type = MdbListItemType.SEASON, season = 1)
+        val projection = projection(watched = listOf(show, season))
+        assertTrue(projection.watchedItems.isEmpty())
+        assertTrue(projection.watchedMovieIds.isEmpty())
+        assertTrue(projection.watchedShowEpisodes.isEmpty())
+        assertFalse(projection.isWatched("tt1", 1, 1))
+    }
+
+    @Test
+    fun `specials remain in history without becoming next up seeds`() {
+        val projection = projection(watched = listOf(mdbListTestEpisode(0, 3)))
+        assertTrue(projection.nextUp(true).isEmpty())
+        assertTrue(projection.isWatched("tt1", 0, 3))
+    }
+
+    @Test
+    fun `multiple local sessions without server IDs are not collapsed together`() {
+        val first = mdbListTestPlayback().copy(id = null)
+        val second = first.copy(media = mdbListTestMovie(2).media)
+        val normalized = MdbListSyncSnapshot(42, playback = listOf(first, second)).normalizeMedia()
+        assertEquals(2, normalized.playback.size)
+    }
+
+    private fun projection(
+        watched: List<MdbListWatchedRecord> = emptyList(),
+        playback: List<MdbListPlayback> = emptyList(),
+        dropped: List<MdbListDroppedRecord> = emptyList()
+    ) = MdbListProgressProjection(MdbListSyncSnapshot(42, watched, playback, dropped).normalizeMedia())
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListScrobbleServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListScrobbleServiceTest.kt
@@ -1,0 +1,161 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingMediaKind
+import com.nuvio.tv.core.tracking.TrackingMediaReference
+import com.nuvio.tv.core.tracking.TrackingScrobbleAction
+import com.nuvio.tv.core.tracking.TrackingScrobbleEvent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListScrobbleServiceTest {
+    @Test
+    fun `start replaces paused progress without marking history even above eighty percent`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed(harness.snapshot().copy(watched = emptyList(), playback = listOf(mdbListTestPlayback())))
+        harness.http.reply(201, """{"id":8,"action":"start","progress":90,"started_at":"2026-09-06T01:00:00Z"}""")
+
+        service(harness).scrobble(harness.repository.currentScope(), TrackingScrobbleAction.START, event(90.0))
+
+        assertTrue(harness.repository.currentSnapshot()?.watched?.isEmpty() == true)
+        assertTrue(harness.repository.currentSnapshot()?.playback?.isEmpty() == true)
+        assertEquals(listOf("/scrobble/start"), harness.http.engine.requests.map { it.path })
+    }
+
+    @Test
+    fun `both pause and stop save below eighty and mark watched at eighty`() = runTest {
+        for (action in listOf(TrackingScrobbleAction.PAUSE, TrackingScrobbleAction.STOP)) {
+            for (progress in listOf(79.99, 80.0, 100.0)) {
+                val harness = MdbListSyncTestHarness(backgroundScope)
+                harness.http.reply(body = if (progress < 80.0) {
+                    """{"id":7,"action":"pause","progress":$progress,"paused_at":"2026-09-06T01:00:00Z"}"""
+                } else """{"action":"scrobble","progress":$progress,"watched_at":"2026-09-06T01:00:00Z"}""")
+
+                service(harness).scrobble(harness.repository.currentScope(), action, event(progress))
+
+                assertEquals(progress >= 80.0, harness.repository.currentSnapshot()!!.watched.isNotEmpty())
+                assertEquals(progress < 80.0, harness.repository.currentSnapshot()!!.playback.isNotEmpty())
+                assertEquals(1, harness.http.engine.requests.size)
+                assertTrue(harness.remote.calls.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun `minimal stop response still saves resumable progress without inventing a playback ID`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.http.reply(body = """{"action":"pause","progress":35}""", headers = mapOf("Date" to "Sun, 06 Sep 2026 01:00:00 GMT"))
+
+        service(harness).scrobble(harness.repository.currentScope(), TrackingScrobbleAction.STOP, event(35.0))
+
+        val playback = harness.repository.currentSnapshot()!!.playback.single()
+        assertEquals(null, playback.id)
+        assertEquals("2026-09-06T01:00:00Z", playback.updatedAt)
+        assertEquals(35f, playback.progress, 0f)
+    }
+
+    @Test
+    fun `paused timestamp never falls back to an old session start time`() {
+        val target = MdbListMutationTarget(MdbListItemType.MOVIE, mdbListTestMovie().media)
+        val response = MdbListHttpResponse(200, """{"action":"pause","progress":30,"started_at":"2026-09-05T00:00:00Z"}""", mapOf("Date" to "Sun, 06 Sep 2026 01:00:00 GMT"))
+        val receipt = decodeMdbListScrobbleReceipt(response, target, TrackingScrobbleAction.PAUSE, 0)
+        assertEquals("2026-09-06T01:00:00Z", receipt.timestamp)
+    }
+
+    @Test
+    fun `server resolved episode coordinates and IDs are applied to local history`() {
+        val target = MdbListMutationTarget(MdbListItemType.EPISODE, mdbListTestMovie().media, 1, 12)
+        val response = MdbListHttpResponse(200, """{
+          "action":"scrobble","progress":95,"watched_at":"2026-09-06T01:00:00Z",
+          "show":{"ids":{"tmdb":1,"imdb":"tt1"}},"episode":{"season":2,"number":3,"ids":{"tmdb":900},"title":"Resolved"}
+        }""")
+        val receipt = decodeMdbListScrobbleReceipt(response, target, TrackingScrobbleAction.STOP, 0)
+        val snapshot = MdbListSyncSnapshot(42).applyScrobble(receipt)
+        val watched = snapshot.watched.single()
+        assertEquals(2, watched.season)
+        assertEquals(3, watched.episode)
+        assertEquals(900L, watched.episodeTmdbId)
+        assertEquals("Resolved", watched.episodeTitle)
+    }
+
+    @Test
+    fun `malformed or unrelated media response never fabricates progress`() = runTest {
+        for (body in listOf("{}", """{"action":"pause","progress":101}""", """{"action":"pause","progress":40,"movie":{"ids":{"imdb":"tt999"}}}""")) {
+            val harness = MdbListSyncTestHarness(backgroundScope)
+            harness.http.reply(body = body)
+            expectMdbListFailure<MdbListDecodingException> {
+                service(harness).scrobble(harness.repository.currentScope(), TrackingScrobbleAction.PAUSE, event(40.0))
+            }
+            assertTrue(harness.repository.currentSnapshot()?.playback?.isEmpty() == true)
+            assertTrue(harness.repository.currentSnapshot()?.watched?.isEmpty() == true)
+            assertEquals(setOf(MdbListSyncBucket.WATCHED, MdbListSyncBucket.PLAYBACK), harness.repository.currentSnapshot()?.invalidatedBuckets)
+            assertEquals(1, harness.http.engine.requests.size)
+        }
+    }
+
+    @Test
+    fun `clear removes paused progress and retains watched history for true false and absent sessions`() = runTest {
+        for ((status, body) in listOf(200 to """{"action":"clear","deleted":true}""", 200 to """{"action":"clear","deleted":false}""", 404 to "{}")) {
+            val harness = MdbListSyncTestHarness(backgroundScope)
+            harness.seed(harness.snapshot().copy(playback = listOf(mdbListTestPlayback())))
+            harness.http.reply(status, body)
+
+            service(harness).clear(harness.repository.currentScope(), "tmdb:1", null, null)
+
+            assertEquals(listOf(mdbListTestMovie()), harness.repository.currentSnapshot()?.watched)
+            assertTrue(harness.repository.currentSnapshot()?.playback?.isEmpty() == true)
+            assertEquals(listOf("/scrobble/clear"), harness.http.engine.requests.map { it.path })
+        }
+    }
+
+    @Test
+    fun `clearing one episode leaves other episodes untouched`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val first = mdbListTestPlayback().copy(type = MdbListItemType.EPISODE, season = 1, episode = 1)
+        val second = first.copy(id = 8, episode = 2)
+        harness.seed(harness.snapshot().copy(playback = listOf(first, second)))
+        harness.http.reply(body = """{"action":"clear","deleted":true}""")
+        service(harness).clear(harness.repository.currentScope(), "tt1", 1, 1)
+        assertEquals(listOf(second), harness.repository.currentSnapshot()?.playback)
+        assertEquals(1, harness.http.engine.requests.size)
+    }
+
+    @Test
+    fun `cancellation after dispatch records pending reconciliation without retrying the write`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val dispatched = CompletableDeferred<Unit>()
+        harness.http.engine.intercept = { dispatched.complete(Unit); awaitCancellation() }
+        val job = launch { service(harness).scrobble(harness.repository.currentScope(), TrackingScrobbleAction.STOP, event(95.0)) }
+        runCurrent()
+        assertTrue(dispatched.isCompleted)
+        job.cancel()
+        job.join()
+        assertEquals(1, harness.http.engine.requests.size)
+        assertTrue(harness.repository.currentSnapshot()?.watched?.isEmpty() == true)
+        assertEquals(setOf(MdbListSyncBucket.WATCHED, MdbListSyncBucket.PLAYBACK), harness.repository.currentSnapshot()?.invalidatedBuckets)
+    }
+
+    @Test
+    fun `unsupported identifiers and nonfinite progress never dispatch requests`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val service = service(harness)
+        service.scrobble(harness.repository.currentScope(), TrackingScrobbleAction.PAUSE, event(Double.NaN))
+        service.scrobble(harness.repository.currentScope(), TrackingScrobbleAction.PAUSE, event(Double.POSITIVE_INFINITY))
+        service.scrobble(harness.repository.currentScope(), TrackingScrobbleAction.PAUSE, event(40.0).copy(media = event(40.0).media.copy(ids = TrackingExternalIds(mal = 100))))
+        assertTrue(harness.http.engine.requests.isEmpty())
+        assertFalse(harness.repository.state.value.hasLoaded)
+    }
+
+    private fun service(harness: MdbListSyncTestHarness) = MdbListScrobbleService(harness.http.api, harness.repository)
+    private fun event(progress: Double) = TrackingScrobbleEvent(
+        TrackingMediaReference(TrackingMediaKind.MOVIE, "Movie", ids = TrackingExternalIds(imdb = "tt1")), progress
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListScrobbleServiceTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListScrobbleServiceTest.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.data.mdblist
 
 import com.nuvio.tv.core.tracking.TrackingExternalIds
+import com.nuvio.tv.core.tracking.TrackingEpisode
 import com.nuvio.tv.core.tracking.TrackingMediaKind
 import com.nuvio.tv.core.tracking.TrackingMediaReference
 import com.nuvio.tv.core.tracking.TrackingScrobbleAction
@@ -17,6 +18,38 @@ import org.junit.Test
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class MdbListScrobbleServiceTest {
+    @Test
+    fun `fractional player progress survives start pause resume and exit for movies and episodes`() = runTest {
+        val movie = event(0.0).media
+        val episode = movie.copy(kind = TrackingMediaKind.SHOW, episode = TrackingEpisode(1, 1))
+        for (media in listOf(movie, episode)) {
+            val harness = MdbListSyncTestHarness(backgroundScope)
+            val actions = listOf(
+                Triple(TrackingScrobbleAction.START, 0.20450681447982788, 0.20),
+                Triple(TrackingScrobbleAction.PAUSE, 64.321533203125, 64.32),
+                Triple(TrackingScrobbleAction.START, 64.32167053222656, 64.32),
+                Triple(TrackingScrobbleAction.STOP, 64.38255310058594, 64.38)
+            )
+            for ((action, progress, expected) in actions) {
+                val start = action == TrackingScrobbleAction.START
+                val responseAction = if (start) "start" else "pause"
+                val timestamp = if (start) "started_at" else "paused_at"
+                harness.http.reply(body = """{"action":"$responseAction","progress":$expected,"$timestamp":"$MDBLIST_TEST_TIME"}""")
+
+                service(harness).scrobble(harness.repository.currentScope(), action, TrackingScrobbleEvent(media, progress))
+
+                val request = harness.http.engine.requests.last()
+                assertEquals("/scrobble/${action.wireValue}", request.path)
+                assertEquals(expected, mdbListResponseElement(request.body).objectValue().text("progress")!!.toDouble(), 0.0)
+                assertTrue(harness.repository.currentSnapshot()!!.watched.isEmpty())
+                if (start) assertTrue(harness.repository.currentSnapshot()!!.playback.isEmpty())
+                else assertEquals(expected.toFloat(), harness.repository.currentSnapshot()!!.playback.single().progress, 0f)
+            }
+            assertEquals(4, harness.http.engine.requests.size)
+            assertTrue(harness.remote.calls.isEmpty())
+        }
+    }
+
     @Test
     fun `start replaces paused progress without marking history even above eighty percent`() = runTest {
         val harness = MdbListSyncTestHarness(backgroundScope)

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncDecoderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncDecoderTest.kt
@@ -1,0 +1,146 @@
+package com.nuvio.tv.data.mdblist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListSyncDecoderTest {
+    @Test
+    fun `watched episodes preserve show identity and separate episode IDs`() {
+        val result = decodeMdbListWatched("""{
+          "episodes":[{"last_watched_at":"2026-09-01T12:00:00Z","episode":{
+            "season":2,"number":3,"name":"Third","ids":{"tmdb":500,"tvdb":600},
+            "show":{"title":"Series","ids":{"imdb":"tt1234","tmdb":50,"mdblist":"abc"}}
+          }}],"pagination":{"next_cursor":"opaque+/="}
+        }""")
+
+        val episode = result.items.single()
+        assertEquals(50L, episode.media.ids.tmdb)
+        assertEquals("tt1234", episode.media.ids.contentId)
+        assertEquals(500L, episode.episodeTmdbId)
+        assertEquals(600L, episode.episodeTvdbId)
+        assertEquals(2, episode.season)
+        assertEquals(3, episode.episode)
+        assertEquals("opaque+/=", result.nextCursor)
+    }
+
+    @Test
+    fun `all watched types and explicit nested episodes decode without inventing history`() {
+        val result = decodeMdbListWatched("""{
+          "movies":[{"watched_at":"2026-09-01T12:00:00+00:00","movie":{"ids":{"tmdb":1}}}],
+          "shows":[{"watched_at":"2026-09-01T12:00:00Z","show":{"ids":{"tmdb":2},"total_aired_episodes":100},
+            "seasons":[{"number":1,"episodes":[{"number":4,"watched_at":"2026-09-01T12:00:00Z"},{"number":5}]}]}],
+          "seasons":[{"watched_at":"2026-09-01T12:00:00Z","season":{"number":2,"ids":{"tmdb":200},"show":{"ids":{"tmdb":2}}}}]
+        }""")
+
+        assertEquals(4, result.items.size)
+        assertEquals(listOf(4), result.items.filter { it.type == MdbListItemType.EPISODE }.map { it.episode })
+        assertEquals(2L, result.items.single { it.type == MdbListItemType.SEASON }.media.ids.tmdb)
+    }
+
+    @Test
+    fun `incomplete identity coordinates or dates fail instead of publishing partial history`() {
+        val bodies = listOf(
+            "{}", "[]", "{broken}",
+            """{"movies":[{"watched_at":"today","movie":{"ids":{"tmdb":1}}}]}""",
+            """{"movies":[{"watched_at":"2026-09-01T12:00:00Z","movie":{"ids":{"tmdb":0}}}]}""",
+            """{"episodes":[{"watched_at":"2026-09-01T12:00:00Z","episode":{"number":1,"ids":{"tmdb":500},"show":{"ids":{"tmdb":5}}}}]}"""
+        )
+        bodies.forEach { body -> assertDecodingFails { decodeMdbListWatched(body) } }
+    }
+
+    @Test
+    fun `paused episodes accept legacy identifier names and unknown runtime`() {
+        val result = decodeMdbListPlayback("""[{
+          "id":7,"type":"episode","progress":42.25,"runtime":0,"updated_at":"2026-09-01T12:00:00Z",
+          "show":{"title":"Series","ids":{"imdbid":"tt1234","tmdbid":50}},
+          "episode":{"season":0,"number":1,"title":"Special","ids":{"tmdbid":500}}
+        }]""").single()
+
+        assertEquals(42.25f, result.progress, 0f)
+        assertEquals(50L, result.media.ids.tmdb)
+        assertEquals(500L, result.episodeTmdbId)
+        assertEquals(0, result.season)
+        assertNull(result.runtimeMinutes)
+    }
+
+    @Test
+    fun `invalid playback percentages and missing coordinates are rejected`() {
+        for (progress in listOf("NaN", "Infinity", "-1", "101")) {
+            assertDecodingFails {
+                decodeMdbListPlayback("""[{"id":1,"type":"movie","progress":"$progress","paused_at":"2026-09-01T12:00:00Z","movie":{"ids":{"tmdb":1}}}]""")
+            }
+        }
+        assertDecodingFails {
+            decodeMdbListPlayback("""[{"id":1,"type":"episode","progress":10,"paused_at":"2026-09-01T12:00:00Z","show":{"ids":{"tmdb":1}},"episode":{"number":1}}]""")
+        }
+    }
+
+    @Test
+    fun `dropped seasons use parent identifiers and retain season zero`() {
+        val show = decodeMdbListDropped("""{"shows":[{"show":{"ids":{"tmdb":5}}}]}""", false).items.single()
+        val season = decodeMdbListDropped("""{"seasons":[{"season":{"number":0,"ids":{"tmdb":500},"show":{"ids":{"tmdb":5}}}}]}""", true).items.single()
+        assertEquals(5L, show.ids.tmdb)
+        assertNull(show.season)
+        assertEquals(5L, season.ids.tmdb)
+        assertEquals(0, season.season)
+    }
+
+    @Test
+    fun `journal separates server action from backdated watch time and ignores ratings`() {
+        val result = decodeMdbListJournal("""{"journal":[
+          {"category":"rated"},
+          {"category":"watched","item_type":"episode","ids":{"mdblist":"abc","tmdb":5},"status":"added","action_at":"2026-09-01T12:00:00Z","value_at":"2020-01-01T00:00:00Z","season":1,"episode":3,"episode_tmdb_id":500},
+          {"category":"watched","item_type":"movie","ids":{"tmdb":6},"status":"removed","action_at":"2026-09-01T12:00:01Z","value_at":null}
+        ],"server_time":"2026-09-01T12:00:02Z","pagination":{"has_more":false}}""")
+
+        assertEquals(2, result.items.size)
+        assertEquals("2020-01-01T00:00:00Z", result.items.first().watchedAt)
+        assertEquals(5L, result.items.first().ids.tmdb)
+        assertEquals(500L, result.items.first().episodeTmdbId)
+        assertTrue(result.items.last().removed)
+    }
+
+    @Test
+    fun `empty filtered journal page still preserves its continuation`() {
+        val page = decodeMdbListJournal("""{"journal":[{"category":"rated"}],"pagination":{"has_more":true,"next_cursor":"next"}}""")
+        assertTrue(page.items.isEmpty())
+        assertEquals("next", page.nextCursor)
+    }
+
+    @Test
+    fun `expired journals request full sync and malformed journals fail`() {
+        assertTrue(decodeMdbListJournal("""{"requires_full_sync":true,"reason":"sync_window_expired"}""").requiresFullSync)
+        listOf("{}", """{"journal":null}""", """{"journal":[],"pagination":{"has_more":true}}""").forEach { body ->
+            assertDecodingFails { decodeMdbListJournal(body) }
+        }
+    }
+
+    @Test
+    fun `activity comparison includes removals and tolerates unrelated metadata`() {
+        val previous = decodeMdbListActivities("""{"server_time":"2026-09-01T12:00:00Z","watched_at":null,"journal_at":null,"paused_at":null,"dropped_at":null,"version":2}""")
+        val next = decodeMdbListActivities("""{"server_time":"2026-09-01T12:00:10Z","watched_at":null,"journal_at":"2026-09-01T12:00:05Z","paused_at":null,"dropped_at":null,"version":3}""")
+        assertTrue(next.watchedChanged(previous))
+        assertEquals(false, next.playbackChanged(previous))
+        assertEquals(false, next.droppedChanged(previous))
+        assertEquals(false, next.values.containsKey("version"))
+    }
+
+    @Test
+    fun `legacy pagination continues by total and cursor pagination takes priority`() {
+        val offset = decodeMdbListWatched("""{"movies":[],"pagination":{"total":3000,"offset":0,"limit":1000}}""")
+        val cursor = decodeMdbListWatched("""{"movies":[],"pagination":{"total":3000,"offset":0,"limit":1000,"next_cursor":"next"}}""")
+        assertEquals(1000, offset.nextOffset)
+        assertNull(cursor.nextOffset)
+        assertEquals("next", cursor.nextCursor)
+    }
+
+    private fun assertDecodingFails(block: () -> Any) {
+        try {
+            block()
+            throw AssertionError("Expected incomplete response to fail")
+        } catch (_: MdbListDecodingException) {
+        }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncEngineTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncEngineTest.kt
@@ -1,0 +1,169 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListSyncEngineTest {
+    @Test
+    fun `bootstrap fetches required buckets once and saves server time rather than device clock`() = runTest {
+        val remote = Remote()
+        remote.watched = listOf(movie())
+
+        val result = MdbListSyncEngine(remote) { 999L }.synchronize(MdbListSyncSnapshot(42))
+
+        assertEquals(listOf("activities", "watched", "playback", "dropped"), remote.calls)
+        assertEquals(TIME, result.watermark)
+        assertEquals(999L, result.checkedAtEpochMs)
+        assertTrue(result.isInitialized)
+        assertEquals(listOf(movie()), result.watched)
+    }
+
+    @Test
+    fun `unchanged account only requests activities and reuses data projections`() = runTest {
+        val previous = snapshot()
+        val remote = Remote()
+
+        val result = MdbListSyncEngine(remote).synchronize(previous)
+
+        assertEquals(listOf("activities"), remote.calls)
+        assertSame(previous.watched, result.watched)
+        assertSame(previous.playback, result.playback)
+        assertSame(previous.dropped, result.dropped)
+    }
+
+    @Test
+    fun `unrelated library activity never triggers a history or playback request`() = runTest {
+        val remote = Remote().apply { activities = activities.copy(values = activities.values + ("watchlisted_at" to TIME)) }
+        MdbListSyncEngine(remote).synchronize(snapshot())
+        assertEquals(listOf("activities"), remote.calls)
+    }
+
+    @Test
+    fun `watched changes fetch journal alone with previous server watermark`() = runTest {
+        val remote = Remote().apply {
+            activities = activities.copy(values = activities.values + ("journal_at" to TIME))
+            journal = MdbListPage(listOf(change(1, removed = true), change(2)))
+        }
+
+        val result = MdbListSyncEngine(remote).synchronize(snapshot())
+
+        assertEquals(listOf("activities", "journal:$TIME"), remote.calls)
+        assertEquals(listOf(2L), result.watched.map { it.media.ids.tmdb })
+        assertEquals("2020-01-01T00:00:00Z", result.watched.single().watchedAt)
+        assertEquals(TIME, result.watermark)
+    }
+
+    @Test
+    fun `playback and dropped invalidations refresh only their own buckets`() = runTest {
+        for ((key, expected) in listOf("paused_at" to "playback", "episode_paused_at" to "playback", "dropped_at" to "dropped")) {
+            val remote = Remote().apply { activities = activities.copy(values = activities.values + (key to TIME)) }
+            val result = MdbListSyncEngine(remote).synchronize(snapshot())
+            assertEquals(listOf("activities", expected), remote.calls)
+            assertEquals(1, result.watched.size)
+        }
+    }
+
+    @Test
+    fun `expired or future watermarks use complete snapshots without journal replay`() = runTest {
+        for (watermark in listOf(null, "2026-08-01T00:00:00Z", "2026-09-07T00:00:00Z")) {
+            val remote = Remote()
+            MdbListSyncEngine(remote).synchronize(snapshot().copy(watermark = watermark))
+            assertEquals(listOf("activities", "watched", "playback", "dropped"), remote.calls)
+        }
+    }
+
+    @Test
+    fun `server journal expiry falls back to authoritative watched replacement`() = runTest {
+        val remote = Remote().apply {
+            activities = activities.copy(values = activities.values + ("journal_at" to TIME))
+            journal = MdbListPage(emptyList(), requiresFullSync = true)
+            watched = listOf(movie(2))
+        }
+        val result = MdbListSyncEngine(remote).synchronize(snapshot())
+        assertEquals(listOf("activities", "journal:$TIME", "watched"), remote.calls)
+        assertEquals(listOf(2L), result.watched.map { it.media.ids.tmdb })
+    }
+
+    @Test
+    fun `failure after successful watched read leaves original cache and watermark untouched`() = runTest {
+        val original = snapshot().copy(isInitialized = false)
+        val remote = Remote().apply { watched = listOf(movie(2)); failPlayback = true }
+
+        expectMdbListFailure<IOException> { MdbListSyncEngine(remote).synchronize(original) }
+
+        assertEquals(listOf(movie()), original.watched)
+        assertEquals(TIME, original.watermark)
+        assertFalse(original.isInitialized)
+    }
+
+    @Test
+    fun `journal aliases retain titles and episode metadata across identifier changes`() {
+        val known = movie().copy(type = MdbListItemType.EPISODE, season = 1, episode = 2, episodeTitle = "Second", episodeTmdbId = 200)
+        val snapshot = snapshot().copy(watched = listOf(known))
+        val update = change(1).copy(type = MdbListItemType.EPISODE, ids = MdbListIds(tmdb = 1, mdblist = "public"), season = 1, episode = 2)
+
+        val result = applyMdbListJournal(snapshot, listOf(update)).single()
+
+        assertEquals("Movie 1", result.media.title)
+        assertEquals("tt1", result.media.ids.imdb)
+        assertEquals("public", result.media.ids.mdblist)
+        assertEquals("Second", result.episodeTitle)
+        assertEquals(200L, result.episodeTmdbId)
+    }
+
+    @Test
+    fun `show and season tombstones do not fabricate removals for unmentioned episodes`() {
+        val episode = movie().copy(type = MdbListItemType.EPISODE, season = 1, episode = 2)
+        val show = episode.copy(type = MdbListItemType.SHOW, season = null, episode = null)
+        val season = episode.copy(type = MdbListItemType.SEASON, episode = null)
+        val original = snapshot().copy(watched = listOf(show, season, episode))
+        val tombstones = listOf(
+            change(1, true).copy(type = MdbListItemType.SHOW),
+            change(1, true).copy(type = MdbListItemType.SEASON, season = 1)
+        )
+        assertEquals(listOf(episode), applyMdbListJournal(original, tombstones))
+    }
+
+    @Test
+    fun `movie and show sharing a TMDB number remain separate`() {
+        val movie = movie()
+        val episode = movie.copy(type = MdbListItemType.EPISODE, media = MdbListMedia(MdbListIds(tmdb = 1, imdb = "tt99"), "Series"), season = 1, episode = 1)
+        val normalized = snapshot().copy(watched = listOf(movie, episode)).normalizeMedia()
+        assertEquals(listOf("tt1", "tt99"), normalized.watched.map { it.media.ids.imdb })
+    }
+
+    private class Remote : MdbListSyncRemote {
+        val calls = mutableListOf<String>()
+        var activities = MdbListActivities(mapOf("watched_at" to null, "journal_at" to null), TIME)
+        var watched = emptyList<MdbListWatchedRecord>()
+        var journal = MdbListPage<MdbListJournalRecord>(emptyList())
+        var failPlayback = false
+
+        override suspend fun activities() = activities.also { calls += "activities" }
+        override suspend fun watched() = watched.also { calls += "watched" }
+        override suspend fun journal(since: String) = journal.also { calls += "journal:$since" }
+        override suspend fun playback(): List<MdbListPlayback> {
+            calls += "playback"
+            if (failPlayback) throw IOException("Offline")
+            return emptyList()
+        }
+        override suspend fun dropped() = emptyList<MdbListDroppedRecord>().also { calls += "dropped" }
+    }
+
+    private fun movie(id: Long = 1) = MdbListWatchedRecord(
+        MdbListItemType.MOVIE, MdbListMedia(MdbListIds(imdb = "tt$id", tmdb = id), "Movie $id"), TIME
+    )
+    private fun snapshot() = MdbListSyncSnapshot(42, watched = listOf(movie()), activities = Remote().activities, watermark = TIME, isInitialized = true)
+    private fun change(id: Long, removed: Boolean = false) = MdbListJournalRecord(
+        MdbListItemType.MOVIE, MdbListIds(tmdb = id), removed, TIME, if (removed) null else "2020-01-01T00:00:00Z"
+    )
+
+    private companion object {
+        const val TIME = "2026-09-06T00:00:00Z"
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRemoteTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRemoteTest.kt
@@ -1,0 +1,104 @@
+package com.nuvio.tv.data.mdblist
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MdbListSyncRemoteTest {
+    @Test
+    fun `watched cursor pages preserve requested fields and fetch every page`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(body = moviePage(1, "opaque+/="))
+        harness.reply(body = moviePage(2))
+
+        val records = remote(harness).watched()
+
+        assertEquals(listOf(1L, 2L), records.map { it.media.ids.tmdb })
+        assertEquals(mapOf("append_to_response" to "poster", "limit" to "1000"), harness.engine.requests.first().query)
+        assertEquals("opaque+/=", harness.engine.requests.last().query["cursor"])
+        assertEquals("poster", harness.engine.requests.last().query["append_to_response"])
+        assertEquals(null, harness.engine.requests.last().query["offset"])
+    }
+
+    @Test
+    fun `journal continuations never combine since and cursor including filtered pages`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(body = """{"journal":[{"category":"rated"}],"pagination":{"has_more":true,"next_cursor":"next"}}""")
+        harness.reply(body = """{"journal":[],"pagination":{"has_more":false}}""")
+
+        assertTrue(remote(harness).journal("2026-09-01T00:00:00Z").items.isEmpty())
+
+        assertEquals("2026-09-01T00:00:00Z", harness.engine.requests.first().query["since"])
+        assertEquals(mapOf("limit" to "1000", "cursor" to "next"), harness.engine.requests.last().query)
+    }
+
+    @Test
+    fun `expired journal can be signalled by success or conflict and discards earlier pages`() = runTest {
+        for (status in listOf(200, 409)) {
+            val harness = connectedHarness()
+            harness.reply(body = """{"journal":[{"category":"watched","item_type":"movie","ids":{"tmdb":1},"status":"removed","action_at":"2026-09-01T00:00:00Z"}],"pagination":{"next_cursor":"next"}}""")
+            harness.reply(status, """{"requires_full_sync":true}""")
+
+            val result = remote(harness).journal("2026-08-01T00:00:00Z")
+
+            assertTrue(result.requiresFullSync)
+            assertTrue(result.items.isEmpty())
+        }
+    }
+
+    @Test
+    fun `unrelated journal conflicts remain failures`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(409, """{"journal":[]}""")
+        expectMdbListFailure<MdbListApiException> { remote(harness).journal("2026-09-01T00:00:00Z") }
+        assertEquals(1, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `repeated cursors stop without returning a partial list`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(body = moviePage(1, "same"))
+        harness.reply(body = moviePage(2, "same"))
+
+        expectMdbListFailure<MdbListDecodingException> { remote(harness).watched() }
+        assertEquals(2, harness.engine.requests.size)
+    }
+
+    @Test
+    fun `page failure and profile change never produce a partial result`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(body = moviePage(1, "next"))
+        harness.reply(403)
+        expectMdbListFailure<MdbListApiException> { remote(harness).watched() }
+
+        val second = connectedHarness()
+        val remote = remote(second)
+        second.reply(body = moviePage(1, "next"))
+        second.engine.intercept = { second.store.selectProfile(2) }
+        expectMdbListFailure<CancellationException> { remote.watched() }
+        assertEquals(1, second.engine.requests.size)
+    }
+
+    @Test
+    fun `dropped reads fetch both scopes with independent cursor streams`() = runTest {
+        val harness = connectedHarness()
+        harness.reply(body = """{"shows":[],"pagination":{"next_cursor":"show-page"}}""")
+        harness.reply(body = """{"shows":[{"show":{"ids":{"tmdb":1}}}]}""")
+        harness.reply(body = """{"seasons":[{"season":{"number":2,"show":{"ids":{"tmdb":1}}}}]}""")
+
+        val result = remote(harness).dropped()
+
+        assertEquals(listOf(null, 2), result.map { it.season })
+        assertEquals(listOf("/sync/dropped", "/sync/dropped", "/sync/seasons/dropped"), harness.engine.requests.map { it.path })
+        assertEquals(null, harness.engine.requests.last().query["cursor"])
+    }
+
+    private fun remote(harness: MdbListTestHarness) = MdbListHttpSyncRemote(harness.api, harness.store.scope())
+    private fun connectedHarness() = MdbListTestHarness().apply { connected() }
+    private fun moviePage(id: Int, cursor: String? = null) = """{
+      "movies":[{"watched_at":"2026-09-01T00:00:00Z","movie":{"ids":{"tmdb":$id}}}],
+      "pagination":{"next_cursor":${cursor?.let { "\"$it\"" } ?: "null"}}
+    }"""
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRepositoryTest.kt
@@ -33,7 +33,7 @@ class MdbListSyncRepositoryTest {
         harness.seed(harness.snapshot(999))
         harness.repository.ensureLoaded()
         assertEquals(42L, harness.repository.currentSnapshot()?.accountId)
-        assertTrue(harness.repository.projection.value.watchedItems.isEmpty())
+        assertTrue(harness.repository.currentProjection().watchedItems.isEmpty())
         assertFalse(harness.repository.state.value.hasLoaded)
     }
 
@@ -158,7 +158,7 @@ class MdbListSyncRepositoryTest {
         runCurrent()
         assertNull(harness.repository.currentSnapshot())
         assertNull(harness.storage.profiles[1])
-        assertTrue(harness.repository.projection.value.watchedItems.isEmpty())
+        assertTrue(harness.repository.currentProjection().watchedItems.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRepositoryTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncRepositoryTest.kt
@@ -1,0 +1,194 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.tracking.TrackingRefreshIntent
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListSyncRepositoryTest {
+    @Test
+    fun `cached account loads without network and survives process recreation`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.repository.ensureLoaded()
+        assertEquals(listOf(mdbListTestMovie()), harness.repository.currentSnapshot()?.watched)
+        assertTrue(harness.repository.state.value.hasLoaded)
+        assertTrue(harness.http.engine.requests.isEmpty())
+        assertTrue(harness.remote.calls.isEmpty())
+    }
+
+    @Test
+    fun `cached data from another account is never exposed`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed(harness.snapshot(999))
+        harness.repository.ensureLoaded()
+        assertEquals(42L, harness.repository.currentSnapshot()?.accountId)
+        assertTrue(harness.repository.projection.value.watchedItems.isEmpty())
+        assertFalse(harness.repository.state.value.hasLoaded)
+    }
+
+    @Test
+    fun `corrupt snapshot restarts bootstrap without disconnecting the account`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.storage.profiles[1] = "broken"
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        assertTrue(harness.repository.state.value.hasLoaded)
+        assertTrue(harness.http.store.state.value.isAuthenticated)
+        assertEquals(listOf("activities", "watched", "playback", "dropped"), harness.remote.calls)
+    }
+
+    @Test
+    fun `overlapping refreshes join one sync including manual refreshes`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val release = CompletableDeferred<Unit>()
+        harness.remote.beforeActivities = { release.await() }
+        val first = async { harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        val second = async { harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        release.complete(Unit)
+        first.await()
+        second.await()
+        assertEquals(1, harness.remote.calls.count { it == "activities" })
+    }
+
+    @Test
+    fun `automatic checks are limited to fifteen minutes while manual refresh can run sooner`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        harness.http.now += MdbListSyncRepository.AUTOMATIC_INTERVAL_MS - 1
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        assertEquals(1, harness.remote.calls.count { it == "activities" })
+        harness.http.now++
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertEquals(3, harness.remote.calls.count { it == "activities" })
+    }
+
+    @Test
+    fun `offline failures preserve cached history and avoid retry storms`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.remote.error = IOException("Offline")
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        repeat(5) { harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC) }
+        assertEquals(1, harness.remote.calls.size)
+        assertTrue(harness.repository.state.value.hasLoaded)
+        assertEquals(listOf(mdbListTestMovie()), harness.repository.currentSnapshot()?.watched)
+        assertEquals(MdbListSyncError.UNAVAILABLE, harness.repository.state.value.error)
+        harness.http.now += MdbListSyncRepository.ERROR_RETRY_MS
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        assertEquals(2, harness.remote.calls.size)
+    }
+
+    @Test
+    fun `quota reset suppresses both automatic and manual attempts`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val reset = harness.http.now + 60_000
+        harness.remote.error = MdbListApiException(429, retryAtEpochMs = reset)
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertEquals(1, harness.remote.calls.size)
+        harness.remote.error = null
+        harness.http.now = reset
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertTrue(harness.repository.state.value.hasLoaded)
+    }
+
+    @Test
+    fun `disk failure never publishes unpersisted history or advances its watermark`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.repository.ensureLoaded()
+        val original = harness.storage.profiles[1]
+        harness.storage.failSave = true
+        harness.remote.activities = harness.remote.activities.copy(serverTime = "2026-09-06T01:00:00Z")
+        harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED)
+        assertEquals(original, harness.storage.profiles[1])
+        assertEquals(MDBLIST_TEST_TIME, harness.repository.currentSnapshot()?.watermark)
+        assertFalse(harness.repository.state.value.isLoading)
+        assertEquals(MdbListSyncError.UNAVAILABLE, harness.repository.state.value.error)
+    }
+
+    @Test
+    fun `late response after switching away and back cannot overwrite either profile`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        val release = CompletableDeferred<Unit>()
+        harness.remote.beforeActivities = { release.await() }
+        val refresh = async { harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        val original = harness.storage.profiles[1]
+        harness.switch(2, 84)
+        harness.switch(1)
+        release.complete(Unit)
+        expectMdbListFailure<CancellationException> { refresh.await() }
+        harness.repository.ensureLoaded()
+        assertEquals(original, harness.storage.profiles[1])
+        assertNull(harness.storage.profiles[2])
+        assertEquals(42L, harness.repository.currentSnapshot()?.accountId)
+    }
+
+    @Test
+    fun `profile change while disk write is queued prevents the stale commit`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.storage.beforeSave = { harness.switch(2, 84) }
+        expectMdbListFailure<CancellationException> { harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        assertNull(harness.storage.profiles[1])
+        assertNull(harness.repository.currentSnapshot())
+    }
+
+    @Test
+    fun `disconnect clears cached data and projections`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.repository.ensureLoaded()
+        harness.http.store.clearAuth()
+        runCurrent()
+        assertNull(harness.repository.currentSnapshot())
+        assertNull(harness.storage.profiles[1])
+        assertTrue(harness.repository.projection.value.watchedItems.isEmpty())
+    }
+
+    @Test
+    fun `profile switch blocks writes even before auth observer has caught up`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        val scope = harness.repository.currentScope()
+        harness.activeProfile.value = 2
+        expectMdbListFailure<CancellationException> { harness.repository.mutate(scope) { error("Must not dispatch") } }
+        assertTrue(harness.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `canceled refresh clears its loading state`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.remote.beforeActivities = { CompletableDeferred<Unit>().await() }
+        val job = launch { harness.repository.refresh(TrackingRefreshIntent.USER_INITIATED) }
+        runCurrent()
+        assertTrue(harness.repository.state.value.isLoading)
+        job.cancel()
+        job.join()
+        assertFalse(harness.repository.state.value.isLoading)
+    }
+
+    @Test
+    fun `invalidated bucket bypasses freshness and only refetches the affected data`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.repository.invalidate(harness.repository.currentScope(), setOf(MdbListSyncBucket.PLAYBACK))
+        harness.repository.refresh(TrackingRefreshIntent.AUTOMATIC)
+        assertEquals(listOf("activities", "playback"), harness.remote.calls)
+        assertTrue(harness.repository.currentSnapshot()?.invalidatedBuckets?.isEmpty() == true)
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncTestFixtures.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncTestFixtures.kt
@@ -13,9 +13,13 @@ internal const val MDBLIST_TEST_TIME = "2026-09-06T00:00:00Z"
 internal class MdbListTestSyncStorage : MdbListSyncStorage {
     val profiles = mutableMapOf<Int, String>()
     var failSave = false
+    var failLoad = false
     var beforeSave: suspend () -> Unit = {}
 
-    override suspend fun load(profileId: Int) = profiles[profileId]
+    override suspend fun load(profileId: Int): String? {
+        if (failLoad) throw IOException("Disk unavailable")
+        return profiles[profileId]
+    }
     override suspend fun save(profileId: Int, payload: String, checkScope: () -> Unit) {
         beforeSave()
         checkScope()

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncTestFixtures.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListSyncTestFixtures.kt
@@ -1,0 +1,94 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import kotlin.coroutines.ContinuationInterceptor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal const val MDBLIST_TEST_TIME = "2026-09-06T00:00:00Z"
+
+internal class MdbListTestSyncStorage : MdbListSyncStorage {
+    val profiles = mutableMapOf<Int, String>()
+    var failSave = false
+    var beforeSave: suspend () -> Unit = {}
+
+    override suspend fun load(profileId: Int) = profiles[profileId]
+    override suspend fun save(profileId: Int, payload: String, checkScope: () -> Unit) {
+        beforeSave()
+        checkScope()
+        if (failSave) throw IOException("Disk unavailable")
+        profiles[profileId] = payload
+    }
+    override suspend fun remove(profileId: Int, checkScope: () -> Unit) {
+        checkScope()
+        profiles.remove(profileId)
+    }
+}
+
+internal class MdbListTestSyncRemote : MdbListSyncRemote {
+    val calls = mutableListOf<String>()
+    var beforeActivities: suspend () -> Unit = {}
+    var activities = MdbListActivities(mapOf("journal_at" to null), MDBLIST_TEST_TIME)
+    var watched = emptyList<MdbListWatchedRecord>()
+    var playback = emptyList<MdbListPlayback>()
+    var dropped = emptyList<MdbListDroppedRecord>()
+    var error: Exception? = null
+
+    override suspend fun activities(): MdbListActivities {
+        calls += "activities"
+        beforeActivities()
+        error?.let { throw it }
+        return activities
+    }
+    override suspend fun watched() = watched.also { calls += "watched" }
+    override suspend fun playback() = playback.also { calls += "playback" }
+    override suspend fun dropped() = dropped.also { calls += "dropped" }
+    override suspend fun journal(since: String) = MdbListPage<MdbListJournalRecord>(emptyList()).also { calls += "journal" }
+}
+
+internal class MdbListSyncTestHarness(coroutineScope: CoroutineScope) {
+    val http = MdbListTestHarness().apply {
+        now = mdbListTimestamp(MDBLIST_TEST_TIME)
+        connected(expiresIn = 30L * 24 * 60 * 60 * 1_000)
+        store.saveUser(MdbListUser(42, "viewer"), store.scope())
+    }
+    val activeProfile = MutableStateFlow(1)
+    val storage = MdbListTestSyncStorage()
+    val remote = MdbListTestSyncRemote()
+    val repository = MdbListSyncRepository(
+        storage, http.store, http.api, activeProfile, coroutineScope, { http.now },
+        coroutineScope.coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+    ) { remote }
+
+    fun seed(snapshot: MdbListSyncSnapshot = snapshot(), profileId: Int = 1) {
+        storage.profiles[profileId] = Json.encodeToString(snapshot)
+    }
+
+    fun snapshot(accountId: Long = 42) = MdbListSyncSnapshot(
+        accountId, watched = listOf(mdbListTestMovie()), activities = remote.activities,
+        watermark = MDBLIST_TEST_TIME, checkedAtEpochMs = http.now, isInitialized = true
+    )
+
+    fun switch(profileId: Int, accountId: Long? = null) {
+        activeProfile.value = profileId
+        http.store.selectProfile(profileId)
+        if (accountId != null) {
+            http.connected()
+            http.store.saveUser(MdbListUser(accountId, "viewer-$accountId"), http.store.scope())
+        }
+    }
+}
+
+internal fun mdbListTestMovie(id: Long = 1) = MdbListWatchedRecord(
+    MdbListItemType.MOVIE, MdbListMedia(MdbListIds(imdb = "tt$id", tmdb = id), "Movie $id"), MDBLIST_TEST_TIME
+)
+
+internal fun mdbListTestEpisode(season: Int = 1, episode: Int = 1, watchedAt: String = MDBLIST_TEST_TIME) =
+    mdbListTestMovie().copy(type = MdbListItemType.EPISODE, season = season, episode = episode, watchedAt = watchedAt)
+
+internal fun mdbListTestPlayback(progress: Float = 40f, timestamp: String = MDBLIST_TEST_TIME) = MdbListPlayback(
+    7, MdbListItemType.MOVIE, mdbListTestMovie().media, progress, timestamp
+)

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListTestFixtures.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListTestFixtures.kt
@@ -1,0 +1,67 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+
+internal class MdbListTestPersistence : MdbListAuthPersistence {
+    val profiles = mutableMapOf<Int, String>()
+    var failWrites = false
+
+    override fun read(profileId: Int): String? = profiles[profileId]
+    override fun write(profileId: Int, value: String?) {
+        if (failWrites) throw IOException("Storage unavailable")
+        if (value == null) profiles.remove(profileId) else profiles[profileId] = value
+    }
+    override fun clear() = profiles.clear()
+}
+
+internal class MdbListTestEngine : MdbListHttpEngine {
+    val requests = mutableListOf<MdbListHttpRequest>()
+    val responses = ArrayDeque<MdbListHttpResponse>()
+    var intercept: suspend (MdbListHttpRequest) -> Unit = {}
+
+    override suspend fun execute(request: MdbListHttpRequest): MdbListHttpResponse {
+        requests += request
+        intercept(request)
+        return responses.removeFirst()
+    }
+}
+
+internal class MdbListTestHarness {
+    var now = 1_700_000_000_000L
+    val sleeps = mutableListOf<Long>()
+    val persistence = MdbListTestPersistence()
+    val store = MdbListAuthStore(persistence)
+    val engine = MdbListTestEngine()
+    val configuration = MdbListConfiguration("public-client", "test")
+    val http = MdbListHttpClient(engine, { now }, { sleeps += it; now += it })
+    val auth = MdbListAuthRepository(http, configuration, store) { now }
+    val api = MdbListApiClient(http, auth, store)
+
+    fun reply(status: Int = 200, body: String = "{}", headers: Map<String, String> = emptyMap()) {
+        engine.responses += MdbListHttpResponse(status, body, headers)
+    }
+
+    fun connected(accessToken: String = "access-one", refreshToken: String = "refresh-one", expiresIn: Long = 120_000L) {
+        store.authorize(MdbListTokens(accessToken, refreshToken, now + expiresIn), store.scope())
+    }
+
+    suspend fun pending(): MdbListDeviceSession {
+        reply(body = DEVICE_RESPONSE)
+        return auth.startDeviceAuthorization()
+    }
+
+    companion object {
+        val DEVICE_RESPONSE = """{"device_code":"device-secret","user_code":"ABCD-EFGH","verification_uri":"https://mdblist.com/oauth/device/","verification_uri_complete":"https://mdblist.com/oauth/device/?user_code=ABCD-EFGH","expires_in":300,"interval":5}"""
+        val TOKEN_RESPONSE = """{"access_token":"access-two","refresh_token":"refresh-two","token_type":"Bearer","expires_in":2592000,"scope":"write"}"""
+    }
+}
+
+internal suspend inline fun <reified T : Throwable> expectMdbListFailure(block: suspend () -> Unit): T {
+    try {
+        block()
+    } catch (error: Throwable) {
+        if (error is T) return error
+        throw AssertionError("Expected ${T::class.simpleName}, got ${error::class.simpleName}", error)
+    }
+    throw AssertionError("Expected ${T::class.simpleName}")
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListTrackingProgressProviderTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/MdbListTrackingProgressProviderTest.kt
@@ -1,0 +1,84 @@
+package com.nuvio.tv.data.mdblist
+
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.domain.model.WatchedItem
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class MdbListTrackingProgressProviderTest {
+    @Test
+    fun `all consumers reuse the fresh cached projection without issuing reads`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed(harness.snapshot().copy(
+            watched = listOf(mdbListTestMovie(), mdbListTestEpisode()), playback = listOf(mdbListTestPlayback())
+        ))
+        val provider = provider(harness)
+        assertEquals(2, provider.watchedItems.first().size)
+        assertTrue(provider.isWatched("tmdb:1", null, 1, 1).first())
+        assertEquals(listOf("tt1"), provider.nextUpSeeds.first().map { it.contentId })
+        assertTrue(provider.watchedMovieIds.first().containsAll(listOf("tt1", "tmdb:1")))
+        runCurrent()
+        assertTrue(provider.remoteProgressLoaded.first())
+        assertTrue(harness.remote.calls.isEmpty())
+        assertTrue(harness.http.engine.requests.isEmpty())
+    }
+
+    @Test
+    fun `profile switching publishes only data belonging to the authorized scope`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed()
+        harness.seed(harness.snapshot(99).copy(watched = listOf(mdbListTestMovie(2))), profileId = 2)
+        val provider = provider(harness)
+        var visible = emptyList<WatchedItem>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { provider.watchedItems.collect { visible = it } }
+        runCurrent()
+        assertEquals(listOf("tt1"), visible.map { it.contentId })
+        harness.activeProfile.value = 2
+        runCurrent()
+        assertTrue(visible.isEmpty())
+        assertFalse(provider.remoteProgressLoaded.first())
+        harness.http.store.selectProfile(2)
+        harness.http.connected()
+        harness.http.store.saveUser(MdbListUser(99, "second-viewer"), harness.http.store.scope())
+        runCurrent()
+        assertEquals(listOf("tt2"), visible.map { it.contentId })
+        assertTrue(provider.remoteProgressLoaded.first())
+        harness.http.store.clearAuth()
+        runCurrent()
+        assertTrue(visible.isEmpty())
+        assertFalse(provider.isAuthenticated.first())
+    }
+
+    @Test
+    fun `exact episode IDs are checked while unresolved anime keeps local tracking`() = runTest {
+        val harness = MdbListSyncTestHarness(backgroundScope)
+        harness.seed(harness.snapshot().copy(watched = listOf(mdbListTestEpisode(2, 3))))
+        harness.repository.ensureLoaded()
+        val provider = provider(harness)
+        assertEquals(true, provider.isWatchedByVideoId("tt1:2:3", 3))
+        assertEquals(false, provider.isWatchedByVideoId("tmdb:1:2:4", 4))
+        assertEquals(null, provider.isWatchedByVideoId("mal:1:2:3", 3))
+        assertTrue(provider.retainsLocalProgress("kitsu:123"))
+        assertFalse(provider.retainsLocalProgress("tt1"))
+    }
+
+    private fun provider(harness: MdbListSyncTestHarness): MdbListTrackingProgressProvider {
+        val profiles = mockk<ProfileManager> { every { activeProfileId } returns harness.activeProfile }
+        val layout = mockk<LayoutPreferenceDataStore> { every { nextUpFromFurthestEpisode } returns MutableStateFlow(true) }
+        return MdbListTrackingProgressProvider(
+            harness.repository, MdbListScrobbleService(harness.http.api, harness.repository), harness.http.store, profiles, layout
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngineTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngineTest.kt
@@ -20,6 +20,27 @@ import org.junit.Test
 
 class OkHttpMdbListEngineTest {
     @Test
+    fun `list update and deletion use the correct methods and bearer authentication`() = runTest {
+        MockWebServer().use { server ->
+            for (method in listOf(MdbListHttpMethod.PUT, MdbListHttpMethod.DELETE)) {
+                server.enqueue(MockResponse().setResponseCode(204))
+                val response = engine(server).execute(MdbListHttpRequest(
+                    method, "/lists/42", body = """{"name":"Weekend","private":true}""", accessToken = "access-token"
+                ))
+                val sent = server.takeRequest()
+                assertEquals(method.name, sent.method)
+                assertEquals("/lists/42", sent.path)
+                assertEquals("Bearer access-token", sent.getHeader("Authorization"))
+                assertEquals(204, response.status)
+                if (method == MdbListHttpMethod.PUT) {
+                    assertEquals("""{"name":"Weekend","private":true}""", sent.body.readUtf8())
+                    assertTrue(sent.getHeader("Content-Type").orEmpty().startsWith("application/json"))
+                } else assertEquals(0L, sent.bodySize)
+            }
+        }
+    }
+
+    @Test
     fun `OAuth form escaping and trailing slash reach the server unchanged`() = runTest {
         MockWebServer().use { server ->
             server.enqueue(MockResponse().setBody("{}"))

--- a/app/src/test/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngineTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/mdblist/OkHttpMdbListEngineTest.kt
@@ -1,0 +1,110 @@
+package com.nuvio.tv.data.mdblist
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OkHttpMdbListEngineTest {
+    @Test
+    fun `OAuth form escaping and trailing slash reach the server unchanged`() = runTest {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setBody("{}"))
+            val engine = engine(server)
+            engine.execute(MdbListHttpRequest(
+                MdbListHttpMethod.POST, "/oauth/token/", form = mapOf("client_id" to "public", "device_code" to "a+b&c")
+            ))
+
+            val sent = server.takeRequest()
+            assertEquals("/oauth/token/", sent.path)
+            assertEquals("client_id=public&device_code=a%2Bb%26c", sent.body.readUtf8())
+            assertTrue(sent.getHeader("Content-Type").orEmpty().startsWith("application/x-www-form-urlencoded"))
+            assertEquals(null, sent.getHeader("Authorization"))
+        }
+    }
+
+    @Test
+    fun `bearer authentication stays out of URL and cursor values are encoded`() = runTest {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setBody("{}"))
+            engine(server).execute(MdbListHttpRequest(
+                MdbListHttpMethod.GET, "/sync/journal", query = mapOf("cursor" to "a+b/c="), accessToken = "access-token"
+            ))
+
+            val sent = server.takeRequest()
+            assertEquals("Bearer access-token", sent.getHeader("Authorization"))
+            assertEquals("a+b/c=", sent.requestUrl?.queryParameter("cursor"))
+            assertFalse(sent.path.orEmpty().contains("access-token"))
+        }
+    }
+
+    @Test
+    fun `redirects never forward credentials to another destination`() = runTest {
+        MockWebServer().use { server ->
+            MockWebServer().use { destination ->
+                server.enqueue(MockResponse().setResponseCode(302).addHeader("Location", destination.url("/stolen")))
+
+                val response = engine(server).execute(MdbListHttpRequest(
+                    MdbListHttpMethod.GET, "/user", accessToken = "access-token"
+                ))
+
+                assertEquals(302, response.status)
+                assertEquals(0, destination.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun `coroutine cancellation cancels in flight HTTP call`() = runTest {
+        MockWebServer().use { server ->
+            val client = OkHttpClient()
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+            val engine = engine(server, client)
+            val operation = async(Dispatchers.IO) { engine.execute(MdbListHttpRequest(MdbListHttpMethod.GET, "/user")) }
+            val request = withContext(Dispatchers.IO) { server.takeRequest(5, TimeUnit.SECONDS) }
+            assertNotNull(request)
+
+            operation.cancel()
+            operation.join()
+
+            assertTrue(operation.isCancelled)
+            assertTrue(client.dispatcher.runningCalls().all { it.isCanceled() })
+        }
+    }
+
+    @Test
+    fun `response size is bounded even when the server omits content length`() {
+        val declared = Buffer().writeUtf8("unread")
+        assertThrows(IOException::class.java) { readMdbListResponseBody(declared, 1_025, 1_024) }
+        assertEquals("unread", declared.readUtf8())
+        assertThrows(IOException::class.java) {
+            readMdbListResponseBody(Buffer().write(ByteArray(1_025)), -1, 1_024)
+        }
+        assertEquals("valid", readMdbListResponseBody(Buffer().writeUtf8("valid"), -1, 1_024))
+    }
+
+    @Test
+    fun `production credentials cannot be sent over plaintext HTTP`() {
+        val engine = OkHttpMdbListEngine(OkHttpClient(), MdbListConfiguration("client", "test", "http://api.mdblist.com"))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            engine.buildRequest(MdbListHttpRequest(MdbListHttpMethod.GET, "/user", accessToken = "token"))
+        }
+    }
+
+    private fun engine(server: MockWebServer, client: OkHttpClient = OkHttpClient()) =
+        OkHttpMdbListEngine(client, MdbListConfiguration("client", "test", server.url("/").toString()))
+}

--- a/app/src/test/java/com/nuvio/tv/data/repository/LibraryRepositoryTrackingTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/LibraryRepositoryTrackingTest.kt
@@ -5,21 +5,23 @@ import com.nuvio.tv.core.auth.AuthManager
 import com.nuvio.tv.core.profile.ProfileManager
 import com.nuvio.tv.core.sync.LibrarySyncService
 import com.nuvio.tv.core.tracking.TrackingLibraryProvider
+import com.nuvio.tv.core.tracking.TrackingListManager
 import com.nuvio.tv.core.tracking.TrackingLibraryProviderRegistry
 import com.nuvio.tv.core.tracking.TrackingMembershipRemovalConfirmation
 import com.nuvio.tv.core.tracking.TrackingMembershipRemovalImpact
 import com.nuvio.tv.core.tracking.TrackingProviderId
 import com.nuvio.tv.core.tracking.TrackingRefreshIntent
 import com.nuvio.tv.data.local.LibraryPreferences
-import com.nuvio.tv.data.local.TraktAuthDataStore
 import com.nuvio.tv.data.local.TraktSettingsDataStore
 import com.nuvio.tv.domain.model.LibraryEntry
 import com.nuvio.tv.domain.model.LibraryEntryInput
 import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.LibraryListPrivacy
 import com.nuvio.tv.domain.model.LibrarySourceMode
 import com.nuvio.tv.domain.model.ListMembershipChanges
 import com.nuvio.tv.domain.model.ListMembershipSnapshot
 import com.nuvio.tv.domain.repository.MetaRepository
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
@@ -144,6 +146,53 @@ class LibraryRepositoryTrackingTest {
         assertFalse(trakt.lastConfirmed)
     }
 
+    @Test
+    fun `MDBList management routes through its selected provider without Trakt calls`() = runTest {
+        val source = MutableStateFlow(LibrarySourceMode.MDBLIST)
+        val mdblistManager = mockk<TrackingListManager>(relaxed = true)
+        val traktManager = mockk<TrackingListManager>(relaxed = true)
+        val mdblist = FakeLibraryProvider(TrackingProviderId.MDBLIST, tab("mdblist:watchlist", TrackingProviderId.MDBLIST), listManager = mdblistManager)
+        val trakt = FakeLibraryProvider(TrackingProviderId.TRAKT, tab("watchlist", TrackingProviderId.TRAKT), listManager = traktManager)
+        val repository = repository(source, setOf(mdblist, trakt))
+        repository.createPersonalList("List", null, LibraryListPrivacy.PRIVATE, LibrarySourceMode.MDBLIST)
+        repository.updatePersonalList("mdblist:list:7", "Renamed", null, LibraryListPrivacy.PUBLIC, LibrarySourceMode.MDBLIST)
+        repository.deletePersonalList("mdblist:list:7", LibrarySourceMode.MDBLIST)
+        coVerify(exactly = 1) { mdblistManager.createList("List", null, LibraryListPrivacy.PRIVATE) }
+        coVerify(exactly = 1) { mdblistManager.updateList("mdblist:list:7", "Renamed", null, LibraryListPrivacy.PUBLIC) }
+        coVerify(exactly = 1) { mdblistManager.deleteList("mdblist:list:7") }
+        coVerify(exactly = 0) { traktManager.createList(any(), any(), any()) }
+        coVerify(exactly = 0) { traktManager.updateList(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { traktManager.deleteList(any()) }
+    }
+
+    @Test
+    fun `source changes and foreign list keys are rejected before management writes`() = runTest {
+        val source = MutableStateFlow(LibrarySourceMode.MDBLIST)
+        val manager = mockk<TrackingListManager>(relaxed = true)
+        val provider = FakeLibraryProvider(TrackingProviderId.MDBLIST, tab("mdblist:watchlist", TrackingProviderId.MDBLIST), listManager = manager)
+        val repository = repository(source, setOf(provider))
+        val foreign = runCatching { repository.deletePersonalList("personal:7", LibrarySourceMode.MDBLIST) }
+        assertTrue(foreign.exceptionOrNull() is IllegalArgumentException)
+        source.value = LibrarySourceMode.LOCAL
+        val changed = runCatching { repository.createPersonalList("List", null, LibraryListPrivacy.PRIVATE, LibrarySourceMode.MDBLIST) }
+        assertTrue(changed.exceptionOrNull() is IllegalStateException)
+        coVerify(exactly = 0) { manager.createList(any(), any(), any()) }
+        coVerify(exactly = 0) { manager.deleteList(any()) }
+    }
+
+    @Test
+    fun `MDBList participates in membership alongside both existing providers`() = runTest {
+        val tabs = listOf(tab("watchlist", TrackingProviderId.TRAKT), tab("simkl:plantowatch", TrackingProviderId.SIMKL), tab("mdblist:watchlist", TrackingProviderId.MDBLIST))
+        val providers = TrackingProviderId.entries.zip(tabs).map { (id, tab) -> FakeLibraryProvider(id, tab) }
+        val source = MutableStateFlow(LibrarySourceMode.MDBLIST)
+        val repository = repository(source, providers.toSet())
+        assertEquals(listOf(tabs.last()), repository.listTabs.first())
+        assertEquals(tabs, repository.membershipListTabs.first())
+        repository.refreshNow()
+        assertTrue(providers.take(2).all { it.refreshIntents.isEmpty() })
+        assertEquals(listOf(TrackingRefreshIntent.USER_INITIATED), providers.last().refreshIntents)
+    }
+
     private fun repository(
         sourceMode: MutableStateFlow<LibrarySourceMode>,
         providers: Set<TrackingLibraryProvider>
@@ -154,14 +203,12 @@ class LibraryRepositoryTrackingTest {
         return LibraryRepositoryImpl(
             appContext = mockk<Context>(relaxed = true),
             libraryPreferences = mockk<LibraryPreferences>(relaxed = true),
-            traktAuthDataStore = mockk<TraktAuthDataStore>(relaxed = true),
             traktSettingsDataStore = settings,
-            traktLibraryService = mockk<TraktLibraryService>(relaxed = true),
             librarySyncService = mockk<LibrarySyncService>(relaxed = true),
             authManager = mockk<AuthManager>(relaxed = true),
             metaRepository = mockk<MetaRepository>(relaxed = true),
             trackingProviders = TrackingLibraryProviderRegistry(providers),
-            profileManager = mockk<ProfileManager>(relaxed = true)
+            profileManager = mockk<ProfileManager> { every { activeProfileId } returns MutableStateFlow(1) }
         )
     }
 
@@ -176,7 +223,8 @@ class LibraryRepositoryTrackingTest {
         override val providerId: TrackingProviderId,
         private val tab: LibraryListTab,
         private val membership: Map<String, Boolean> = emptyMap(),
-        private val removalConfirmation: TrackingMembershipRemovalConfirmation? = null
+        private val removalConfirmation: TrackingMembershipRemovalConfirmation? = null,
+        override val listManager: TrackingListManager? = null
     ) : TrackingLibraryProvider {
         val refreshIntents = mutableListOf<TrackingRefreshIntent>()
         var applyCalls = 0
@@ -187,7 +235,7 @@ class LibraryRepositoryTrackingTest {
         override val items = flowOf(emptyList<LibraryEntry>())
         override val tabs = flowOf(listOf(tab))
 
-        override fun recognizesListKey(key: String): Boolean = true
+        override fun recognizesListKey(key: String): Boolean = key == tab.key || key.startsWith("${providerId.storageId}:")
 
         override fun observeMembership(itemId: String, itemType: String): Flow<Set<String>> =
             flowOf(emptySet())

--- a/app/src/test/java/com/nuvio/tv/data/repository/TraktTrackingListManagerTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/repository/TraktTrackingListManagerTest.kt
@@ -1,0 +1,38 @@
+package com.nuvio.tv.data.repository
+
+import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TraktTrackingListManagerTest {
+    @Test
+    fun `shared management preserves Trakt privacy descriptions and list ordering`() = runTest {
+        val service = mockk<TraktLibraryService>(relaxed = true)
+        val manager = TraktTrackingLibraryProvider(service, mockk<TraktAuthDataStore>(relaxed = true)).listManager
+        assertTrue(manager.capabilities.supportsDescription)
+        assertTrue(manager.capabilities.supportsReordering)
+        assertEquals(LibraryListPrivacy.entries, manager.capabilities.privacyOptions)
+        val prefix = TraktLibraryService.PERSONAL_KEY_PREFIX
+        manager.createList("List", "Description", LibraryListPrivacy.FRIENDS)
+        manager.updateList("${prefix}7", "Renamed", "Changed", LibraryListPrivacy.LINK)
+        manager.reorderLists(listOf("${prefix}8", "${prefix}7"))
+        manager.deleteList("${prefix}7")
+        coVerify { service.createPersonalList("List", "Description", LibraryListPrivacy.FRIENDS) }
+        coVerify { service.updatePersonalList("7", "Renamed", "Changed", LibraryListPrivacy.LINK) }
+        coVerify { service.reorderPersonalLists(listOf("8", "7")) }
+        coVerify { service.deletePersonalList("7") }
+    }
+
+    @Test
+    fun `Trakt manager rejects MDBList keys before calling Trakt`() = runTest {
+        val service = mockk<TraktLibraryService>(relaxed = true)
+        val manager = TraktTrackingLibraryProvider(service, mockk<TraktAuthDataStore>(relaxed = true)).listManager
+        assertTrue(runCatching { manager.deleteList("mdblist:list:7") }.exceptionOrNull() is IllegalArgumentException)
+        coVerify(exactly = 0) { service.deletePersonalList(any()) }
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/data/simkl/SimklMutationReconciliationTest.kt
+++ b/app/src/test/java/com/nuvio/tv/data/simkl/SimklMutationReconciliationTest.kt
@@ -117,7 +117,7 @@ class SimklMutationReconciliationTest {
     }
 
     @Test
-    fun `history response records episode and resolved anime classification locally`() {
+    fun `history response records episode and resolved anime classification and retains reconciliation`() {
         val request = TrackingHistoryItem(
             media = anime(TrackingEpisode(number = 3)),
             watchedAtEpochMs = 1_700_000_000_000L
@@ -159,7 +159,7 @@ class SimklMutationReconciliationTest {
         assertEquals(SimklListStatus.WATCHING, entry.status)
         assertEquals("tv", entry.animeType)
         assertEquals("2023-11-14T22:13:20Z", entry.seasons.single().episodes.single().watchedAt)
-        assertFalse(receipt.requiresReconciliation)
+        assertTrue(receipt.requiresReconciliation)
     }
 
     @Test

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingAiringRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingAiringRulesTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 /**
  * Regression tests for currently-airing series leaving Continue Watching on air day.
@@ -104,7 +105,6 @@ class ContinueWatchingAiringRulesTest {
     @Test
     fun `earliestUpcomingEpisodeMs uses next mid-season air time not only next season`() {
         val now = Instant.parse("2026-07-12T12:00:00Z")
-        val zone = ZoneId.systemDefault()
         val tomorrow = LocalDate.of(2026, 7, 13)
         val nextSeasonPremiere = LocalDate.of(2026, 9, 1)
 
@@ -130,7 +130,7 @@ class ContinueWatchingAiringRulesTest {
 
         val ms = meta.earliestUpcomingEpisodeMs(now)
         assertNotNull(ms)
-        val expected = tomorrow.atStartOfDay(zone).toInstant().toEpochMilli()
+        val expected = tomorrow.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
         assertEquals(expected, ms)
 
         // Revalidation should prefer the nearer mid-season episode over S2 premiere window.

--- a/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingExcludedSeasonsTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/home/ContinueWatchingExcludedSeasonsTest.kt
@@ -1,0 +1,48 @@
+package com.nuvio.tv.ui.screens.home
+
+import com.nuvio.tv.domain.model.WatchProgress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ContinueWatchingExcludedSeasonsTest {
+    @Test
+    fun `next up skips excluded seasons and retains the history seed`() {
+        val seed = seed().copy(excludedNextUpSeasons = setOf(2))
+        val next = resolveNextUpVideoFromMeta(seed, metadata(), showUnairedNextUp = false)
+        assertEquals(3, next?.season)
+        assertEquals(1, next?.episode)
+        assertEquals(1, seed.season)
+    }
+
+    @Test
+    fun `excluding the seed season still allows an eligible following season`() {
+        val next = resolveNextUpVideoFromMeta(seed().copy(excludedNextUpSeasons = setOf(1)), metadata(), false)
+        assertEquals(2, next?.season)
+    }
+
+    @Test
+    fun `providers without exclusions preserve existing next up behavior`() {
+        val next = resolveNextUpVideoFromMeta(seed(), metadata(), false)
+        assertEquals(2, next?.season)
+        assertEquals(1, next?.episode)
+    }
+
+    @Test
+    fun `changing exclusions invalidates cached resolution with deterministic keys`() {
+        val original = buildNextUpSeedCacheKey(seed(), false)
+        val changed = buildNextUpSeedCacheKey(seed().copy(excludedNextUpSeasons = setOf(2, 3)), false)
+        val reordered = buildNextUpSeedCacheKey(seed().copy(excludedNextUpSeasons = setOf(3, 2)), false)
+        assertNotEquals(original, changed)
+        assertEquals(changed, reordered)
+    }
+
+    private fun seed() = WatchProgress(
+        "tt1", "series", "Series", null, null, null, "tt1:1:1", 1, 1, null,
+        100, 100, 1, progressPercent = 100f
+    )
+    private fun metadata() = CwMetaSummary(
+        "tt1", "Series", null, null, null, null, emptyList(), null, null, null, null,
+        (1..3).map { season -> CwVideoSummary("tt1:$season:1", "Episode", "2020-01-01T00:00:00Z", null, season, 1, null) }
+    )
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/library/LibraryListManagementTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/library/LibraryListManagementTest.kt
@@ -1,0 +1,180 @@
+package com.nuvio.tv.ui.screens.library
+
+import com.nuvio.tv.MainDispatcherRule
+import com.nuvio.tv.core.auth.AuthManager
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tracking.TrackingLibraryProvider
+import com.nuvio.tv.core.tracking.TrackingLibraryProviderRegistry
+import com.nuvio.tv.core.tracking.TrackingListManagementCapabilities
+import com.nuvio.tv.core.tracking.TrackingListManager
+import com.nuvio.tv.core.tracking.TrackingProviderId
+import com.nuvio.tv.data.local.DebridSettingsDataStore
+import com.nuvio.tv.data.local.LayoutPreferenceDataStore
+import com.nuvio.tv.data.local.LibraryPreferences
+import com.nuvio.tv.data.local.WatchedSeriesStateHolder
+import com.nuvio.tv.domain.model.AuthState
+import com.nuvio.tv.domain.model.DebridSettings
+import com.nuvio.tv.domain.model.LibraryEntry
+import com.nuvio.tv.domain.model.LibraryListPrivacy
+import com.nuvio.tv.domain.model.LibraryListTab
+import com.nuvio.tv.domain.model.LibrarySourceMode
+import com.nuvio.tv.domain.repository.LibraryRepository
+import com.nuvio.tv.domain.repository.WatchProgressRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class LibraryListManagementTest {
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    @Test
+    fun `MDBList editor saves the provider key and omits unsupported existing descriptions`() = runTest {
+        val f = Fixture()
+        runCurrent()
+        f.viewModel.onOpenManageLists()
+        f.viewModel.onStartEditList()
+        assertEquals("mdblist:list:7", f.viewModel.uiState.value.listEditorState!!.listId)
+        f.viewModel.onUpdateEditorName("Renamed")
+        f.viewModel.onUpdateEditorPrivacy(LibraryListPrivacy.FRIENDS)
+        assertEquals(LibraryListPrivacy.PRIVATE, f.viewModel.uiState.value.listEditorState!!.privacy)
+        f.viewModel.onUpdateEditorPrivacy(LibraryListPrivacy.PUBLIC)
+        f.viewModel.onSubmitEditor()
+        runCurrent()
+        coVerify(exactly = 1) {
+            f.repository.updatePersonalList("mdblist:list:7", "Renamed", null, LibraryListPrivacy.PUBLIC, LibrarySourceMode.MDBLIST)
+        }
+        assertNull(f.viewModel.uiState.value.listEditorState)
+    }
+
+    @Test
+    fun `profile switch clears the editor and prevents submitting to the new profile`() = runTest {
+        val f = Fixture()
+        runCurrent()
+        f.viewModel.onOpenManageLists()
+        f.viewModel.onStartCreateList()
+        f.viewModel.onUpdateEditorName("Old profile")
+        f.profile.value = 2
+        f.viewModel.onSubmitEditor()
+        runCurrent()
+        assertFalse(f.viewModel.uiState.value.showManageDialog)
+        assertNull(f.viewModel.uiState.value.listEditorState)
+        coVerify(exactly = 0) { f.repository.createPersonalList(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `disconnect and library source changes dismiss management`() = runTest {
+        for (disconnect in listOf(true, false)) {
+            val f = Fixture()
+            runCurrent()
+            f.viewModel.onOpenManageLists()
+            f.viewModel.onStartEditList()
+            if (disconnect) f.authenticated.value = false else f.source.value = LibrarySourceMode.LOCAL
+            runCurrent()
+            assertFalse(f.viewModel.uiState.value.showManageDialog)
+            f.viewModel.onDeleteSelectedList()
+            coVerify(exactly = 0) { f.repository.deletePersonalList(any(), any()) }
+        }
+    }
+
+    @Test
+    fun `duplicate save is suppressed and an old completion cannot close a newly opened editor`() = runTest {
+        val f = Fixture()
+        val finished = CompletableDeferred<Unit>()
+        coEvery { f.repository.createPersonalList(any(), any(), any(), any()) } coAnswers { finished.await() }
+        runCurrent()
+        f.viewModel.onOpenManageLists()
+        f.viewModel.onStartCreateList()
+        f.viewModel.onUpdateEditorName("First")
+        f.viewModel.onSubmitEditor()
+        f.viewModel.onSubmitEditor()
+        runCurrent()
+        assertTrue(f.viewModel.uiState.value.pendingOperation)
+        f.viewModel.onCloseManageLists()
+        f.viewModel.onOpenManageLists()
+        f.viewModel.onStartCreateList()
+        f.viewModel.onUpdateEditorName("New draft")
+        finished.complete(Unit)
+        runCurrent()
+        assertEquals("New draft", f.viewModel.uiState.value.listEditorState!!.name)
+        coVerify(exactly = 1) { f.repository.createPersonalList(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `MDBList never offers list reordering and defaults to each selected list rank`() = runTest {
+        val f = Fixture()
+        val second = f.tab.copy(key = "mdblist:list:8", title = "Other")
+        f.tabs.value = listOf(f.tab, second)
+        fun item(id: String, first: Int, other: Int) = LibraryEntry(
+            id, "movie", id, null, background = null, logo = null, description = null, releaseInfo = null,
+            imdbRating = null, genres = emptyList(), addonBaseUrl = null,
+            listKeys = setOf(f.tab.key, second.key), listRanks = mapOf(f.tab.key to first, second.key to other)
+        )
+        f.items.value = listOf(item("First", 1, 2), item("Second", 2, 1))
+        runCurrent()
+        assertEquals(listOf("First", "Second"), f.viewModel.uiState.value.visibleItems.map { it.name })
+        f.viewModel.onSelectListTab(second.key)
+        assertEquals(listOf("Second", "First"), f.viewModel.uiState.value.visibleItems.map { it.name })
+        f.viewModel.onOpenManageLists()
+        f.viewModel.onMoveSelectedListDown()
+        runCurrent()
+        coVerify(exactly = 0) { f.repository.reorderPersonalLists(any(), any()) }
+    }
+
+    private class Fixture {
+        val profile = MutableStateFlow(1)
+        val source = MutableStateFlow(LibrarySourceMode.MDBLIST)
+        val authenticated = MutableStateFlow(true)
+        val tab = LibraryListTab("mdblist:list:7", "Favourites", LibraryListTab.Type.PERSONAL,
+            description = "Existing provider description", privacy = LibraryListPrivacy.PRIVATE)
+        val tabs = MutableStateFlow(listOf(tab))
+        val items = MutableStateFlow(emptyList<LibraryEntry>())
+        val repository = mockk<LibraryRepository>(relaxed = true) {
+            every { sourceMode } returns source
+            every { isSyncing } returns flowOf(false)
+            every { libraryItems } returns items
+            every { listTabs } returns tabs
+        }
+        private val manager = mockk<TrackingListManager> {
+            every { capabilities } returns TrackingListManagementCapabilities(listOf(LibraryListPrivacy.PRIVATE, LibraryListPrivacy.PUBLIC))
+        }
+        private val provider = mockk<TrackingLibraryProvider> {
+            every { providerId } returns TrackingProviderId.MDBLIST
+            every { isAuthenticated } returns authenticated
+            every { listManager } returns manager
+        }
+        val viewModel = LibraryViewModel(
+            libraryRepository = repository, cloudLibraryRepository = mockk(relaxed = true), cloudPlaybackSessionStore = mockk(),
+            externalPlaybackTracker = mockk(), playerSettingsDataStore = mockk(), metaRepository = mockk(),
+            debridSettingsDataStore = mockk<DebridSettingsDataStore> { every { settings } returns flowOf(DebridSettings(cloudLibraryEnabled = false)) },
+            layoutPreferenceDataStore = mockk<LayoutPreferenceDataStore> {
+                every { posterCardWidthDp } returns flowOf(126)
+                every { posterCardCornerRadiusDp } returns flowOf(12)
+            },
+            libraryPreferences = mockk<LibraryPreferences>(relaxed = true) {
+                every { sortOption } returns flowOf(null)
+                every { lastSelectedList } returns flowOf(null)
+                every { lastSelectedType } returns flowOf(null)
+            },
+            authManager = mockk<AuthManager> { every { authState } returns MutableStateFlow(AuthState.SignedOut) },
+            trackingProviderRegistry = TrackingLibraryProviderRegistry(setOf(provider)),
+            watchProgressRepository = mockk<WatchProgressRepository> { every { observeWatchedMovieIds() } returns flowOf(emptySet()) },
+            watchedSeriesStateHolder = mockk<WatchedSeriesStateHolder> { every { fullyWatchedSeriesIds } returns MutableStateFlow(emptySet()) },
+            profileManager = mockk<ProfileManager> { every { activeProfileId } returns profile },
+            posterOptions = mockk(relaxed = true), context = mockk(relaxed = true)
+        )
+    }
+}

--- a/app/src/test/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/settings/TrackingSettingsViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.nuvio.tv.ui.screens.settings
+
+import com.nuvio.tv.MainDispatcherRule
+import com.nuvio.tv.core.profile.ProfileManager
+import com.nuvio.tv.core.tracking.TrackingProviderId
+import com.nuvio.tv.core.tracking.TrackingSourceController
+import com.nuvio.tv.core.tracking.TrackingSourceSelection
+import com.nuvio.tv.data.local.TraktAuthDataStore
+import com.nuvio.tv.data.local.TraktAuthState
+import com.nuvio.tv.data.local.TraktSettingsDataStore
+import com.nuvio.tv.data.local.WatchProgressSource
+import com.nuvio.tv.data.mdblist.MdbListTestHarness
+import com.nuvio.tv.data.simkl.SimklAnimeIdPreference
+import com.nuvio.tv.data.simkl.SimklAuthRepository
+import com.nuvio.tv.data.simkl.SimklAuthState
+import com.nuvio.tv.domain.model.LibrarySourceMode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class TrackingSettingsViewModelTest {
+    @get:Rule
+    val mainDispatcher = MainDispatcherRule()
+
+    @Test
+    fun `source reconciliation waits for credentials of the selected profile`() = runTest {
+        val harness = MdbListTestHarness()
+        harness.store.selectProfile(2)
+        harness.connected()
+        harness.store.selectProfile(1)
+        harness.connected()
+        val activeProfile = MutableStateFlow(1)
+        val profiles = mockk<ProfileManager> { every { activeProfileId } returns activeProfile }
+        val reconciliations = mutableListOf<Set<TrackingProviderId>>()
+        val controller = mockk<TrackingSourceController> {
+            every { watchProgressSource } returns MutableStateFlow(WatchProgressSource.MDBLIST)
+            every { librarySourceMode } returns MutableStateFlow(LibrarySourceMode.LOCAL)
+            coEvery { reconcileConnectedProviders(any()) } coAnswers {
+                reconciliations += firstArg<Set<TrackingProviderId>>()
+                TrackingSourceSelection(WatchProgressSource.MDBLIST, LibrarySourceMode.LOCAL)
+            }
+        }
+        val settings = mockk<TraktSettingsDataStore> {
+            every { simklAnimeIdPreference } returns MutableStateFlow(SimklAnimeIdPreference.DEFAULT)
+        }
+        val trakt = mockk<TraktAuthDataStore> { every { state } returns flowOf(TraktAuthState()) }
+        val simkl = mockk<SimklAuthRepository> { every { state } returns MutableStateFlow(SimklAuthState()) }
+        val viewModel = TrackingSettingsViewModel(controller, settings, mockk(), trakt, simkl, harness.store, profiles)
+        runCurrent()
+        assertEquals(setOf(TrackingProviderId.MDBLIST), viewModel.uiState.value.connectedProviderIds)
+        val previousCount = reconciliations.size
+        activeProfile.value = 2
+        runCurrent()
+        assertFalse(viewModel.uiState.value.isReady)
+        assertEquals(previousCount, reconciliations.size)
+        harness.store.selectProfile(2)
+        runCurrent()
+        assertTrue(viewModel.uiState.value.isReady)
+        assertEquals(WatchProgressSource.MDBLIST, viewModel.uiState.value.watchProgressSource)
+        assertTrue(reconciliations.all { TrackingProviderId.MDBLIST in it })
+    }
+}

--- a/docs/architecture/mdblist-library.md
+++ b/docs/architecture/mdblist-library.md
@@ -1,0 +1,72 @@
+# MDBList Library support
+
+MDBList can be selected independently as the Library Source in Settings → Trackers. Library displays the connected account’s watchlist and owned static movie/show lists. The shared membership picker can add or remove a title from MDBList alongside local, Trakt and Simkl destinations. Each remote destination shows its provider name so two watchlists or identically named lists remain distinguishable.
+
+## Supported behavior
+
+- Browse and filter watchlist and owned static lists with the existing Library controls.
+- Add/remove movies and shows, including series supplied by anime metadata sources when an external ID is available.
+- Create private or public static lists; rename them, change visibility, and delete them through Manage Lists.
+- Preserve per-list item order when a title belongs to several lists.
+- Restore cached contents across app launches, isolate profiles/accounts, and retain the last complete cache when synchronization fails.
+
+Dynamic, feed, official, external and season/episode lists are excluded from this scope. MDBList has no documented list-description editing or list-reordering endpoint, so those controls are hidden. Trakt retains its description, privacy and ordering features. List item responses do not consistently include an added timestamp; added-date sorting uses it when supplied and otherwise falls back to stable ordering. Ratings enrichment remains the separate existing API-key feature.
+
+## Shared architecture
+
+`TrackingLibraryProvider` already provides browsing, membership and refresh contracts. Its optional `TrackingListManager` now provides list-management operations and capabilities. The Library repository and dialogs select that manager; they no longer call Trakt directly for list CRUD. `LibraryListPrivacy` replaces the Trakt-specific type name without changing its wire values. Existing library-source names retain their stored meaning; `MDBLIST` is appended.
+
+TV has its existing tracking ports and no dependency on the mobile Compose application. MDBList’s library business logic uses the same TV ports, identity models, HTTP client and account-scoped sync repository as the existing tracker implementation. No duplicate platform authentication, profile storage or network retry policy was introduced.
+
+- `MdbListLibraryRemote`: owned-list metadata, cursor/offset paging and version-based reuse.
+- `MdbListLibraryDecoder`: strict static-list classification and mixed/legacy item response decoding.
+- `MdbListLibraryProjection`: external-ID aliases, typed movie/show identity, memberships and per-list ranks.
+- `MdbListLibraryWriter`: validated write receipts, scoped CRUD and membership changes.
+- `MdbListLibraryService`: lazy refresh, cached membership reads, coalescing and retry gates.
+- `MdbListTrackingLibraryProvider`: registration in the shared source/membership system.
+
+Library data is an optional, backwards-compatible field in `MdbListSyncSnapshot`, persisted through the existing profile storage. Every write captures an OAuth scope and checks it around HTTP and persistence. Successful changes update the cached snapshot without re-fetching the whole library. Each membership destination is committed separately, preserving completed writes if a later destination fails. Uncertain writes mark the cache invalid for a later read reconciliation; POST/PUT/DELETE are not retried after ambiguous server or transport failures.
+
+Management dialogs capture their profile, source and dialog instance. Switching profiles or sources closes the editor. Duplicate submissions are suppressed, and completion of an old request cannot close a newly opened editor. Repository routing also validates the source, profile and list-key namespace.
+
+## API contract and request budget
+
+Sources reviewed: the [current OpenAPI schema](https://api.mdblist.com/schema/), [API reference](https://api.mdblist.com/docs/), [authentication guide](https://api.mdblist.com/docs/authentication/), and the full local documentation snapshot under `docs/mdblist/`. Live contract checks were performed on 6 September 2026 using the registered Device Code account.
+
+| Operation | Endpoint / behavior |
+|---|---|
+| Owned lists | `GET /lists/user?unified=false&sort=ranked`; include explicitly static lists owned by the current account |
+| Watchlist | `GET /watchlist/items` |
+| Static contents | `GET /lists/{id}/items` |
+| Membership changes | `POST /watchlist/items/{add,remove}` uses nested `ids`; `POST /lists/{id}/items/{add,remove}` uses direct provider IDs |
+| Create | `POST /lists/user/add` with `name` and `private` |
+| Rename/visibility | `PUT /lists/{id}` with `name` and `private` |
+| Delete | `DELETE /lists/{id}`; require a successful confirmation or HTTP 204 |
+
+The live service returns `ids: [id]` for unified metadata, an array for list-info reads, and nested per-media mutation counts for static lists. A create response can omit the name. Static item mutations update `last_updated_at`. Parsers preserve these observed differences from the incomplete schema.
+
+Reads request up to 1,000 items per page with bundled posters, descriptions and genres. All pages must succeed before publishing. Repeated cursors, missing continuation data, or malformed items fail the refresh rather than truncating the library.
+
+| Situation | Library requests, excluding account lookup, token refresh and retries |
+|---|---:|
+| Restore fresh cache or revisit Library | 0 |
+| First load with N single-page static lists | 2 + N |
+| Unchanged refresh after the 15-minute interval | 2: list metadata and watchlist |
+| Changed static list | One additional request per page of that list |
+| Missing version or invalidated cache | Re-read affected/all static contents |
+| Add/remove one title in one destination | 1 write when membership changes |
+| Create, rename, change visibility or delete | 1 write each with an initialized cache |
+
+Refreshes are triggered by consumers and user actions, not a background timer. Overlapping refreshes coalesce. Failed automatic reads back off for 60 seconds; quota errors honor the API reset. Per-title MDBList lookups are not used for Library metadata.
+
+A planning estimate for one TV, 2–4 episodes per day and a few cached lists is roughly 30–80 total tracking/library requests daily. This is not usage telemetry or a guarantee. Initial imports, pagination, additional devices and manual refreshes add requests. The separate ratings integration can add one request per enabled rating source per uncached title (for example, 20 titles × 6 sources = 120 requests). The API’s headers and `/user` expose actual usage and allowance.
+
+## Validation
+
+The full JVM regression completed 1,356 tests: 1,342 passed, 13 failed and one was skipped. All 13 failing test identities match the failures already reproduced on revision `23d1fe478`; no new failures were introduced. The recorded comparison is in `docs/mdblist/validation/library/full-jvm/summary.json`. The final focused JVM run passed all 220 tests with no failures or skips. Both the full debug APK/instrumentation build and Play Store debug Kotlin compilation passed. The cross-variant check also caught and fixed a nullable OkHttp response-body compatibility issue. Raw local evidence is retained under `docs/mdblist/validation/library/`; it contains no OAuth tokens. Live tests use a temporary private list, remove their test membership additions and verify list deletion. The live checks are gated by explicit instrumentation arguments, so ordinary test runs do not change a real account.
+
+The normal signed full debug APK also built successfully with the repository’s original non-debuggable settings. Live library reads and mutations returned successful responses, watchlist changes were restored, and a final metadata read confirmed the temporary static list was absent. Media source links were checked against MDBList’s canonical redirects.
+
+All six Compose UI checks passed on API 36 Android TV. They cover supported fields/privacy, Trakt compatibility, empty-list Create focus, pending-action disabling, provider-labelled watchlist navigation, and D-pad selection. The separately gated live Library lifecycle check passed on the same emulator, including movie/show membership, rename, watchlist add/remove, readback, and deletion cleanup.
+
+After validation, the normal signed APK was restored and verified without the `DEBUGGABLE` flag. The instrumentation package was removed and the test emulator was stopped. The curated architecture document is intentionally committed despite the repository’s general `docs/` ignore rule; downloaded provider documentation and raw QA artifacts remain local.


### PR DESCRIPTION
## Summary

Add MDBList as a tracking and Library provider alongside Trakt and Simkl, in response to user requests.

- Connect through Device Code OAuth with a QR code, account status, manual sync and disconnect controls in Settings > Tracking.
- Sync watched history and playback progress, including start, pause, resume and stop scrobbles. Use MDBList for Continue Watching and Next Up.
- Choose MDBList independently as the Watch Progress source or Library source.
- Browse the watchlist and owned static movie/show lists. Add or remove titles, create and rename lists, change privacy and delete lists.

The integration uses the existing provider interfaces and shared list-management controls. MDBList Ratings keeps its separate API-key configuration.

## Testing

- 220 focused JVM tests passed.
- Android TV account, source selection and Library UI checks passed.
- Live OAuth login, token refresh, scrobbling, watchlist and static-list operations passed. 

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0698eb51-fb88-4980-8499-1d8a673c470c" />

