### PR TITLE
Fix Player: stop auto-play skipping an episode after a dismissed card

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -44,6 +44,9 @@ object PlayerNextEpisodeRules {
         thresholdPercent: Float,
         thresholdMinutesBeforeEnd: Float
     ): Boolean {
+        // A duration below the current position is not a valid end-of-video signal.
+        if (durationMs > 0L && positionMs > durationMs + END_OF_VIDEO_EPSILON_MS) return false
+
         val outroSegments = skipIntervals.filter { it.type in OUTRO_SEGMENT_TYPES }
 
         if (outroSegments.isNotEmpty()) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRules.kt
@@ -99,6 +99,26 @@ object PlayerNextEpisodeRules {
         }
     }
 
+    /** True when a reading is clearly before the end and outside the next-episode window. */
+    fun isAwayFromEnd(
+        positionMs: Long,
+        durationMs: Long,
+        skipIntervals: List<SkipInterval>,
+        thresholdMode: NextEpisodeThresholdMode,
+        thresholdPercent: Float,
+        thresholdMinutesBeforeEnd: Float
+    ): Boolean =
+        durationMs > 0L &&
+            positionMs < durationMs - NEAR_END_MS &&
+            !shouldShowNextEpisodeCard(
+                positionMs = positionMs,
+                durationMs = durationMs,
+                skipIntervals = skipIntervals,
+                thresholdMode = thresholdMode,
+                thresholdPercent = thresholdPercent,
+                thresholdMinutesBeforeEnd = thresholdMinutesBeforeEnd
+            )
+
     fun parseEpisodeReleaseDate(raw: String?): LocalDate? {
         return parseEpisodeReleaseLocalDate(raw)
     }
@@ -112,4 +132,7 @@ object PlayerNextEpisodeRules {
     const val POST_OUTRO_AUTOPLAY_GAP_MS = 5_000L
 
     const val END_OF_VIDEO_EPSILON_MS = 1_000L
+
+    /** How close to the duration MPV treats as the end of the file. */
+    const val NEAR_END_MS = 500L
 }

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeController.kt
@@ -400,6 +400,10 @@ class PlayerRuntimeController(
 
     internal var playbackStartedForParentalGuide = false
     internal var hasRenderedFirstFrame = false
+    // Prevent the previous stream's end from completing the new stream.
+    internal var endDetectionArmed = false
+    // Ignore EOF until MPV has reported a non-EOF state for this stream.
+    internal var mpvEofSeenClear = false
     internal var shouldEnforceAutoplayOnFirstReady = true
 
     internal var rebufferCount: Int = 0

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerInitialization.kt
@@ -2057,6 +2057,8 @@ internal fun PlayerRuntimeController.resetLoadingOverlayForNewStream() {
         progress = null
     )
     hasRenderedFirstFrame = false
+    endDetectionArmed = false
+    mpvEofSeenClear = false
     hasMarkedCurrentEpisodeCompleted = false
     shouldEnforceAutoplayOnFirstReady = true
     userPausedManually = false

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -357,6 +357,19 @@ internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionM
     // Prefer the largest known duration; the per-poll value can drop transiently.
     val effectiveDurationEarly = maxOf(durationMs, lastKnownDuration)
     if (isShortPlaceholderDuration(effectiveDurationEarly)) return
+    // Act only after this stream has reported a position away from its end.
+    if (!endDetectionArmed) {
+        if (!PlayerNextEpisodeRules.isAwayFromEnd(
+                positionMs = positionMs,
+                durationMs = effectiveDurationEarly,
+                skipIntervals = skipIntervals,
+                thresholdMode = nextEpisodeThresholdModeSetting,
+                thresholdPercent = nextEpisodeThresholdPercentSetting,
+                thresholdMinutesBeforeEnd = nextEpisodeThresholdMinutesBeforeEndSetting
+            )
+        ) return
+        endDetectionArmed = true
+    }
     if (!_uiState.value.error.isNullOrBlank()) return
 
     val state = _uiState.value

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMetadata.kt
@@ -354,7 +354,8 @@ internal fun PlayerRuntimeController.evaluatePostPlayOverlayVisibility(positionM
     if (_playbackTimeline.value.isLive) return
     if (!hasRenderedFirstFrame) return
     // Short debrid/error clips must never arm next-episode auto-play (see #2819).
-    val effectiveDurationEarly = durationMs.takeIf { it > 0L } ?: lastKnownDuration
+    // Prefer the largest known duration; the per-poll value can drop transiently.
+    val effectiveDurationEarly = maxOf(durationMs, lastKnownDuration)
     if (isShortPlaceholderDuration(effectiveDurationEarly)) return
     if (!_uiState.value.error.isNullOrBlank()) return
 

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerMpv.kt
@@ -41,6 +41,8 @@ internal fun PlayerRuntimeController.attachMpvView(view: NuvioMpvSurfaceView?) {
         view.setPaused(false)
         applyPendingMpvSeekIfNeeded(view)
         hasRenderedFirstFrame = false
+        endDetectionArmed = false
+        mpvEofSeenClear = false
         _uiState.update {
             it.copy(
                 isBuffering = true,
@@ -150,6 +152,8 @@ internal fun PlayerRuntimeController.initializeMpvPlayer(
         applyPendingMpvSeekIfNeeded(view)
 
         hasRenderedFirstFrame = false
+        endDetectionArmed = false
+        mpvEofSeenClear = false
         _uiState.update {
             it.copy(
                 isBuffering = true,

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -227,12 +227,16 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                         playerReportsLive = view.isLiveStreamNow(),
                         isPlaying = playingForWatchClock
                     )
-                    val nearEnd = playerDuration > 0L && pos >= (playerDuration - 500L)
+                    // Prefer the largest known duration; MPV can report a shorter one transiently.
+                    // The playerDuration check stays: lastKnownDuration can still hold the previous
+                    // stream's value until it resets.
+                    val effectiveDuration = maxOf(playerDuration, lastKnownDuration)
+                    val nearEnd = playerDuration > 0L && pos >= (effectiveDuration - 500L)
                     val mpvEofReached = view.isEofReached()
                     val naturalEnded = !view.isLiveStreamNow() && (nearEnd || mpvEofReached) && shouldTreatAsNaturalPlaybackCompletion(
                         hasRenderedFirstFrame = firstFrameReady,
                         hasFatalError = !_uiState.value.error.isNullOrBlank(),
-                        durationMs = playerDuration
+                        durationMs = effectiveDuration
                     )
                     val wasEnded = _uiState.value.playbackEnded
                     _uiState.update { state ->

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
@@ -231,8 +231,11 @@ internal fun PlayerRuntimeController.startProgressUpdates() {
                     // The playerDuration check stays: lastKnownDuration can still hold the previous
                     // stream's value until it resets.
                     val effectiveDuration = maxOf(playerDuration, lastKnownDuration)
-                    val nearEnd = playerDuration > 0L && pos >= (effectiveDuration - 500L)
-                    val mpvEofReached = view.isEofReached()
+                    val nearEnd = endDetectionArmed && playerDuration > 0L &&
+                        pos >= (effectiveDuration - PlayerNextEpisodeRules.NEAR_END_MS)
+                    val eofNow = view.isEofReached()
+                    if (!eofNow) mpvEofSeenClear = true
+                    val mpvEofReached = mpvEofSeenClear && eofNow
                     val naturalEnded = !view.isLiveStreamNow() && (nearEnd || mpvEofReached) && shouldTreatAsNaturalPlaybackCompletion(
                         hasRenderedFirstFrame = firstFrameReady,
                         hasFatalError = !_uiState.value.error.isNullOrBlank(),
@@ -1586,6 +1589,8 @@ fun PlayerRuntimeController.onEvent(event: PlayerEvent) {
         }
         PlayerEvent.OnRetry -> {
             hasRenderedFirstFrame = false
+            endDetectionArmed = false
+            mpvEofSeenClear = false
             hasRetriedCurrentStreamAfter416 = false
             playbackIssueReportRequestVersion.incrementAndGet()
             resetErrorRetryState()

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1371,6 +1371,9 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     currentSeason = targetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
     currentEpisode = targetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
     currentEpisodeTitle = targetVideo?.title ?: _uiState.value.episodeStreamsTitle ?: currentEpisodeTitle
+    // Until the new file loads, MPV keeps reporting the old one, which is often at its end.
+    endDetectionArmed = false
+    mpvEofSeenClear = false
     currentTraktEpisodeMapping = null
     currentTraktEpisodeMappingKey = null
     lastSavedPosition = 0L

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
@@ -165,4 +165,57 @@ class PlayerNextEpisodeRulesTest {
     fun `an unknown duration never fires`() {
         assertFalse(shouldShow(positionMs = 25 * 60_000L, durationMs = 0L))
     }
+
+    private fun awayFromEnd(positionMs: Long, durationMs: Long) =
+        PlayerNextEpisodeRules.isAwayFromEnd(
+            positionMs = positionMs,
+            durationMs = durationMs,
+            skipIntervals = emptyList(),
+            thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+            thresholdPercent = 97f,
+            thresholdMinutesBeforeEnd = 2f
+        )
+
+    @Test
+    fun `the start of a stream is away from the end`() {
+        assertTrue(awayFromEnd(positionMs = 0L, durationMs = 22 * 60_000L))
+    }
+
+    @Test
+    fun `mid-episode is away from the end`() {
+        assertTrue(awayFromEnd(positionMs = 11 * 60_000L, durationMs = 22 * 60_000L))
+    }
+
+    @Test
+    fun `the previous file's end position is not away from the end`() {
+        // Stale reading after a switch: previous episode's end against a similar duration.
+        assertFalse(awayFromEnd(positionMs = 22 * 60_000L, durationMs = 22 * 60_000L))
+    }
+
+    @Test
+    fun `a stale position inside the card threshold is not away from the end`() {
+        // Previous episode ended at 22:00; the new one reports 22:20. Before the file end, but
+        // past 97%, so it must not arm.
+        assertFalse(awayFromEnd(positionMs = 22 * 60_000L, durationMs = 22 * 60_000L + 20_000L))
+    }
+
+    @Test
+    fun `a resume inside the card window but below completion is not away from the end`() {
+        // 17:30 of a 20 minute episode is 87.5%, so it resumes, but it is inside a 3 minute window.
+        assertFalse(
+            PlayerNextEpisodeRules.isAwayFromEnd(
+                positionMs = 17 * 60_000L + 30_000L,
+                durationMs = 20 * 60_000L,
+                skipIntervals = emptyList(),
+                thresholdMode = NextEpisodeThresholdMode.MINUTES_BEFORE_END,
+                thresholdPercent = 97f,
+                thresholdMinutesBeforeEnd = 3f
+            )
+        )
+    }
+
+    @Test
+    fun `an unknown duration is not away from the end`() {
+        assertFalse(awayFromEnd(positionMs = 0L, durationMs = 0L))
+    }
 }

--- a/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
+++ b/app/src/test/java/com/nuvio/tv/ui/screens/player/PlayerNextEpisodeRulesTest.kt
@@ -1,5 +1,7 @@
 package com.nuvio.tv.ui.screens.player
 
+import com.nuvio.tv.data.local.NextEpisodeThresholdMode
+import com.nuvio.tv.data.repository.SkipInterval
 import com.nuvio.tv.domain.model.Video
 import java.time.Clock
 import java.time.Instant
@@ -81,5 +83,86 @@ class PlayerNextEpisodeRulesTest {
 
         assertFalse(PlayerNextEpisodeRules.hasEpisodeAired("2026-07-15T15:00:00Z", before))
         assertTrue(PlayerNextEpisodeRules.hasEpisodeAired("2026-07-15T15:00:00Z", exact))
+    }
+
+    private fun shouldShow(
+        positionMs: Long,
+        durationMs: Long,
+        skipIntervals: List<SkipInterval> = emptyList(),
+        mode: NextEpisodeThresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+        percent: Float = 97f,
+        minutesBeforeEnd: Float = 2f
+    ) = PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+        positionMs = positionMs,
+        durationMs = durationMs,
+        skipIntervals = skipIntervals,
+        thresholdMode = mode,
+        thresholdPercent = percent,
+        thresholdMinutesBeforeEnd = minutesBeforeEnd
+    )
+
+    private fun outro(startSec: Double, endSec: Double) =
+        SkipInterval(startTime = startSec, endTime = endSec, type = "outro", provider = "introdb")
+
+    @Test
+    fun `percentage mode fires past the threshold`() {
+        assertTrue(shouldShow(positionMs = 44 * 60_000L, durationMs = 45 * 60_000L))
+    }
+
+    @Test
+    fun `a duration below the position does not fire in percentage mode`() {
+        // 25 minutes into a 45 minute episode, player transiently reports 20 minutes.
+        assertFalse(shouldShow(positionMs = 25 * 60_000L, durationMs = 20 * 60_000L))
+    }
+
+    @Test
+    fun `a duration below the position does not fire in minutes mode`() {
+        assertFalse(
+            shouldShow(
+                positionMs = 25 * 60_000L,
+                durationMs = 20 * 60_000L,
+                mode = NextEpisodeThresholdMode.MINUTES_BEFORE_END
+            )
+        )
+    }
+
+    @Test
+    fun `a duration below the position does not fire with outro segments`() {
+        assertFalse(
+            shouldShow(
+                positionMs = 25 * 60_000L,
+                durationMs = 20 * 60_000L,
+                skipIntervals = listOf(outro(startSec = 1_180.0, endSec = 1_200.0))
+            )
+        )
+    }
+
+    @Test
+    fun `the end of the episode still fires within the epsilon`() {
+        val durationMs = 45 * 60_000L
+        assertTrue(shouldShow(positionMs = durationMs, durationMs = durationMs))
+        assertTrue(shouldShow(positionMs = durationMs + 500L, durationMs = durationMs))
+    }
+
+    @Test
+    fun `position beyond the epsilon does not fire`() {
+        val durationMs = 45 * 60_000L
+        assertFalse(shouldShow(positionMs = durationMs + 1_001L, durationMs = durationMs))
+    }
+
+    @Test
+    fun `minutes mode fires inside the window`() {
+        assertTrue(
+            shouldShow(
+                positionMs = 44 * 60_000L,
+                durationMs = 45 * 60_000L,
+                mode = NextEpisodeThresholdMode.MINUTES_BEFORE_END
+            )
+        )
+    }
+
+    @Test
+    fun `an unknown duration never fires`() {
+        assertFalse(shouldShow(positionMs = 25 * 60_000L, durationMs = 0L))
     }
 }


### PR DESCRIPTION
## Summary

With the next-episode card dismissed on MPV, letting an episode play out advanced twice and landed on the episode after the next. This fixes that, and also hardens the shared end-detection paths against transient invalid duration readings.

- Reset end detection when switching episodes, and wait for the new stream to report a position away from its end before acting on it.
- Count MPV's EOF only once the stream has reported a non-EOF state.
- Use the largest known duration in the auto-play and MPV end checks, and reject a position beyond it.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A dismissed card still auto-plays at the natural end, which switches to the next episode while MPV is still reporting the previous file at its end. End-detection state was only reset when MPV loaded the new file, so that stale reading could count as the new episode ending. Because `playNextEpisode` marks the target episode's post-play state as dismissed, the stale end then entered the dismissed-card path and caused the second advance.

End detection now resets at the episode switch and only arms after a subsequent reading is clearly away from the end. MPV's EOF is likewise ignored until a non-EOF state has been seen.

The same change also hardens the duration-based end checks against transient duration readings shorter than the current position, using the largest known duration as `getEffectiveDuration` already does. `isShortPlaceholderDuration` only covers durations up to 120999 ms, for the error clips in #2819. The hardening is limited to the same end-detection paths involved in the bug and stops invalid duration readings producing the same false end signal.

## Issue or approval

Fixes #3481

## Reproduction steps

1. Use MPV and enable auto-play next episode.
2. Play a series episode, seek past the next-episode threshold, and dismiss the card.
3. Let the episode play to the end. Before this change it advances twice. After it, it advances once and plays the next episode.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

End detection resets when a stream is switched or initialized, and on retry. Resume only happens below the 90% completion threshold, so a normally resumed episode has ample time to report a non-EOF state before reaching the end. ExoPlayer's `STATE_ENDED` is not gated.

The duration guard is in `PlayerNextEpisodeRules`, so it also covers the recommendation timing path.

Intentionally not changed:

- `isShortPlaceholderDuration` and the #2819 behavior it guards.
- `getEffectiveDuration` and the progress-save path.
- Reuse last link. Testing was done with it off; saving a switched-to episode's link under the previous episode is a separate bug, fixed in its own PR.

## Testing

**Build:** Passed.

**Unit tests:** Added coverage in `PlayerNextEpisodeRulesTest` for durations below the position in each threshold mode, the end-of-video epsilon, unknown durations, normal firing in percentage and minutes-before-end modes, and the stream-switch arming conditions, including a resume inside the card window. `shouldShowNextEpisodeCard` had no coverage before.

`testFullDebugUnitTest`: 1208 tests, with 12 pre-existing failures also present on `dev`.

**Device:** Nvidia Shield Pro (2019), Android 11, MPV, reuse last link off.

| Check | Result |
| --- | --- |
| Card dismissed, episode plays out: advances once, no card at the start of the next | Pass |
| Card not dismissed: advances once at the threshold | Pass |
| Minutes-before-end timing still fires | Pass |
| A short following episode still auto-plays at its own end | Pass |
| Only the finished episode is marked watched | Pass |
| Resumed at around 50%: finishes and advances normally | Pass |
| Resumed inside the card window, below 90%: plays out and advances at its end | Pass |
| Duration dropping below the position | Unable to reproduce |

## Screenshots / Video

No visual change.

## Breaking changes

None.

## Linked issues

Fixes #3481