### PR TITLE
Fix Player: stop saving the next episode's link under the previous episode

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/PlayerRuntimeControllerStreams.kt
@@ -1360,14 +1360,18 @@ internal fun PlayerRuntimeController.switchToEpisodeStream(
     )
     val playbackUrl = currentStreamUrl
     val playbackHeaders = currentHeaders
-    persistSelectedStreamForReuse(stream = stream, url = playbackUrl, headers = playbackHeaders)
+    val targetVideoId = targetVideo?.id ?: _uiState.value.episodeStreamsForVideoId ?: currentVideoId
+    // Do not persist an episode switch under the outgoing episode's reuse key.
+    if (targetVideoId == currentVideoId) {
+        persistSelectedStreamForReuse(stream = stream, url = playbackUrl, headers = playbackHeaders)
+    }
     persistedTrackPreference = null
     subtitleDisabledByPersistedPreference = false
     subtitleAddonRestoredByPersistedPreference = false
     pendingRestoredAddonSubtitle = null
     hasRetriedCurrentStreamAfter416 = false
     resetErrorRetryState()
-    currentVideoId = targetVideo?.id ?: _uiState.value.episodeStreamsForVideoId ?: currentVideoId
+    currentVideoId = targetVideoId
     currentSeason = targetVideo?.season ?: _uiState.value.episodeStreamsSeason ?: currentSeason
     currentEpisode = targetVideo?.episode ?: _uiState.value.episodeStreamsEpisode ?: currentEpisode
     currentEpisodeTitle = targetVideo?.title ?: _uiState.value.episodeStreamsTitle ?: currentEpisodeTitle


### PR DESCRIPTION
## Summary

With "Reuse Last Link" enabled, switching episodes in the player saved the new episode's link under the previous episode's reuse entry. Replaying the previous episode could then play the next episode's video while showing the previous episode.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

`switchToEpisodeStream` applies the new stream before updating `currentVideoId`. `persistSelectedStreamForReuse` uses the current reuse key, so the new stream was saved under the outgoing episode.

PR #3163 moved persistence ahead of the episode advance to avoid creating a reuse entry for an episode selected from the episode panel. The resulting ordering also saved the new stream under the old episode.

This change only persists when the target episode is the current episode. Episode switches of direct streams do not create a reuse entry; source switches within the current episode still update it.

## Issue or approval

Fixes #3484

## Reproduction steps

1. Enable "Reuse Last Link" and auto-play next episode.
2. Play an episode and let it auto-advance to the next episode.
3. Exit and play the first episode again.
4. Before this change, it plays the second episode's video while showing the first. After this change, it plays the first episode.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

`switchToSourceStream` is a same-episode source switch and is unaffected.

Torrent episode switches already save under the correct episode and are unchanged.

Intentionally not changed:

- Whether an episode reached by switching should get a reuse entry. This preserves the behavior introduced by #3163 for direct streams.
- The reuse read path and its manual-selection behavior.

## Testing

**Build:** Passed.

**Unit tests:** None added. The fix depends on controller state during episode switching and was verified through playback tests.

`testFullDebugUnitTest`: 1194 tests, 12 pre-existing failures also present on `dev`.

**Device:** Nvidia Shield Pro (2019), Android 11, internal player (MPV engine), direct (Usenet) streams.

| Check | Result |
| --- | --- |
| Auto-advance, then replay the first episode: plays its own video | Pass |
| That replay then auto-advances to the real next episode | Pass |
| Only the finished episode is marked watched | Pass |
| Source switch within an episode, then replay: reuses the new source | Pass |
| Direct-stream episode reached by auto-advance has no reuse entry | Pass |
| Episode chosen from the panel, then its source switched: saved under that episode | Pass |
| Reuse Last Link off: behavior unchanged | Pass |

## Screenshots / Video

No visual change.

## Breaking changes

None.

## Linked issues

Fixes #3484