### PR TITLE
Fix Search: restore the first card on Back in RTL

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -305,6 +305,10 @@ fun SearchScreen(
     val searchRowFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val searchRowEntryFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
     val searchRowFocusedItemIndex = remember { mutableMapOf<String, Int>() }
+    // Clears the row-local focus index so the row's entry requester moves to the first card.
+    // Scoped to one row so a Back in one does not reset what the others remember.
+    var focusResetCounter by remember { mutableIntStateOf(0) }
+    var focusResetRowKey by remember { mutableStateOf<String?>(null) }
     // Mirrors the focused index for the active row. The map above is a plain MutableMap,
     // so its values cannot drive recomposition of the Back handler.
     val focusedResultItemIndex = remember { mutableIntStateOf(viewModel.savedFocusItemIndex.coerceAtLeast(0)) }
@@ -542,9 +546,14 @@ fun SearchScreen(
             if (!isRecentSearchSectionFocused && focusedItemIndex > 0 && focusedRowKey != null) {
                 searchRowFocusedItemIndex[focusedRowKey] = 0
                 focusedResultItemIndex.intValue = 0
+                focusResetRowKey = focusedRowKey
+                focusResetCounter++
                 coroutineScope.launch {
+                    // Let the reset take effect so the entry requester moves to the first card.
+                    repeat(2) { withFrameNanos { } }
                     searchRowStates[focusedRowKey]?.scrollToItem(0)
-                    searchRowFocusRequesters[focusedRowKey]?.let { runCatching { it.requestFocus() } }
+                    searchRowEntryFocusRequesters[focusedRowKey]
+                        ?.let { runCatching { it.requestFocus() } }
                 }
             } else {
                 coroutineScope.launch {
@@ -786,7 +795,11 @@ fun SearchScreen(
                                 } else {
                                     searchRowFocusedItemIndex[catalogKey] ?: -1
                                 },
-                                focusResetToken = uiState.query,
+                                focusResetToken = if (catalogKey == focusResetRowKey) {
+                                    "${uiState.query}#$focusResetCounter"
+                                } else {
+                                    uiState.query
+                                },
                                 isItemWatched = { item ->
                                     val isSeries = item.apiType.equals("series", ignoreCase = true) || item.apiType.equals("tv", ignoreCase = true)
                                     if (isSeries) item.id in watchedSeriesIds else item.id in watchedMovieIds


### PR DESCRIPTION
## Summary

Follow-up to #3448, which added Back handling to Search. In an RTL layout, Back inside a result row moved focus to the leftmost visible card instead of returning to the first card. LTR was unaffected.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Back requested focus on the row itself. Focus is already inside the row at that point, so `focusRestorer` never ran and Compose resolved the request within the focus group. In LTR this resolves to the first card; in RTL it resolves to the opposite visible end.

`CatalogRowSection` attaches `entryFocusRequester` to its remembered card, or the first card when there is none. Resetting that index through the `focusResetToken` the row already accepts, then requesting the entry requester, selects a specific card instead of relying on focus-group resolution.

The reset is applied during composition, so the request waits two frames for it to take effect, matching the existing focus requests in `SearchScreen`.

## Issue or approval

Fixes #3474

## Reproduction steps

1. Set the device language to an RTL locale, or enable force-RTL in developer options.
2. Search for something with a result row wider than the screen.
3. Move focus into the row, move one card along, and press Back.
4. Before this change focus moves to the leftmost visible card. After it, focus returns to the first card, which in RTL is the rightmost.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Back inside a result row now returns to the first card in both layout directions. LTR behaviour is unchanged.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The reset is scoped to the row handling Back. Other rows keep their own focus state and Search's per-row remembered index.

The row's own focus requester is no longer used by the Back handler. It remains in use elsewhere.

Intentionally not changed:

- `CatalogRowSection`, including its restorer and RTL bring-into-view handling.
- The rest of the Back ladder from #3448.

## Testing

**Build:** Passed.

**Unit tests:** None added. Compose focus behavior rather than ViewModel state.

**Device:** Nvidia Shield Pro (2019), Android 11. App language set to Arabic for the RTL runs.

| Check | Result |
| --- | --- |
| RTL, row fits on screen: move off the first card, Back returns to it | Pass |
| RTL, row scrolls: move several cards, Back returns to the first card | Pass |
| RTL: at the first card, Back returns to the search field | Pass |
| RTL: repeated Back presses behave the same each time | Pass |
| RTL: the same on a second row | Pass |
| RTL: focus a later card in row 2, press Back in row 1, return to row 2, and verify its remembered card is unchanged | Pass |
| LTR: all of the above unchanged | Pass |
| A new query still focuses the first card | Pass |

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3474