### PR TITLE
 Fix Search: prevent Back from reopening the keyboard

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/search/SearchScreen.kt
@@ -120,6 +120,16 @@ import com.nuvio.tv.R
 /** Skeleton rows shown while a search is pending, matching the two mobile renders. */
 private const val SEARCH_SKELETON_ROW_COUNT = 2
 
+private val NAVIGATION_KEYS = setOf(
+    KeyEvent.KEYCODE_DPAD_UP,
+    KeyEvent.KEYCODE_DPAD_DOWN,
+    KeyEvent.KEYCODE_DPAD_LEFT,
+    KeyEvent.KEYCODE_DPAD_RIGHT,
+    KeyEvent.KEYCODE_DPAD_CENTER,
+    KeyEvent.KEYCODE_ENTER,
+    KeyEvent.KEYCODE_NUMPAD_ENTER
+)
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun SearchScreen(
@@ -160,8 +170,13 @@ fun SearchScreen(
     val didRestoreSearchFocus = remember { mutableStateOf(false) }
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
+    // Latches the Back-to-field step until the user navigates, types or submits. Focus alone cannot
+    // lift it: closing the Fire TV keyboard moves focus into the recent searches with no key press,
+    // which would otherwise re-enable this handler.
+    var backToFieldLatched by remember { mutableStateOf(false) }
     val onVoiceQueryResultState = rememberUpdatedState<(String) -> Unit> { recognized ->
         if (recognized.isNotBlank()) {
+            backToFieldLatched = false
             viewModel.onEvent(SearchEvent.QueryChanged(recognized))
             viewModel.onEvent(SearchEvent.SubmitSearch)
             focusResults = false
@@ -379,6 +394,8 @@ fun SearchScreen(
     }
     val submitCurrentQuery: (String) -> Unit = { submittedQuery ->
         viewModel.onEvent(SearchEvent.SubmitSearch)
+        // Submitting moves focus into the results without a key event on an on-screen keyboard.
+        backToFieldLatched = false
         focusResults = false
         if (submittedQuery.length >= MIN_SEARCH_QUERY_LENGTH) {
             pendingFocusMoveToResultsQuery = submittedQuery
@@ -393,6 +410,8 @@ fun SearchScreen(
         }
     }
     val handleQueryChanged: (String) -> Unit = { nextQuery ->
+        // A real edit is user intent. An IME that re-commits the same text on dismiss is not.
+        if (nextQuery != uiState.query) backToFieldLatched = false
         val previousQuery = uiState.query.trim()
         val trimmedNextQuery = nextQuery.trim()
         val selectedSuggestion = trimmedNextQuery.length >= MIN_SEARCH_QUERY_LENGTH &&
@@ -532,6 +551,14 @@ fun SearchScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .onPreviewKeyEvent { keyEvent ->
+                if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
+                    keyEvent.nativeKeyEvent.keyCode in NAVIGATION_KEYS
+                ) {
+                    backToFieldLatched = false
+                }
+                false
+            }
             .background(NuvioTheme.colors.Background),
         contentAlignment = Alignment.TopCenter
     ) {
@@ -541,7 +568,7 @@ fun SearchScreen(
         val focusedRowKey = lastFocusedRowKey
         val focusedItemIndex = focusedResultItemIndex.intValue
         BackHandler(
-            enabled = !inputRowHasFocus &&
+            enabled = !inputRowHasFocus && !backToFieldLatched &&
                 (isRecentSearchSectionFocused || (!isDiscoverMode && focusedRowKey != null))
         ) {
             if (!isRecentSearchSectionFocused && focusedItemIndex > 0 && focusedRowKey != null) {
@@ -557,9 +584,12 @@ fun SearchScreen(
                         ?.let { runCatching { it.requestFocus() } }
                 }
             } else {
+                backToFieldLatched = true
                 coroutineScope.launch {
                     listState.scrollToItem(0)
                     runCatching { searchFocusRequester.requestFocus() }
+                    // The focus request can start an input session and show the keyboard.
+                    keyboardController?.hide()
                 }
             }
         }


### PR DESCRIPTION
## Summary

Regression from #3448. On Fire TV, Back from the search results returns focus to the search field, which opens the keyboard. Pressing Back closes the keyboard, focus lands on the field again, and the keyboard reopens. Search cannot be left with Back.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Focusing the text field starts an input session, which shows the keyboard. On Fire TV, focusing the field can make `inputRowHasFocus` read false, and closing the keyboard can move focus into the recent searches. That can re-enable the Search `BackHandler`, so Back returns focus to the field again.

Two changes:

- The Back-to-field step is latched. A D-pad, Center or Enter press lifts it, and so does typing or submitting a search. On Fire TV the keyboard moves focus into the recent searches when it closes, with no key press involved, which used to re-enable the handler and continue the loop. Typing and submitting lift the latch because an on-screen keyboard moves focus into the results with no key event, and the Back behavior from #3448 has to keep working there.
- The keyboard is hidden after the focus request. Where that takes effect, Back returns to the field without reopening it. A Fire TV Stick 4k still shows it, which is why the latch has to hold on its own.

Compose queues the input session start and the hide into one pass, so the keyboard should not appear at all. That was read from androidx source rather than the version this BOM resolves, and a Fire TV Stick 4k shows the keyboard regardless, so the device checks below are what confirm it.

The latch alone fixed the loop from a results row on one tester's Fire TV. It did not on a device where closing the keyboard moved focus into the recent searches, which is what the key press requirement addresses.

## Issue or approval

Fixes #3477

## Reproduction steps

1. On a Fire TV Stick, open Search. The device has no speech recognizer, so Search opens with the field focused and the keyboard up.
2. Search for anything and let focus move into the results.
3. Press Back. Focus returns to the search field. Before this change the keyboard opens. After the fix, the keyboard stays closed.
4. Press Back again. Before this change the keyboard reopens and Search cannot be left. After it, the sidebar opens as it does from any root screen.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The Back ladder from #3448 is unchanged apart from the latch.

Intentionally not changed:

- Entry focus, which still prefers voice search where it is available.
- The root handlers in `MainActivity`.
- The ON_PAUSE keyboard hide and `canFocus = isScreenActive`.

On a touchscreen install, where the hide takes effect, Back to the field leaves it focused without the keyboard, so typing needs one tap or Center first. The app ships no mobile build, but `touchscreen` and `leanback` are both optional in the manifest.

## Testing

**Build:** Debug APK built from `d08dae2de` and shared with the reporters.

**Unit tests:** None added. This is Compose focus and IME behavior rather than ViewModel state. The existing suite was run and passes.

**Device:** Two Fire TV testers from #3477 confirmed the loop is gone and Back leaves Search.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #3477