### PR TITLE
Fix Search: step back within Search and settle its focus targets

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -142,6 +142,7 @@ fun SearchScreen(
     val searchFocusRequester = remember { FocusRequester() }
     val discoverFirstItemFocusRequester = remember { FocusRequester() }
     val recentClearHistoryFocusRequester = remember { FocusRequester() }
+    val discoverButtonFocusRequester = remember { FocusRequester() }
     var isSearchFieldFocused by remember { mutableStateOf(false) }
     // Track the whole input row, including voice and Discover.
     var inputRowHasFocus by remember { mutableStateOf(false) }
@@ -463,8 +464,17 @@ fun SearchScreen(
 
     LaunchedEffect(Unit) {
         if (viewModel.hasSavedSearchFocus) return@LaunchedEffect
+        if (pendingDiscoverRestoreOnResume || restoreDiscoverFocus) return@LaunchedEffect
         repeat(2) { withFrameNanos { } }
         runCatching { initialFocusRequester.requestFocus() }
+    }
+
+    // Restore the Discover button after returning.
+    LaunchedEffect(restoreDiscoverFocus) {
+        if (!restoreDiscoverFocus) return@LaunchedEffect
+        repeat(2) { withFrameNanos { } }
+        runCatching { discoverButtonFocusRequester.requestFocus() }
+        restoreDiscoverFocus = false
     }
 
     // Push search suggestions to the native keyboard suggestion bar. Keyed on the query as well
@@ -593,7 +603,13 @@ fun SearchScreen(
                         viewModel.onEvent(SearchEvent.RememberSearchFromTextInput)
                         focusResults = true
                     },
-                    onOpenDiscover = onOpenDiscover,
+                    onOpenDiscover = {
+                        // Arm the restore so coming back lands on this button rather than the
+                        // default entry focus.
+                        pendingDiscoverRestoreOnResume = true
+                        onOpenDiscover()
+                    },
+                    discoverFocusRequester = discoverButtonFocusRequester,
                     showDiscoverButton = uiState.discoverLocation == DiscoverLocation.IN_SEARCH,
                     keyboardController = keyboardController,
                     clearHistoryFocusRequester = if (showRecentSearches) recentClearHistoryFocusRequester else null,
@@ -1111,6 +1127,7 @@ private fun SearchInputField(
     onVoiceSearch: () -> Unit,
     onMoveToResults: () -> Unit,
     onOpenDiscover: () -> Unit,
+    discoverFocusRequester: FocusRequester? = null,
     showDiscoverButton: Boolean,
     keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?,
     clearHistoryFocusRequester: FocusRequester?,
@@ -1131,6 +1148,9 @@ private fun SearchInputField(
             IconButton(
                 onClick = onOpenDiscover,
                 modifier = Modifier
+                    .then(
+                        discoverFocusRequester?.let { Modifier.focusRequester(it) } ?: Modifier
+                    )
                     .onFocusChanged { isDiscoverButtonFocused = it.isFocused }
                     .size(NuvioTheme.spacing.huge)
                     .border(

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -86,6 +87,7 @@ import com.nuvio.tv.ui.util.RtlKeyUtils
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -141,6 +143,8 @@ fun SearchScreen(
     val discoverFirstItemFocusRequester = remember { FocusRequester() }
     val recentClearHistoryFocusRequester = remember { FocusRequester() }
     var isSearchFieldFocused by remember { mutableStateOf(false) }
+    // Track the whole input row, including voice and Discover.
+    var inputRowHasFocus by remember { mutableStateOf(false) }
     var isRecentSearchSectionFocused by remember { mutableStateOf(false) }
     var focusResults by remember { mutableStateOf(false) }
     var pendingFocusMoveToResultsQuery by remember { mutableStateOf<String?>(null) }
@@ -266,9 +270,6 @@ fun SearchScreen(
             speechRecognizer?.destroy()
         }
     }
-    val topInputFocusRequester = remember(isVoiceSearchAvailable) {
-        if (isVoiceSearchAvailable) voiceFocusRequester else searchFocusRequester
-    }
     val launchVoiceSearch: () -> Unit = {
         if (!isVoiceSearchAvailable || speechRecognizer == null) {
             Toast.makeText(context, strVoiceUnavailable, Toast.LENGTH_SHORT).show()
@@ -303,6 +304,9 @@ fun SearchScreen(
     val searchRowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val searchRowEntryFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val searchRowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
+    // Mirrors the focused index for the active row. The map above is a plain MutableMap,
+    // so its values cannot drive recomposition of the Back handler.
+    val focusedResultItemIndex = remember { mutableIntStateOf(viewModel.savedFocusItemIndex.coerceAtLeast(0)) }
     var lastFocusedRowKey by remember { mutableStateOf(viewModel.savedFocusRowKey) }
     var posterOptionsRowKey by remember { mutableStateOf<String?>(null) }
 
@@ -455,10 +459,12 @@ fun SearchScreen(
         pendingFocusMoveHadExistingSearchRows = false
     }
 
+    val initialFocusRequester = if (isVoiceSearchAvailable) voiceFocusRequester else searchFocusRequester
+
     LaunchedEffect(Unit) {
         if (viewModel.hasSavedSearchFocus) return@LaunchedEffect
         repeat(2) { withFrameNanos { } }
-        runCatching { topInputFocusRequester.requestFocus() }
+        runCatching { initialFocusRequester.requestFocus() }
     }
 
     // Push search suggestions to the native keyboard suggestion bar. Keyed on the query as well
@@ -475,10 +481,10 @@ fun SearchScreen(
 
     var isScreenActive by remember { mutableStateOf(true) }
     val latestPendingDiscoverRestore by rememberUpdatedState(pendingDiscoverRestoreOnResume)
+    val latestInitialFocusRequester by rememberUpdatedState(initialFocusRequester)
     val latestShouldKeepSearchFocus by rememberUpdatedState(
         focusResults || uiState.isSearching || isVoiceListening
     )
-    val latestVoiceSearchAvailable by rememberUpdatedState(isVoiceSearchAvailable)
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
@@ -491,15 +497,10 @@ fun SearchScreen(
                     // already restored it or will restore it via focusedItemIndex.
                     didRestoreSearchFocus.value = false
                 } else if (!latestShouldKeepSearchFocus) {
+                    // Keep resume and entry consistent; ON_RESUME also fires on entry.
                     coroutineScope.launch {
                         repeat(2) { withFrameNanos { } }
-                        runCatching {
-                            if (latestVoiceSearchAvailable) {
-                                voiceFocusRequester.requestFocus()
-                            } else {
-                                searchFocusRequester.requestFocus()
-                            }
-                        }
+                        runCatching { latestInitialFocusRequester.requestFocus() }
                     }
                 }
             } else if (event == Lifecycle.Event.ON_PAUSE) {
@@ -521,6 +522,28 @@ fun SearchScreen(
     ) {
         val listState = rememberLazyListState()
 
+        // Step back within Search before falling through to the root handler.
+        val focusedRowKey = lastFocusedRowKey
+        val focusedItemIndex = focusedResultItemIndex.intValue
+        BackHandler(
+            enabled = !inputRowHasFocus &&
+                (isRecentSearchSectionFocused || (!isDiscoverMode && focusedRowKey != null))
+        ) {
+            if (!isRecentSearchSectionFocused && focusedItemIndex > 0 && focusedRowKey != null) {
+                searchRowFocusedItemIndex[focusedRowKey] = 0
+                focusedResultItemIndex.intValue = 0
+                coroutineScope.launch {
+                    searchRowStates[focusedRowKey]?.scrollToItem(0)
+                    searchRowFocusRequesters[focusedRowKey]?.let { runCatching { it.requestFocus() } }
+                }
+            } else {
+                coroutineScope.launch {
+                    listState.scrollToItem(0)
+                    runCatching { searchFocusRequester.requestFocus() }
+                }
+            }
+        }
+
         // Skip the initial composition; there is nothing stale to reset yet.
         var lastScrollResetQuery by remember { mutableStateOf(uiState.query) }
         LaunchedEffect(uiState.query) {
@@ -528,6 +551,7 @@ fun SearchScreen(
             lastScrollResetQuery = uiState.query
             // Clear stale focus so the restorer cannot return to an item from the previous query.
             searchRowFocusedItemIndex.clear()
+            focusedResultItemIndex.intValue = 0
             // Clear saved offsets too; rebuilt rows can otherwise inherit the old query's position.
             viewModel.savedRowScrollPositions = emptyMap()
             listState.scrollToItem(0)
@@ -549,6 +573,7 @@ fun SearchScreen(
         ) {
             item(key = "search_input") {
                 SearchInputField(
+                    modifier = Modifier.onFocusChanged { inputRowHasFocus = it.hasFocus },
                     query = uiState.query,
                     canMoveToResults = canMoveToResults,
                     voiceFocusRequester = if (isVoiceSearchAvailable) voiceFocusRequester else null,
@@ -590,7 +615,7 @@ fun SearchScreen(
                             },
                             onSectionFocusChanged = { focused -> isRecentSearchSectionFocused = focused },
                             clearHistoryFocusRequester = recentClearHistoryFocusRequester,
-                            emptyHistoryFocusRequester = topInputFocusRequester,
+                            emptyHistoryFocusRequester = searchFocusRequester,
                             modifier = Modifier.padding(horizontal = 52.dp)
                         )
                     }
@@ -625,7 +650,7 @@ fun SearchScreen(
                                         isRecentSearchSectionFocused = focused
                                     },
                                     clearHistoryFocusRequester = recentClearHistoryFocusRequester,
-                                    emptyHistoryFocusRequester = topInputFocusRequester,
+                                    emptyHistoryFocusRequester = searchFocusRequester,
                                     modifier = Modifier.padding(horizontal = 52.dp)
                                 )
                             } else {
@@ -737,6 +762,8 @@ fun SearchScreen(
                                 enableRowFocusRestorer = true,
                                 rowFocusRequester = rowFocusRequester,
                                 entryFocusRequester = entryFocusRequester,
+                                // Anchor Up to the field; geometric focus varies with the card.
+                                upFocusRequester = if (index == 0) searchFocusRequester else null,
                                 listState = listState,
                                 restorerFocusedIndex = if (restoringSearchFocus.value && catalogKey == viewModel.savedFocusRowKey) {
                                     viewModel.savedFocusItemIndex
@@ -751,7 +778,10 @@ fun SearchScreen(
                                 focusedItemIndex = when {
                                     restoringSearchFocus.value && catalogKey == viewModel.savedFocusRowKey ->
                                         viewModel.savedFocusItemIndex
-                                    focusResults && index == 0 -> 0
+                                    // The remembered card, not item 0. A query change clears
+                                    // the map, so a new search still lands on the first item.
+                                    focusResults && index == 0 ->
+                                        searchRowFocusedItemIndex[catalogKey] ?: 0
                                     else -> -1
                                 },
                                 onItemFocused = { itemIndex ->
@@ -767,6 +797,7 @@ fun SearchScreen(
                                     // pending auto-focus so it doesn't steal focus later.
                                     pendingFocusMoveToResultsQuery = null
                                     searchRowFocusedItemIndex[catalogKey] = itemIndex
+                                    focusedResultItemIndex.intValue = itemIndex
                                     // Prefetch meta for the focused item to warm cache for detail screen.
                                     catalogRow.items.getOrNull(itemIndex)?.let { item ->
                                         viewModel.prefetchMetaOnFocus(item.id, item.rawType)
@@ -1066,6 +1097,7 @@ private fun RecentSearchesSection(
 
 @Composable
 private fun SearchInputField(
+    modifier: Modifier = Modifier,
     query: String,
     canMoveToResults: Boolean,
     voiceFocusRequester: FocusRequester?,
@@ -1089,7 +1121,7 @@ private fun SearchInputField(
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = NuvioTheme.spacing.xxxl)
             .focusGroup(),
@@ -1297,7 +1329,11 @@ private fun SearchInputField(
             var isClearButtonFocused by remember { mutableStateOf(false) }
             Spacer(modifier = Modifier.width(NuvioTheme.spacing.md))
             IconButton(
-                onClick = { onQueryChanged("") },
+                onClick = {
+                    // Clearing drops this button from the row, so hand focus back first.
+                    runCatching { searchFocusRequester.requestFocus() }
+                    onQueryChanged("")
+                },
                 modifier = Modifier
                     .onFocusChanged { isClearButtonFocused = it.isFocused }
                     .size(NuvioTheme.spacing.huge)

--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -921,7 +921,8 @@ private fun RecentSearchesSection(
     val searchFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val removeFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     var pendingDownwardFocus by remember { mutableStateOf<Pair<String, String>?>(null) }
-    val firstRemoveFocusRequester = removeFocusRequesters.getOrPut(recentSearches.first()) {
+    // Downward focus enters the query column. The remove buttons are reached with right.
+    val firstSearchFocusRequester = searchFocusRequesters.getOrPut(recentSearches.first()) {
         FocusRequester()
     }
     LaunchedEffect(recentSearches, pendingDownwardFocus) {
@@ -962,7 +963,7 @@ private fun RecentSearchesSection(
                 modifier = Modifier
                     .focusRequester(clearHistoryFocusRequester)
                     .focusProperties {
-                        down = firstRemoveFocusRequester
+                        down = firstSearchFocusRequester
                     },
                 colors = ButtonDefaults.colors(
                     containerColor = NuvioTheme.colors.BackgroundCard,


### PR DESCRIPTION
## Summary

Fixes seven related Back and focus-navigation issues in Search. All changes are limited to `ui/screens/search`.

- **Back steps back within Search.** A result row returns to its first item, then to the search field; recent searches return directly to the field. Back from the field keeps the existing root behavior.

- **The first result row restores its previous card** when focus moves back down, matching every other row. Up is anchored to the search field instead of relying on geometric focus.

- **Entry focus is consistent.** Entry and resume now use the same target: voice search when available, otherwise the search field. This removes the visible field-to-voice jump and the keyboard flash on entry.

- **Discover restores the button that opened it.**

- **Clearing the query keeps focus on the field.**

- **Recent-search navigation enters the query column** instead of the remove buttons.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`SearchScreen` had no `BackHandler`, so every press fell through to the root handling in `MainActivity`. Home has one in each layout, and Settings gained the same stepping in #3281.

The other issues came from missing or conflicting focus targets. Discover restoration was scaffolded but unused, entry and resume requested different controls, and the first result row always requested item 0 instead of its remembered card. Clearing the query removed the focused clear button from the row, and Clear history pointed down at the first remove button instead of the first query.

## Issue or approval

Fixes #3447

## Reproduction steps

1. Open Search and search for something with several result rows.
2. Move focus into the results and along a row, four or five items in.
3. Press Back. Before this change Search exits to Home. After it, focus returns to the start of that row. Back again returns to the search field. Back once more falls through to the existing root handling.

For the Discover fix: from Search, open Discover with the button next to the field, then press Back. Before this change focus lands on voice search. After it, on the Discover button.

For the recent searches fix: clear the field so recent searches show, and move focus down into the list. Before this change focus lands on an x button. After it, on the query.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The Back handler applies to result rows and recent searches. The input row and Discover content keep the existing root behavior. Recent searches are handled separately because they can also appear in Discover mode. Long-press Back is unchanged.

After a new query the remembered first-row index is cleared, so the first item remains the destination.

Remove buttons keep their existing horizontal and vertical navigation, and focus handling after a deletion is unchanged.

Intentionally not changed:

- Discover's own screen and its scroll handling.
- The root handlers in `MainActivity`.
- Home and Settings, which already step back.

## Testing

**Build:** Passed.

**Unit tests:** None added. This is Compose focus behavior rather than ViewModel state.

**Device:** Android TV, Android 11.

| Check | Result |
| --- | --- |
| Back through results: row start, search field, root | Pass |
| Back from recent searches, in both Search and Discover modes | Pass |
| Back on the field retains existing keyboard and root behavior | Pass |
| Back from the voice and Discover buttons falls through | Pass |
| First-row up and down focus, including a card scrolled off screen | Pass |
| New search enters at item 1 | Pass |
| Rows below the first unchanged | Pass |
| Entry focus with voice available, no visible move | Pass |
| Discover return restores its button | Pass |
| Clear button preserves field focus | Pass |
| Recent-search and remove-button navigation, including deletion | Pass |
| Discover, Home and Settings otherwise unaffected | Pass |

Not tested: the no-voice-search path, where entry and the Discover return should land on the search field instead. No device without a speech recogniser was available. The fallback is the pre-existing branch and is unchanged by this PR.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3447