### PR TITLE
Prevent decoder flush on audio track selection before first frame is rendered

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerTrackSelection.kt
@@ -71,10 +71,10 @@ internal fun PlayerRuntimeController.selectAudioTrack(trackIndex: Int) {
                             .buildUpon()
                             .setOverrideForType(override)
                             .build()
-                        // Nudge the player to avoid infinite buffering after audio track switch
-                        // where the new track requires a different segment.
-                        val pos = player.currentPosition
-                        if (pos > 0) player.seekTo((pos - 1).coerceAtLeast(0))
+                        if (hasRenderedFirstFrame) {
+                            val pos = player.currentPosition
+                            if (pos > 0) player.seekTo((pos - 1).coerceAtLeast(0))
+                        }
                         return
                     }
                     currentAudioIndex++


### PR DESCRIPTION
## Summary

Prevent the startup audio-preference restore from issuing a `seekTo` that flushed the just-started hardware video decoder. The flush stopped the first frame from ever rendering, so playback never began and the player hung on the loading overlay (paused at the resume position). Most reliably reproduced from Home → Continue Watching auto-play of a resumed item.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

- On startup, restoring the persisted audio preference (`applyPersistedTrackPreference` → `selectAudioTrack`) applied the audio override and then issued a "nudge" `seekTo(position - 1)`.
- When that seek landed after the video decoder (`c2.realtek.video.avc.decoder`) was already created and started, it flushed the running decoder (`MediaCodec::flush`). On TCL/Realtek the decoder then never rendered the first frame.
- `play()` and the loading-overlay dismissal are gated on `onRenderedFirstFrame()`, and the first-frame watchdog is gated on `STATE_READY` (which was never reached), so startup deadlocked: paused at the resume position while the buffer grew and the overlay never cleared.
- The nudge is only meaningful for a mid-playback audio switch that needs a different segment; during startup it is redundant (the resume seek is handled separately) and harmful.

## Issue or approval

Critical playback hang: starting a resumed stream (most reliably Home → Continue Watching auto-play) could leave the player stuck on the loading overlay and never begin playback. Root cause diagnosed from on-device `adb logcat` captures on a TCL G10 (Realtek). The problem is described in Linked issues below.

## Reproduction steps

1. On a TCL G10 (Realtek `c2.realtek.video.avc.decoder`), play part of an episode so a resume position is saved.
2. From Home → Continue Watching, select the item so it auto-plays and resumes mid-file.
3. Before the fix: the player could stay on the loading overlay, paused at the resume position, buffer growing, first frame never rendered, playback never starting.
4. After the fix: the same path renders the first frame and starts playing normally.
5. The bug is a startup race, so opening from the Detail screen (or re-opening) often won the race and played, which made it look path-specific.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Single guard in `selectAudioTrack` (`PlayerRuntimeControllerTrackSelection.kt`): the nudge `seekTo` now runs only after the first frame (`hasRenderedFirstFrame`).
- No change to track-selection logic, the audio override (`setOverrideForType`), the startup policy, the watchdog, navigation, or any UI.
- Mid-playback audio switching keeps the nudge exactly as before.

## Testing

Diagnosed and verified from on-device `adb logcat` captures (TCL G10 / Realtek, `video/x-matroska`, `avc1.640028 1918x802`):

- Before the fix (stuck): `selectAllTracks` ran twice during startup; the second run (audio restore) was immediately followed by `MediaCodec::flush===V`. No `VIDEOFUNC ... first frame` marker ever appeared. `PlaybackState` stayed `PAUSED` at the resume position (e.g. 65211ms) while `buffered position` grew to ~135000ms and `speed=0.0`; `state=PLAYING` never occurred across a 45s window.
- After the fix (fresh build, same resume-from-progress path): the audio restore still ran (`TRACK_PREF restore: audio index=7`) and `selectAllTracks` still ran twice, but the session `MediaCodec::flush` count was 0; `VIDEOFUNC ... first frame` fired; `PlaybackState` advanced `BUFFERING → PLAYING` and position progressed normally (178405 → 202982ms+).
- Tunneled safety: `hasRenderedFirstFrame` is also set synthetically at `STATE_READY` for tunneled playback (where `onRenderedFirstFrame` never fires), so the nudge is skipped only during startup and preserved for mid-playback switches in both tunneled and non-tunneled modes.
- Build: `.\gradlew.bat :app:compileFullDebugKotlin` → BUILD SUCCESSFUL.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Player hangs on the loading overlay when starting a resumed stream (most reliably Home → Continue Watching auto-play). The startup audio-preference restore issued a `seekTo` that flushed the just-started video decoder, so the first frame never rendered, `playWhenReady`/`play()` were never invoked (both gated on `onRenderedFirstFrame`), and `STATE_READY` was never reached (so the first-frame watchdog never armed). The player stayed paused at the resume position while the buffer grew and the overlay never cleared. Fixed by skipping the nudge seek before the first frame.
