### PR TITLE
Follow-up: Extend Content-Based Text Direction Fix

### DIFF
--- a/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/NuvioDialog.kt
@@ -1,6 +1,7 @@
 package com.nuvio.tv.ui.components
 
 import com.nuvio.tv.ui.theme.NuvioTheme
+import com.nuvio.tv.ui.util.contentTextDirection
 
 import android.os.SystemClock
 import android.view.KeyEvent as AndroidKeyEvent
@@ -103,7 +104,9 @@ fun NuvioDialog(
                 if (title.isNotBlank()) {
                     Text(
                         text = title,
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            textDirection = title.contentTextDirection()
+                        ),
                         color = NuvioTheme.colors.TextPrimary,
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = titleTextAlign,

--- a/app/src/main/java/com/nuvio/tv/ui/components/P2pConsentDialog.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/components/P2pConsentDialog.kt
@@ -49,21 +49,8 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.nuvio.tv.R
+import com.nuvio.tv.ui.util.isContentRtl
 import kotlinx.coroutines.launch
-
-private fun String.isRtl(): Boolean {
-    for (char in this) {
-        val directionality = Character.getDirectionality(char)
-        if (directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
-            directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC) {
-            return true
-        }
-        if (directionality == Character.DIRECTIONALITY_LEFT_TO_RIGHT) {
-            return false
-        }
-    }
-    return false
-}
 
 @Composable
 fun P2pConsentDialog(
@@ -72,7 +59,7 @@ fun P2pConsentDialog(
 ) {
     val focusRequester = remember { FocusRequester() }
     val bodyText = stringResource(R.string.p2p_consent_body)
-    val isRtl = remember(bodyText) { bodyText.isRtl() }
+    val isRtl = remember(bodyText) { bodyText.isContentRtl() }
     val layoutDirection = if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/home/ModernHomeRows.kt
@@ -127,6 +127,7 @@ import com.nuvio.tv.ui.util.recompositionHighlighter
 import com.nuvio.tv.ui.util.StableMap
 import com.nuvio.tv.ui.util.StableRef
 import com.nuvio.tv.ui.util.asStable
+import com.nuvio.tv.ui.util.contentTextDirection
 import com.nuvio.tv.ui.util.rememberLongPressKeyTracker
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.debounce
@@ -533,7 +534,7 @@ internal fun ModernRowSection(
         }
         Text(
             text = rowTitle,
-            style = rowTitleStyle,
+            style = rowTitleStyle.copy(textDirection = rowTitle.contentTextDirection()),
             color = textColor,
             modifier = textModifier
         )

--- a/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/player/StreamComponents.kt
@@ -59,6 +59,7 @@ import com.nuvio.tv.ui.components.SourceChipStatus
 import com.nuvio.tv.ui.components.SourceStatusFilterChip
 import com.nuvio.tv.ui.components.StreamBadgeChips
 import com.nuvio.tv.ui.theme.NuvioTheme
+import com.nuvio.tv.ui.util.contentTextDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
@@ -161,7 +162,9 @@ internal fun StreamItem(
                 ) {
                     Text(
                         text = streamName,
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            textDirection = streamName.contentTextDirection()
+                        ),
                         color = NuvioTheme.colors.TextPrimary
                     )
 
@@ -185,7 +188,9 @@ internal fun StreamItem(
                     if (description != streamName) {
                         Text(
                             text = description,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                textDirection = description.contentTextDirection()
+                            ),
                             color = NuvioTheme.extendedColors.textSecondary
                         )
                     }
@@ -220,7 +225,9 @@ internal fun StreamItem(
 
                     Text(
                         text = stream.addonName,
-                        style = MaterialTheme.typography.labelSmall,
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            textDirection = stream.addonName.contentTextDirection()
+                        ),
                         color = NuvioTheme.extendedColors.textTertiary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/screens/stream/StreamScreen.kt
@@ -73,6 +73,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import com.nuvio.tv.ui.util.contentTextDirection
 import com.nuvio.tv.ui.util.localizeEpisodeTitle
 import androidx.tv.material3.Border
 import androidx.tv.material3.Card
@@ -1268,7 +1269,9 @@ private fun StreamCard(
 
                 Text(
                     text = streamName,
-                    style = MaterialTheme.typography.titleMedium,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        textDirection = streamName.contentTextDirection()
+                    ),
                     color = NuvioTheme.colors.TextPrimary
                 )
 
@@ -1276,7 +1279,9 @@ private fun StreamCard(
                     if (description.isNotBlank() && description != streamName) {
                         Text(
                             text = description,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                textDirection = description.contentTextDirection()
+                            ),
                             color = NuvioTheme.extendedColors.textSecondary
                         )
                     }
@@ -1317,7 +1322,9 @@ private fun StreamCard(
 
                     Text(
                         text = stream.addonName,
-                        style = MaterialTheme.typography.labelSmall,
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            textDirection = stream.addonName.contentTextDirection()
+                        ),
                         color = NuvioTheme.extendedColors.textTertiary,
                         maxLines = 1
                     )

--- a/app/src/main/java/com/nuvio/tv/ui/util/TextDirectionUtils.kt
+++ b/app/src/main/java/com/nuvio/tv/ui/util/TextDirectionUtils.kt
@@ -7,8 +7,10 @@ import androidx.compose.ui.text.style.TextDirection
  * (Unicode bidi rules P2/P3), independent of the app's ambient UI locale/LayoutDirection.
  */
 fun String.contentTextDirection(): TextDirection {
-    for (char in this) {
-        val directionality = Character.getDirectionality(char)
+    var index = 0
+    while (index < length) {
+        val codePoint = codePointAt(index)
+        val directionality = Character.getDirectionality(codePoint)
         if (directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
             directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC) {
             return TextDirection.Rtl
@@ -16,6 +18,7 @@ fun String.contentTextDirection(): TextDirection {
         if (directionality == Character.DIRECTIONALITY_LEFT_TO_RIGHT) {
             return TextDirection.Ltr
         }
+        index += Character.charCount(codePoint)
     }
     return TextDirection.Ltr
 }


### PR DESCRIPTION
## Summary

Follow-up to the previous content-based text direction fix (#3389).

This PR extends the same fix to:

* Handle descriptions starting with emojis before determining text direction.
* Apply the direction detection fix to additional locations in the app where the same issue was identified.

Each affected location was tested separately to verify that the text direction is detected and rendered correctly.

## Why

The original fix handled text direction based on the content of the description, but descriptions beginning with an emoji could still cause incorrect direction detection.

While reviewing the app, I also identified additional places where the same RTL/LTR issue could occur. This PR applies the same established fix to those locations.

## UI / behavior impact

* Fixes incorrect text direction when descriptions start with emojis.
* Fixes the same RTL/LTR rendering issue in additional affected locations.
* No new UI or feature behavior is introduced.

## Testing

Each affected location was tested independently, including:

* LTR text
* RTL text
* Text beginning with emojis
* Mixed content where applicable

## Breaking changes

None.
