### PR TITLE
fix player follow nested mkv seekhead so exoplayer can seek

### DIFF
--- a/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
+++ b/app/src/main/java/com/nuvio/tv/core/player/dvmkv/MatroskaExtractor.java
@@ -243,6 +243,7 @@ public class MatroskaExtractor implements Extractor {
   private static final int MAX_EARLY_DTS_SCAN_BYTES = 8 * 1024 * 1024;
   private static final int MAX_EARLY_DTS_FRAME_BYTES = 256 * 1024;
   private static final int MAX_EBML_HEADER_SIZE = 12; // 4-byte id + 8-byte data size.
+  private static final int MAX_SEEK_HEAD_FOLLOWS = 4;
 
   private static final String DOC_TYPE_MATROSKA = "matroska";
   private static final String DOC_TYPE_WEBM = "webm";
@@ -616,6 +617,9 @@ public class MatroskaExtractor implements Extractor {
   private int primarySeekTrackNumber = C.INDEX_UNSET;
   private boolean seekForCues;
   private long cuesContentPosition = C.INDEX_UNSET;
+  private long pendingSeekHeadPosition = C.INDEX_UNSET;
+  private boolean seekForSeekHead;
+  private int followedSeekHeadCount;
   private long seekPositionAfterBuildingCues = C.INDEX_UNSET;
   private long clusterTimecodeUs = C.TIME_UNSET;
 
@@ -999,6 +1003,12 @@ public class MatroskaExtractor implements Extractor {
           if (seekForCuesEnabled && cuesContentPosition != C.INDEX_UNSET) {
             // We know where the Cues element is located. Seek to request it.
             seekForCues = true;
+          } else if (shouldFollowNestedSeekHead(
+              seekForCuesEnabled,
+              cuesContentPosition,
+              pendingSeekHeadPosition,
+              followedSeekHeadCount)) {
+            seekForSeekHead = true;
           } else {
             // We don't know where the Cues element is located. It's most likely omitted. Allow
             // playback, but disable seeking.
@@ -1058,7 +1068,17 @@ public class MatroskaExtractor implements Extractor {
         }
         if (seekEntryId == ID_CUES) {
           cuesContentPosition = seekEntryPosition;
+        } else if (seekEntryId == ID_SEEK_HEAD) {
+          pendingSeekHeadPosition =
+              nextNestedSeekHeadPosition(
+                  seekEntryPosition,
+                  cuesContentPosition,
+                  pendingSeekHeadPosition,
+                  seekPositionAfterBuildingCues);
         }
+        break;
+      case ID_SEEK_HEAD:
+        maybeFollowPendingIndexAfterSeekHead();
         break;
       case ID_CUES:
         if (!sentSeekMap) {
@@ -1220,7 +1240,9 @@ public class MatroskaExtractor implements Extractor {
     int firstAudioTrackNumber = C.INDEX_UNSET;
 
     // If we're not going to seek for cues, output the formats immediately.
-    boolean mayBeSendFormatsEarly = !seekForCuesEnabled || cuesContentPosition == C.INDEX_UNSET;
+    boolean mayBeSendFormatsEarly =
+        !seekForCuesEnabled
+            || (cuesContentPosition == C.INDEX_UNSET && pendingSeekHeadPosition == C.INDEX_UNSET);
 
     for (int i = 0; i < tracks.size(); i++) {
       Track trackItem = tracks.valueAt(i);
@@ -2537,8 +2559,30 @@ public class MatroskaExtractor implements Extractor {
    * @return Whether the seek position was updated.
    */
   private boolean maybeSeekForCues(PositionHolder seekPosition, long currentPosition) {
+    if (seekForSeekHead) {
+      long target = pendingSeekHeadPosition;
+      pendingSeekHeadPosition = C.INDEX_UNSET;
+      seekForSeekHead = false;
+      if (target < 0
+          || target == currentPosition
+          || followedSeekHeadCount >= MAX_SEEK_HEAD_FOLLOWS) {
+        if (!sentSeekMap) {
+          checkNotNull(extractorOutput).seekMap(new SeekMap.Unseekable(durationUs));
+          sentSeekMap = true;
+        }
+        return false;
+      }
+      if (seekPositionAfterBuildingCues == C.INDEX_UNSET) {
+        seekPositionAfterBuildingCues = currentPosition;
+      }
+      seekPosition.position = target;
+      followedSeekHeadCount++;
+      return true;
+    }
     if (seekForCues) {
-      seekPositionAfterBuildingCues = currentPosition;
+      if (seekPositionAfterBuildingCues == C.INDEX_UNSET) {
+        seekPositionAfterBuildingCues = currentPosition;
+      }
       seekPosition.position = cuesContentPosition;
       seekForCues = false;
       return true;
@@ -2551,6 +2595,47 @@ public class MatroskaExtractor implements Extractor {
       return true;
     }
     return false;
+  }
+
+  private void maybeFollowPendingIndexAfterSeekHead() {
+    if (sentSeekMap || !seekForCuesEnabled || seekPositionAfterBuildingCues == C.INDEX_UNSET) {
+      return;
+    }
+    if (cuesContentPosition != C.INDEX_UNSET) {
+      seekForCues = true;
+    } else if (shouldFollowNestedSeekHead(
+        seekForCuesEnabled, cuesContentPosition, pendingSeekHeadPosition, followedSeekHeadCount)) {
+      seekForSeekHead = true;
+    } else {
+      extractorOutput.seekMap(new SeekMap.Unseekable(durationUs));
+      sentSeekMap = true;
+    }
+  }
+
+  static boolean shouldFollowNestedSeekHead(
+      boolean seekForCuesEnabled,
+      long cuesContentPosition,
+      long pendingSeekHeadPosition,
+      int followedSeekHeadCount) {
+    return seekForCuesEnabled
+        && cuesContentPosition == C.INDEX_UNSET
+        && pendingSeekHeadPosition != C.INDEX_UNSET
+        && followedSeekHeadCount < MAX_SEEK_HEAD_FOLLOWS;
+  }
+
+  static long nextNestedSeekHeadPosition(
+      long position,
+      long cuesContentPosition,
+      long pendingSeekHeadPosition,
+      long seekPositionAfterBuildingCues) {
+    if (position < 0 || position == cuesContentPosition || position == pendingSeekHeadPosition) {
+      return pendingSeekHeadPosition;
+    }
+    if (seekPositionAfterBuildingCues != C.INDEX_UNSET
+        && position <= seekPositionAfterBuildingCues) {
+      return pendingSeekHeadPosition;
+    }
+    return position;
   }
 
   private long scaleTimecodeToUs(long unscaledTimecode) throws ParserException {

--- a/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaNestedSeekHeadTest.kt
+++ b/app/src/test/java/com/nuvio/tv/core/player/dvmkv/MatroskaNestedSeekHeadTest.kt
@@ -1,0 +1,88 @@
+package com.nuvio.tv.core.player.dvmkv
+
+import androidx.media3.common.C
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MatroskaNestedSeekHeadTest {
+
+    @Test
+    fun `first SeekHead that only names another SeekHead is followed`() {
+        val pendingTrailingSeekHead = 2_837_202_547L
+        assertTrue(
+            MatroskaExtractor.shouldFollowNestedSeekHead(
+                true,
+                UNSET,
+                pendingTrailingSeekHead,
+                0,
+            ),
+        )
+    }
+
+    @Test
+    fun `direct Cues pointer is preferred over a nested SeekHead`() {
+        assertFalse(
+            MatroskaExtractor.shouldFollowNestedSeekHead(
+                true,
+                2_837_048_772L,
+                2_837_202_547L,
+                0,
+            ),
+        )
+    }
+
+    @Test
+    fun `missing Cues and missing trailing SeekHead is not followed`() {
+        assertFalse(
+            MatroskaExtractor.shouldFollowNestedSeekHead(
+                true,
+                UNSET,
+                UNSET,
+                0,
+            ),
+        )
+    }
+
+    @Test
+    fun `nested SeekHead hop is capped`() {
+        assertFalse(
+            MatroskaExtractor.shouldFollowNestedSeekHead(
+                true,
+                UNSET,
+                100L,
+                4,
+            ),
+        )
+    }
+
+    @Test
+    fun `records trailing SeekHead and ignores the already-parsed first one`() {
+        val firstSeekHead = 52L
+        val cluster = 5_843L
+        val trailingSeekHead = 2_837_202_547L
+
+        val afterFirst =
+            MatroskaExtractor.nextNestedSeekHeadPosition(
+                trailingSeekHead,
+                UNSET,
+                UNSET,
+                UNSET,
+            )
+        assertEquals(trailingSeekHead, afterFirst)
+
+        val afterTrailingPointsBack =
+            MatroskaExtractor.nextNestedSeekHeadPosition(
+                firstSeekHead,
+                UNSET,
+                trailingSeekHead,
+                cluster,
+            )
+        assertEquals(trailingSeekHead, afterTrailingPointsBack)
+    }
+
+    companion object {
+        private val UNSET = C.INDEX_UNSET.toLong()
+    }
+}


### PR DESCRIPTION
## Summary

ExoPlayer treated some progressive MKV files as unseekable when the first SeekHead only pointed at a second SeekHead at EOF. Seeking forwards then jumped back to 0:00. The extractor now follows that nested SeekHead, loads Cues, and keeps the file seekable.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Translation/localization only
- [x] Critical bug fix

<!-- For translation/localization PRs: check the first box. In the "Reproduction steps" section write: "No reproduction steps - localization-only update." -->

## Why

mkvmerge-style files often store a tiny first SeekHead that only names another SeekHead after the first Cluster. Stock MatroskaExtractor never followed that pointer, so it published an unseekable SeekMap even though Cues and duration existed. On the internal player, a forward seek then restarted playback from the beginning instead of moving ahead.

## Issue or approval

Fixes #3438 #3233

## Reproduction steps

1. Open a series episode in the internal ExoPlayer (the report used Vigil S2E1; the same failure happens on progressive MKV where the first SeekHead only points at a trailing SeekHead).
2. Start playback and wait until video is running.
3. Press Right on the remote to seek forwards.
4. Before this fix: position returns to the start of the video.
5. After this fix: playback continues from the seek target.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, feature requests, UI changes, refactors, and other non-critical changes may be closed or deferred without review while NuvioTV is being prepared for a stable release.

## Scope boundaries

Does not change HLS/DASH/MP4 seeking, MPV, or HTTP Range handling. Extra EOF hops run only when the first SeekHead omits Cues and names another SeekHead. No player UI, settings, or overlay chrome were added.

## Testing

Unit tests:

```
./gradlew :app:testFullDebugUnitTest --tests com.nuvio.tv.core.player.dvmkv.MatroskaNestedSeekHeadTest
```

Covered cases:

- First SeekHead that only names a trailing SeekHead is followed
- Direct Cues pointer is still preferred
- Missing Cues and missing trailing SeekHead stays unseekable
- Nested SeekHead hops are capped
- Pointer back to the already-parsed first SeekHead is ignored

Manual: play a progressive MKV in the internal player, seek forwards with the remote, confirm position advances instead of restarting at 0:00.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #3438 #3233
