### PR TITLE
fix player treat truncated mkv tails as end of input

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/DefaultEbmlReader.java
@@ -172,7 +172,9 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   private long maybeResyncToNextLevel1Element(ExtractorInput input) throws IOException {
     input.resetPeekPosition();
     while (true) {
-      input.peekFully(scratch, 0, MAX_ID_BYTES);
+      if (!peekFullyOrEnd(input, scratch, MAX_ID_BYTES)) {
+        return C.RESULT_END_OF_INPUT;
+      }
       int varintLength = VarintReader.parseUnsignedVarintLength(scratch[0]);
       if (varintLength != C.LENGTH_UNSET && varintLength <= MAX_ID_BYTES) {
         int potentialId = (int) VarintReader.assembleVarint(scratch, varintLength, false);
@@ -181,7 +183,24 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
           return potentialId;
         }
       }
-      input.skipFully(1);
+      try {
+        input.skipFully(1);
+      } catch (EOFException e) {
+        return C.RESULT_END_OF_INPUT;
+      }
+    }
+  }
+
+  private static boolean peekFullyOrEnd(ExtractorInput input, byte[] target, int length)
+      throws IOException {
+    long streamLength = input.getLength();
+    if (streamLength != C.LENGTH_UNSET && streamLength - input.getPeekPosition() < length) {
+      return false;
+    }
+    try {
+      return input.peekFully(target, 0, length, /* allowEndOfInput= */ true);
+    } catch (EOFException e) {
+      return false;
     }
   }
 

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -60,6 +60,7 @@ import androidx.media3.extractor.text.SubtitleParser;
 import androidx.media3.extractor.text.SubtitleTranscodingExtractorOutput;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -799,6 +800,30 @@ public class MatroskaExtractor implements Extractor {
 
   @Override
   public final int read(ExtractorInput input, PositionHolder seekPosition) throws IOException {
+    try {
+      return readFromInput(input, seekPosition);
+    } catch (EOFException e) {
+      if (sentSeekMap) {
+        Log.w(TAG, "MKV stream ended mid-element after seek map; treating as end of input");
+        return finishReadAtEndOfInput();
+      }
+      throw e;
+    } catch (ParserException e) {
+      if (shouldTreatEbmlErrorAsEndOfInput(input, e)) {
+        Log.w(TAG, "Ignoring truncated MKV tail: " + e.getMessage());
+        return finishReadAtEndOfInput();
+      }
+      throw e;
+    } catch (IllegalStateException e) {
+      if (shouldTreatEbmlErrorAsEndOfInput(input, e)) {
+        Log.w(TAG, "Ignoring truncated MKV tail: " + e.getMessage());
+        return finishReadAtEndOfInput();
+      }
+      throw e;
+    }
+  }
+
+  private int readFromInput(ExtractorInput input, PositionHolder seekPosition) throws IOException {
     haveOutputSample = false;
     boolean continueReading = true;
     while (continueReading && !haveOutputSample) {
@@ -815,18 +840,45 @@ public class MatroskaExtractor implements Extractor {
       }
     }
     if (!continueReading) {
-      if (pendingFinishTracks) {
-        pendingFinishTracks = false;
-        finishTracksElement();
-      }
-      for (int i = 0; i < tracks.size(); i++) {
-        Track track = tracks.valueAt(i);
-        track.assertOutputInitialized();
-        track.outputPendingSampleMetadata();
-      }
-      return Extractor.RESULT_END_OF_INPUT;
+      return finishReadAtEndOfInput();
     }
     return Extractor.RESULT_CONTINUE;
+  }
+
+  private int finishReadAtEndOfInput() throws ParserException {
+    if (pendingFinishTracks) {
+      pendingFinishTracks = false;
+      finishTracksElement();
+    }
+    for (int i = 0; i < tracks.size(); i++) {
+      Track track = tracks.valueAt(i);
+      track.assertOutputInitialized();
+      track.outputPendingSampleMetadata();
+    }
+    return Extractor.RESULT_END_OF_INPUT;
+  }
+
+  private boolean shouldTreatEbmlErrorAsEndOfInput(ExtractorInput input, Throwable error) {
+    if (!sentSeekMap || !isTruncatedEbmlTailError(error)) {
+      return false;
+    }
+    long length = input.getLength();
+    long position = input.getPosition();
+    if (length == C.LENGTH_UNSET || length <= 0L) {
+      return true;
+    }
+    long remaining = Math.max(0L, length - position);
+    long tailBudget = Math.max(8L * 1024L * 1024L, length / 50L);
+    return remaining <= tailBudget;
+  }
+
+  private static boolean isTruncatedEbmlTailError(Throwable error) {
+    String message = error.getMessage();
+    if (message == null) {
+      return false;
+    }
+    return message.contains("No valid varint length mask found")
+        || message.contains("EBML lacing sample size out of range");
   }
 
   /**

--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/VarintReader.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/VarintReader.java
@@ -16,6 +16,7 @@
 package com.nuvio.tv.core.player.dvmkv;
 
 import androidx.media3.common.C;
+import androidx.media3.common.ParserException;
 import androidx.media3.extractor.ExtractorInput;
 import java.io.EOFException;
 import java.io.IOException;
@@ -67,7 +68,7 @@ import java.io.IOException;
    *     should be considered an error, causing an {@link EOFException} to be thrown.
    * @param removeLengthMask Removes the variable-length integer length mask from the value.
    * @param maximumAllowedLength Maximum allowed length of the variable integer to be read.
-   * @return The read value, or {@link C#RESULT_END_OF_INPUT} if {@code allowEndOfStream} is true
+   * @return The read value, or {@link C#RESULT_END_OF_INPUT} if {@code allowEndOfInput} is true
    *     and the end of the input was encountered, or {@link C#RESULT_MAX_LENGTH_EXCEEDED} if the
    *     length of the varint exceeded maximumAllowedLength.
    * @throws IOException If an error occurs reading from the input.
@@ -86,7 +87,12 @@ import java.io.IOException;
       int firstByte = scratch[0] & 0xFF;
       length = parseUnsignedVarintLength(firstByte);
       if (length == C.LENGTH_UNSET) {
-        throw new IllegalStateException("No valid varint length mask found");
+        state = STATE_BEGIN_READING;
+        if (allowEndOfInput) {
+          return C.RESULT_MAX_LENGTH_EXCEEDED;
+        }
+        throw ParserException.createForMalformedContainer(
+            "No valid varint length mask found", /* cause= */ null);
       }
       state = STATE_READ_CONTENTS;
     }

--- a/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaTruncatedTailTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaTruncatedTailTest.kt
@@ -1,0 +1,204 @@
+package com.nuvio.tv.core.player.dvmkv
+
+import androidx.media3.common.C
+import androidx.media3.common.ParserException
+import androidx.media3.extractor.ExtractorInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.EOFException
+import java.io.IOException
+
+class MatroskaTruncatedTailTest {
+
+    @Test
+    fun `zero byte with allowEndOfInput returns max length exceeded instead of crashing`() {
+        val reader = VarintReader()
+        val result = reader.readUnsignedVarint(
+            FakeExtractorInput(byteArrayOf(0x00)),
+            /* allowEndOfInput = */ true,
+            /* removeLengthMask = */ false,
+            /* maximumAllowedLength = */ 4
+        )
+        assertEquals(C.RESULT_MAX_LENGTH_EXCEEDED.toLong(), result)
+    }
+
+    @Test
+    fun `zero byte without allowEndOfInput is a malformed container`() {
+        val reader = VarintReader()
+        try {
+            reader.readUnsignedVarint(
+                FakeExtractorInput(byteArrayOf(0x00)),
+                /* allowEndOfInput = */ false,
+                /* removeLengthMask = */ true,
+                /* maximumAllowedLength = */ 8
+            )
+            throw AssertionError("expected ParserException")
+        } catch (e: ParserException) {
+            assertTrue(e.message.orEmpty().contains("No valid varint length mask found"))
+        }
+    }
+
+    @Test
+    fun `trailing zeros after a complete element end the stream`() {
+        val data = byteArrayOf(0xEC.toByte(), 0x80.toByte()) + ByteArray(32)
+        val reader = DefaultEbmlReader()
+        val processor = RecordingProcessor()
+        reader.init(processor)
+
+        val input = FakeExtractorInput(data)
+        assertFalse(reader.read(input))
+        assertEquals(listOf(0xEC), processor.seenIds)
+    }
+
+    @Test
+    fun `resync skips zero padding to the next level-1 cluster`() {
+        val clusterId = byteArrayOf(0x1F, 0x43, 0xB6.toByte(), 0x75)
+        val data = byteArrayOf(0xEC.toByte(), 0x80.toByte()) +
+            ByteArray(8) +
+            clusterId +
+            byteArrayOf(0x80.toByte())
+        val reader = DefaultEbmlReader()
+        val processor = RecordingProcessor(level1Ids = setOf(0x1F43B675))
+        reader.init(processor)
+
+        val input = FakeExtractorInput(data)
+        assertFalse(reader.read(input))
+        assertEquals(listOf(0xEC, 0x1F43B675), processor.seenIds)
+    }
+
+    private class FakeExtractorInput(private val data: ByteArray) : ExtractorInput {
+        private var position = 0
+        private var peekPosition = 0
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (position >= data.size) return C.RESULT_END_OF_INPUT
+            val toRead = minOf(length, data.size - position)
+            System.arraycopy(data, position, buffer, offset, toRead)
+            position += toRead
+            peekPosition = position
+            return toRead
+        }
+
+        override fun readFully(target: ByteArray, offset: Int, length: Int, allowEndOfInput: Boolean): Boolean {
+            if (length == 0) return true
+            if (position >= data.size) {
+                if (allowEndOfInput) return false
+                throw EOFException()
+            }
+            if (position + length > data.size) {
+                throw EOFException()
+            }
+            System.arraycopy(data, position, target, offset, length)
+            position += length
+            peekPosition = position
+            return true
+        }
+
+        override fun readFully(target: ByteArray, offset: Int, length: Int) {
+            readFully(target, offset, length, false)
+        }
+
+        override fun skip(length: Int): Int {
+            if (position >= data.size) return C.RESULT_END_OF_INPUT
+            val skipped = minOf(length, data.size - position)
+            position += skipped
+            peekPosition = position
+            return skipped
+        }
+
+        override fun skipFully(length: Int, allowEndOfInput: Boolean): Boolean {
+            if (position + length > data.size) {
+                if (allowEndOfInput && position >= data.size) return false
+                throw EOFException()
+            }
+            position += length
+            peekPosition = position
+            return true
+        }
+
+        override fun skipFully(length: Int) {
+            skipFully(length, false)
+        }
+
+        override fun peek(target: ByteArray, offset: Int, length: Int): Int {
+            if (peekPosition >= data.size) return C.RESULT_END_OF_INPUT
+            val toPeek = minOf(length, data.size - peekPosition)
+            System.arraycopy(data, peekPosition, target, offset, toPeek)
+            peekPosition += toPeek
+            return toPeek
+        }
+
+        override fun peekFully(target: ByteArray, offset: Int, length: Int, allowEndOfInput: Boolean): Boolean {
+            if (peekPosition + length > data.size) {
+                if (allowEndOfInput && peekPosition >= data.size) return false
+                throw EOFException()
+            }
+            System.arraycopy(data, peekPosition, target, offset, length)
+            peekPosition += length
+            return true
+        }
+
+        override fun peekFully(target: ByteArray, offset: Int, length: Int) {
+            peekFully(target, offset, length, false)
+        }
+
+        override fun advancePeekPosition(length: Int, allowEndOfInput: Boolean): Boolean {
+            if (peekPosition + length > data.size) {
+                if (allowEndOfInput && peekPosition >= data.size) return false
+                throw EOFException()
+            }
+            peekPosition += length
+            return true
+        }
+
+        override fun advancePeekPosition(length: Int) {
+            advancePeekPosition(length, false)
+        }
+
+        override fun resetPeekPosition() {
+            peekPosition = position
+        }
+
+        override fun getPeekPosition(): Long = peekPosition.toLong()
+
+        override fun getPosition(): Long = position.toLong()
+
+        override fun getLength(): Long = data.size.toLong()
+
+        override fun <E : Throwable> setRetryPosition(position: Long, e: E) {
+            this.position = position.toInt()
+            peekPosition = this.position
+            throw e
+        }
+    }
+
+    private class RecordingProcessor(
+        private val level1Ids: Set<Int> = emptySet()
+    ) : EbmlProcessor {
+        val seenIds = mutableListOf<Int>()
+
+        override fun getElementType(id: Int): Int {
+            seenIds += id
+            return EbmlProcessor.ELEMENT_TYPE_UNKNOWN
+        }
+
+        override fun isLevel1Element(id: Int) = id in level1Ids
+
+        override fun startMasterElement(id: Int, contentPosition: Long, contentSize: Long) = Unit
+
+        override fun endMasterElement(id: Int) = Unit
+
+        override fun integerElement(id: Int, value: Long) = Unit
+
+        override fun floatElement(id: Int, value: Double) = Unit
+
+        override fun stringElement(id: Int, value: String) = Unit
+
+        @Throws(IOException::class)
+        override fun binaryElement(id: Int, contentsSize: Int, input: ExtractorInput) {
+            input.skipFully(contentsSize)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stop ExoPlayer from failing progressive MKV playback with `No valid varint length mask found` (`ERROR_CODE_IO_UNSPECIFIED`) when the stream tail is truncated or zero-padded.

The vendored Matroska/EBML reader treated a `0x00` byte where an element ID was expected as a fatal `IllegalStateException`. After a late seek this aborted an otherwise working session. Invalid varints now resync or end the stream, and near-EOF parse errors after the seek map is sent are treated as end of input.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

A valid 4K HEVC MKV could play and seek, then die near the end of the file. The host served a shorter body than the advertised size, so the last cluster or padding was not valid EBML. Media3 wrapped that as an unexpected loader error, released the decoders, and showed a playback error even when most of the episode was already buffered.

## Issue or approval

Fixes NUV-199C74

## Reproduction steps

1. Use the internal ExoPlayer engine (not MPV).
2. Open WondLa S02E04 and play the 4K HDR10 MKV (about 3.25 GB), not the DV/HDR10+ variant.
3. Seek to 21:03 (episode length about 21:50) and wait 10–15 seconds without leaving the player.
4. Before this change, playback hits `Unexpected IllegalStateException: No valid varint length mask found`.
5. After this change, playback continues or ends instead of showing that error.

The issue was reproduced on this stream and confirmed fixed.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No player UI, settings, engine failover, or HTTP/cache changes. Only the vendored Matroska/EBML path used by ExoPlayer.

## Testing

- Unit tests: `com.nuvio.tv.core.player.dvmkv.MatroskaTruncatedTailTest` (`testFullDebugUnitTest`).
- Manual: issue reproduced on the original 4K MKV by seeking to 21:03, then verified fixed on the same stream and seek. Playback no longer errors at the truncated tail.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

NUV-199C74
