### PR TITLE
Fix downscaling 4:3 1080p to 720p when matching resolution

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/core/player/FrameRateUtils.kt
@@ -259,11 +259,32 @@ object FrameRateUtils {
         return if (width >= height) width to height else height to width
     }
 
-    private fun resolutionDistanceSquared(mode: Display.Mode, targetWidth: Int, targetHeight: Int): Long {
-        val (modeWidth, modeHeight) = normalizedSize(mode.physicalWidth, mode.physicalHeight)
-        val dw = modeWidth - targetWidth
-        val dh = modeHeight - targetHeight
-        return dw.toLong() * dw.toLong() + dh.toLong() * dh.toLong()
+    private fun selectResolutionCandidates(
+        modeSizes: List<Pair<Int, Int>>,
+        videoWidth: Int,
+        videoHeight: Int
+    ): List<Pair<Int, Int>> {
+        if (modeSizes.isEmpty()) return modeSizes
+        val (targetWidth, targetHeight) = normalizedSize(videoWidth, videoHeight)
+
+        fun area(width: Int, height: Int): Long {
+            val (normalizedWidth, normalizedHeight) = normalizedSize(width, height)
+            return normalizedWidth.toLong() * normalizedHeight.toLong()
+        }
+
+        fun fits(width: Int, height: Int): Boolean {
+            val (modeWidth, modeHeight) = normalizedSize(width, height)
+            return modeWidth >= targetWidth && modeHeight >= targetHeight
+        }
+
+        val fitting = modeSizes.filter { fits(it.first, it.second) }
+        if (fitting.isNotEmpty()) {
+            val minArea = fitting.minOf { area(it.first, it.second) }
+            return fitting.filter { area(it.first, it.second) == minArea }
+        }
+
+        val maxArea = modeSizes.maxOf { area(it.first, it.second) }
+        return modeSizes.filter { area(it.first, it.second) == maxArea }
     }
 
     private fun selectModesForVideoResolution(
@@ -272,9 +293,12 @@ object FrameRateUtils {
         videoHeight: Int
     ): List<Display.Mode> {
         if (modes.isEmpty()) return modes
-        val (targetWidth, targetHeight) = normalizedSize(videoWidth, videoHeight)
-        val minDistance = modes.minOfOrNull { resolutionDistanceSquared(it, targetWidth, targetHeight) } ?: return modes
-        return modes.filter { resolutionDistanceSquared(it, targetWidth, targetHeight) == minDistance }
+        val selectedSizes = selectResolutionCandidates(
+            modeSizes = modes.map { it.physicalWidth to it.physicalHeight },
+            videoWidth = videoWidth,
+            videoHeight = videoHeight
+        ).map { normalizedSize(it.first, it.second) }.toSet()
+        return modes.filter { normalizedSize(it.physicalWidth, it.physicalHeight) in selectedSizes }
     }
 
     suspend fun matchFrameRateAndWait(


### PR DESCRIPTION
## Summary
Resolution matching no longer picks 720p for 4:3 1080p files (1440x1080). It now selects the smallest HDMI mode that can show the video without downscaling, so 1440x1080 lands on 1920x1080.
## PR type
- [ ] Translation/localization only
- [x] Critical bug fix
## Why
With Match Resolution enabled, 1440x1080 (4:3 1080p) was treated as closer to 1280x720 than to 1920x1080 because selection used Euclidean pixel distance. The player switched HDMI output to 720p, downscaled 1080-tall content, and the TV then upscaled that 720p signal. Reported on Fire Stick 4K Max and reproduced by others on Xiaomi / Panasonic Android TV.
## Issue or approval
Fixes #3460
## Reproduction steps
1. Enable Match Resolution.
2. Set the playback engine to ExoPlayer.
3. Play a 1440x1080 (4:3 1080p) file.
4. Check the resolution overlay in the top right.
Before this change the overlay shows 1280x720. After this change it should show 1920x1080.
## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.
## Scope boundaries
- Does not add a minimum-resolution floor (keep 1080p for SD). That was requested in the issue comments and is out of scope.
- Does not change AFR refresh-rate matching beyond using the corrected resolution candidate set.
- Does not change player UI, overlay layout, or settings copy.
## Testing
- Walked the #3460 path: Match Resolution on, ExoPlayer, 1440x1080 source. HDMI mode selection now returns 1920x1080 instead of 1280x720.
- Confirmed 1920x1080 still stays on 1080p (does not jump to 4K).
- Confirmed 1280x720 still stays on 720p.
## Screenshots / Video
Not a UI change.
## Breaking changes
None.
## Linked issues
Fixes #3460