### PR TITLE
docs(settings): clarify external subtitle forwarding and addon tracking

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2823,7 +2823,6 @@
     <string name="playback_cache_vod_sub">حفظ البايتات المنزلة على القرص للبث الحالي. يمدد التنقل الفوري للخلف أبعد من المخزون الخلفي في الذاكرة ويصمد أمام انقطاعات الشبكة القصيرة. ينطبق فقط على البثوث التدريجية (ليس HLS/DASH).</string>
     <string name="playback_estimated_memory_usage">الاستخدام التقديري للذاكرة: %1$d / %2$d م.ب</string>
     <string name="playback_external_forward_subtitles">تمرير الترجمات إلى المشغل الخارجي</string>
-    <string name="playback_external_forward_subtitles_sub">جلب الترجمات بلغتك المفضلة من الإضافات وتمريرها إلى المشغل الخارجي.</string>
     <string name="playback_external_send_skip_segments">إرسال طوابع وقت المقدمة والخاتمة</string>
     <string name="playback_external_send_skip_segments_sub">تمرير طوابع وقت تخطي المقدمة/الخاتمة إلى المشغل الخارجي للتخطي التلقائي. يعمل فقط في المشغلات الداعمة له؛ والمشغلات الأخرى تتجاهله.</string>
     <string name="playback_net_chunk_size">حجم القطعة</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -715,7 +715,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Cambiar automáticamente de motor en caso de error al iniciar</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Si falla el inicio del stream, alterna automáticamente entre ExoPlayer y libmpv.</string>
     <string name="playback_external_forward_subtitles">Enviar subtítulos al reproductor externo</string>
-    <string name="playback_external_forward_subtitles_sub">Obtén subtítulos en tu idioma preferido desde los addons y envíalos al reproductor externo.</string>
     <string name="playback_external_send_skip_segments">Enviar marcas de tiempo de introducción y créditos finales</string>
     <string name="playback_external_send_skip_segments_sub">Envía las marcas de tiempo de omisión de introducción y créditos finales al reproductor externo para omitirlas automáticamente. Solo funciona en reproductores compatibles; los demás las ignorarán.</string>
     <string name="playback_section_audio">Audio y video</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -742,7 +742,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Automatski promeni mehanizam pri grešci pokretanja</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Ako pokretanje strima ne uspe, automatski prebaci između ExoPlayer-a i libmpv-a.</string>
     <string name="playback_external_forward_subtitles">Prosledi titlove eksternom plejeru</string>
-    <string name="playback_external_forward_subtitles_sub">Preuzmi titlove na željenom jeziku sa dodataka i prosledi ih eksternom plejeru.</string>
     <string name="playback_external_send_skip_segments">Pošalji vremenske oznake uvoda i odjave</string>
     <string name="playback_external_send_skip_segments_sub">Prosledi razrešene vremenske oznake uvoda/odjave eksternom plejeru za automatsko preskakanje. Radi samo u plejerima koji to podržavaju; ostali plejeri to ignorišu.</string>
     <string name="playback_section_audio">Zvuk i video</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -578,7 +578,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Автоматично превключване на двигателя при грешка при стартиране</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Ако стартирането на потока се провали, превключи автоматично между ExoPlayer и libmpv.</string>
     <string name="playback_external_forward_subtitles">Препрати субтитри към външен плейър</string>
-    <string name="playback_external_forward_subtitles_sub">Извлечи субтитри на предпочитания език от добавките и ги предай на външния плейър.</string>
     <string name="playback_section_audio">Аудио и видео</string>
     <string name="playback_section_audio_desc">Контроли за аудио и съвместимост на видео.</string>
     <string name="playback_section_subtitles">Субтитри</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -625,7 +625,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Automaticky přepnout engine při chybě spuštění</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Pokud spuštění streamu selže, automaticky přepnout mezi ExoPlayer a libmpv.</string>
     <string name="playback_external_forward_subtitles">Předávat titulky externímu přehrávači</string>
-    <string name="playback_external_forward_subtitles_sub">Načíst titulky v preferovaném jazyce z doplňků a předat je externímu přehrávači.</string>
     <string name="playback_external_send_skip_segments">Odesílat časové značky úvodu a závěru</string>
     <string name="playback_external_send_skip_segments_sub">Předat vypočtené časové značky pro přeskočení úvodu/závěru externímu přehrávači pro automatické přeskakování. Funguje jen v přehrávačích, které to podporují; ostatní ho ignorují.</string>
     <string name="playback_section_audio">Audio a video</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -582,7 +582,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Skift motor automatisk ved opstartsfejl</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Hvis stream-opstart fejler, skift automatisk mellem ExoPlayer og libmpv.</string>
     <string name="playback_external_forward_subtitles">Videresend undertekster til ekstern afspiller</string>
-    <string name="playback_external_forward_subtitles_sub">Hent undertekster på dit foretrukne sprog fra addons og send dem til den eksterne afspiller.</string>
     <string name="playback_section_audio">Lyd &amp; video</string>
     <string name="playback_section_audio_desc">Lydkontrol og videokompatibilitet.</string>
     <string name="playback_section_subtitles">Undertekster</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2704,7 +2704,6 @@
   <string name="trakt_library_error_fetch_list_items">Αποτυχία ανάκτησης στοιχείων λίστας</string>
   <!-- Missing Greek locale parity -->
   <string name="playback_external_forward_subtitles">Προώθηση υποτίτλων σε εξωτερικό player</string>
-  <string name="playback_external_forward_subtitles_sub">Ανάκτηση υποτίτλων στην προτιμώμενη γλώσσα σας από πρόσθετα και αποστολή τους στον εξωτερικό player.</string>
   <string name="video_section">Βίντεο</string>
   <string name="dv7_handling_title">Χειρισμός Dolby Vision Profile 7</string>
   <string name="dv7_handling_dialog_subtitle">Επιλέξτε πώς θα γίνεται επεξεργασία των ροών DV Profile 7 κατά την αναπαραγωγή.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -522,7 +522,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Changement auto du moteur en cas d’erreur au démarrage</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Si le démarrage du flux échoue, bascule automatiquement entre ExoPlayer et libmpv.</string>
     <string name="playback_external_forward_subtitles">Transférer les sous-titres au lecteur externe</string>
-    <string name="playback_external_forward_subtitles_sub">Récupère les sous-titres dans votre langue préférée depuis les addons et les transmet au lecteur externe.</string>
     <string name="playback_external_send_skip_segments">Envoyer les horodatages d’intro et d’outro</string>
     <string name="playback_external_send_skip_segments_sub">Transmet les horodatages de saut d’intro/outro résolus au lecteur externe pour le saut automatique. Ne fonctionne que dans les lecteurs compatibles ; les autres l’ignorent.</string>
     <string name="playback_section_audio">Audio et vidéo</string>

--- a/app/src/main/res/values-hu/string.xml
+++ b/app/src/main/res/values-hu/string.xml
@@ -665,7 +665,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Automatikus motorváltás indítási hiba esetén</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Ha a stream indítása sikertelen, váltson automatikusan az ExoPlayer és libmpv között.</string>
     <string name="playback_external_forward_subtitles">Feliratok továbbítása külső lejátszónak</string>
-    <string name="playback_external_forward_subtitles_sub">Töltsd le a feliratokat az előnyben részesített nyelven a bővítményekből, és add át a külső lejátszónak.</string>
     <string name="playback_external_send_skip_segments">Bevezető és záró időbélyegek küldése</string>
     <string name="playback_external_send_skip_segments_sub">Átadja a feloldott bevezető/záró átugrási időbélyegeket a külső lejátszónak az automatikus átugráshoz. Csak az ezt támogató lejátszókban működik, a többi figyelmen kívül hagyja.</string>
     <string name="playback_section_audio">Hang és előzetes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -715,7 +715,6 @@
 <string name="playback_auto_switch_internal_player_on_error">Cambio motore automatico su errore di avvio</string>
 <string name="playback_auto_switch_internal_player_on_error_sub">Se l\'avvio del flusso fallisce, passa automaticamente tra ExoPlayer e libmpv.</string>
 <string name="playback_external_forward_subtitles">Inoltra i sottotitoli al player esterno</string>
-<string name="playback_external_forward_subtitles_sub">Recupera dagli add-on i sottotitoli nella tua lingua preferita e passali al player esterno.</string>
 <string name="playback_external_send_skip_segments">Invia i timestamp di intro e outro</string>
 <string name="playback_external_send_skip_segments_sub">Passa al player esterno i timestamp risolti per saltare intro/outro e attivare l\'auto-skip. Funziona solo nei player che lo supportano; gli altri lo ignorano.</string>
 <string name="playback_section_audio">Audio &amp; Video</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -703,7 +703,6 @@
     <string name="playback_auto_switch_internal_player_on_error">החלף מנוע אוטומטית בשגיאת הפעלה</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">אם הפעלת המקור נכשלת, החלף אוטומטית בין ExoPlayer ל-Libmpv</string>
     <string name="playback_external_forward_subtitles">העבר כתוביות לנגן חיצוני</string>
-    <string name="playback_external_forward_subtitles_sub">משוך כתוביות בשפה המועדפת שלך מתוספים והעבר אותן לנגן החיצוני.</string>
     <string name="playback_external_send_skip_segments">שלח חותמות זמן של פתיח וסיום</string>
     <string name="playback_external_send_skip_segments_sub">העברת חותמות זמן של דילוגים של פתיחה/סיום לנגן החיצוני לצורך דילוג אוטומטי. זה עובד רק בנגנים שתומכים בכך; נגנים אחרים מתעלמים ממנו.</string>
     <string name="playback_section_audio">שמע ווידאו</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -586,7 +586,6 @@
     <string name="playback_auto_switch_internal_player_on_error">起動エラー時にエンジンを自動切り替え</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">ストリーム起動に失敗した場合、ExoPlayerとlibmpvを自動で切り替えます。</string>
     <string name="playback_external_forward_subtitles">外部プレーヤーに字幕を転送</string>
-    <string name="playback_external_forward_subtitles_sub">アドオンから優先言語の字幕を取得し、外部プレーヤーに渡します。</string>
     <string name="playback_section_audio">音声と映像</string>
     <string name="playback_section_audio_desc">音声設定と映像互換性</string>
     <string name="playback_section_subtitles">字幕</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -731,7 +731,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Engine automatisch wisselen bij opstartfout</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Als het starten van een stream mislukt, wissel dan automatisch tussen ExoPlayer en libmpv.</string>
     <string name="playback_external_forward_subtitles">Ondertiteling doorsturen naar externe speler</string>
-    <string name="playback_external_forward_subtitles_sub">Haal ondertiteling in je voorkeurstaal op bij add-ons en geef die door aan de externe speler.</string>
     <string name="playback_external_send_skip_segments">Tijdstempels van intro en outro versturen</string>
     <string name="playback_external_send_skip_segments_sub">Geef de gevonden tijdstempels voor intro/outro door aan de externe speler voor automatisch overslaan. Werkt alleen in spelers die dit ondersteunen; andere spelers negeren het.</string>
     <string name="playback_section_audio">Audio &amp; video</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1504,7 +1504,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Automatyczne przełączanie silnika przy błędzie</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Jeśli uruchomienie strumienia się nie powiedzie, automatycznie przełącz między ExoPlayer a libmpv.</string>
     <string name="playback_external_forward_subtitles">Przekazuj napisy do zewnętrznego odtwarzacza</string>
-    <string name="playback_external_forward_subtitles_sub">Pobierz napisy w preferowanym języku z dodatków i przekaż je do zewnętrznego odtwarzacza.</string>
     <string name="playback_engine_exoplayer_desc">Najlepsza kompatybilność z funkcjami Nuvio.</string>
     <string name="playback_engine_mvplayer_desc">Używa libmpv z kontrolkami Nuvio OSD. Eksperymentalny.</string>
     <string name="player_engine_switching_title">Przełączanie silnika odtwarzacza</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -738,7 +738,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Alternar motor em erro inicial</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Se falhar, alternar ExoPlayer/libmpv</string>
     <string name="playback_external_forward_subtitles">Enviar legendas ao player externo</string>
-    <string name="playback_external_forward_subtitles_sub">Carrega automaticamente as legendas no seu idioma quando você escolhe assistir usando outro aplicativo de vídeo.</string>
     <string name="playback_external_send_skip_segments">Enviar marcadores de tempo de introdução e créditos</string>
     <string name="playback_external_send_skip_segments_sub">Envia os marcadores de tempo de introdução/créditos para o player externo para pular automaticamente. Funciona apenas em players compatíveis; outros ignorarão essa função.</string>
     <string name="playback_section_audio">Áudio e Vídeo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -565,7 +565,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Mudar automaticamente de motor em caso de erro ao iniciar</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Se o início do stream falhar, alterna entre o ExoPlayer e a libmpv automaticamente.</string>
     <string name="playback_external_forward_subtitles">Enviar legendas para o leitor externo</string>
-    <string name="playback_external_forward_subtitles_sub">Obtém legendas no teu idioma preferido a partir dos addons e envia-as para o leitor externo.</string>
     <string name="playback_section_audio">Áudio e vídeo</string>
     <string name="playback_section_audio_desc">Controlos de áudio e compatibilidade de vídeo.</string>
     <string name="playback_section_subtitles">Legendas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2066,7 +2066,6 @@
     <string name="auto_skip_outro">Аутро / Эндинг</string>
     <string name="auto_skip_outro_sub">Автоматически пропускать аутро и эндинги аниме.</string>
     <string name="playback_external_forward_subtitles">Передавать субтитры во внешний плеер</string>
-    <string name="playback_external_forward_subtitles_sub">Получать субтитры на предпочитаемом языке из аддонов и передавать во внешний плеер.</string>
     <string name="playback_external_send_skip_segments">Передавать метки времени интро и титров</string>
     <string name="playback_external_send_skip_segments_sub">Передавать во внешний плеер найденные метки времени интро/титров для автопропуска. Работает только в плеерах с поддержкой этой функции; остальные плееры её игнорируют.</string>
     <string name="playback_resolution_matching_unsupported_sub">Дисплей сообщает только одно разрешение; подбор может не иметь эффекта.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -2532,7 +2532,6 @@
 <string name="supporters_contributors_donation_progress_remaining">Po 100%, ďalšia podpora ide na vývoj.</string>
 <string name="supporters_contributors_loading_donation_progress">Načítavanie pokroku financovania...</string>
 <string name="playback_external_forward_subtitles">Posielaj titulky do externého prehrávača</string>
-<string name="playback_external_forward_subtitles_sub">Načítaj titulky v tvojom preferovanom jazyku z doplnkov a posielaj ich do externého prehrávača.</string>
 <string name="playback_external_send_skip_segments">Posielaj časové značky úvodu a záveru</string>
 <string name="playback_external_send_skip_segments_sub">Posielaj vyriešené časové značky preskakovania úvodu/záveru do externého prehrávača na automatické preskakovanie. Funguje iba v prehrávačoch, ktoré to podporujú; ostatné prehrávače to ignorujú.</string>
 <string name="video_section">Video</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -649,7 +649,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Ndërro automatikisht motorin në rast gabimi gjatë nisjes</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Nëse nisja e transmetimit dështon, ndërro automatikisht midis ExoPlayer dhe libmpv.</string>
     <string name="playback_external_forward_subtitles">Dërgo titrat te luajtësi i jashtëm</string>
-    <string name="playback_external_forward_subtitles_sub">Merr titrat në gjuhën e preferuar nga shtesat dhe dërgoji te luajtësi i jashtëm.</string>
     <string name="playback_external_send_skip_segments">Dërgo kohëshënuesit e hyrjes dhe daljes</string>
     <string name="playback_external_send_skip_segments_sub">Dërgo kohëshënuesit e përcaktuar për kapërcimin e hyrjes/daljes te luajtësi i jashtëm për kapërcim automatik. Funksionon vetëm në luajtësit që e mbështesin; luajtësit e tjerë e shpërfillin.</string>
     <string name="playback_section_audio">Audio dhe video</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -694,7 +694,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Başlangıç hatasında motoru otomatik değiştir</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Yayın başlarken hata olursa ExoPlayer ile libmpv arasında otomatik geçiş yap.</string>
     <string name="playback_external_forward_subtitles">Altyazıları harici oynatıcıya aktar</string>
-    <string name="playback_external_forward_subtitles_sub">Altyazıları tercih ettiğiniz dilde eklentilerden çekip harici oynatıcıya gönderir.</string>
     <string name="playback_external_send_skip_segments">Açılış ve kapanış zaman damgalarını gönder</string>
     <string name="playback_external_send_skip_segments_sub">Bulunan açılış/kapanış atlama zamanlarını otomatik atlama için harici oynatıcıya iletir. Bunu destekleyen oynatıcılarda çalışır; diğerleri yok sayar.</string>
     <string name="playback_section_audio">Ses &amp; Video</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -583,7 +583,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Авто-перемикання рушія при помилці запуску</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Якщо запуск потоку не вдався, автоматично перемикатися між ExoPlayer та libmpv.</string>
     <string name="playback_external_forward_subtitles">Передавати субтитри у зовнішній плеєр</string>
-    <string name="playback_external_forward_subtitles_sub">Отримувати субтитри бажаною мовою з адонів та передавати у зовнішній плеєр.</string>
     <string name="playback_section_audio">Аудіо та відео</string>
     <string name="playback_section_audio_desc">Налаштування аудіо та сумісність відео.</string>
     <string name="playback_section_subtitles">Субтитри</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -740,7 +740,6 @@
     <string name="playback_auto_switch_internal_player_on_error">Tự động chuyển lõi trình phát khi khởi động bị lỗi</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">Nếu khởi động luồng phát thất bại, tự động chuyển đổi giữa ExoPlayer và libmpv.</string>
     <string name="playback_external_forward_subtitles">Chuyển phụ đề sang trình phát bên ngoài</string>
-    <string name="playback_external_forward_subtitles_sub">Tải phụ đề bằng ngôn ngữ ưu tiên từ các tiện ích rồi chuyển sang trình phát bên ngoài.</string>
     <string name="playback_external_send_skip_segments">Gửi mốc thời gian phần giới thiệu và đoạn kết</string>
     <string name="playback_external_send_skip_segments_sub">Gửi mốc thời gian phần giới thiệu và đoạn kết sang trình phát bên ngoài để tự động bỏ qua. Chỉ hỗ trợ trên các trình phát tương thích; trình phát khác sẽ không sử dụng thông tin này.</string>
     <string name="playback_section_audio">Âm thanh &amp; Video</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -621,7 +621,6 @@
     <string name="playback_auto_switch_internal_player_on_error">启动错误时自动切换播放引擎</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">如果流启动失败，自动在 ExoPlayer 和 libmpv 之间切换。</string>
     <string name="playback_external_forward_subtitles">将字幕转发至外部播放器</string>
-    <string name="playback_external_forward_subtitles_sub">从扩展获取您偏好语言的字幕，并传递给外部播放器。</string>
     <string name="playback_external_send_skip_segments">发送片头和片尾时间戳</string>
     <string name="playback_external_send_skip_segments_sub">将解析出的片头/片尾跳过时间戳传递给外部播放器以实现自动跳过。仅适用于支持该功能的播放器；其他播放器会忽略。</string>
     <string name="playback_section_audio">音频与视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -621,7 +621,6 @@
     <string name="playback_auto_switch_internal_player_on_error">啟動錯誤時自動切換播放引擎</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">如果串流啟動失敗，自動在 ExoPlayer 和 libmpv 之間切換。</string>
     <string name="playback_external_forward_subtitles">將字幕轉發至外部播放器</string>
-    <string name="playback_external_forward_subtitles_sub">從擴充套件獲取您偏好語言的字幕，並傳遞給外部播放器。</string>
     <string name="playback_external_send_skip_segments">傳送片頭和片尾時間戳</string>
     <string name="playback_external_send_skip_segments_sub">將解析出的片頭/片尾跳過時間戳傳遞給外部播放器以實現自動跳過。僅適用於支援該功能的播放器；其他播放器會忽略。</string>
     <string name="playback_section_audio">音訊與影片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,7 +740,7 @@
     <string name="playback_auto_switch_internal_player_on_error">Auto-switch engine on startup error</string>
     <string name="playback_auto_switch_internal_player_on_error_sub">If stream startup fails, switch between ExoPlayer and libmpv automatically.</string>
     <string name="playback_external_forward_subtitles">Forward subtitles to external player</string>
-    <string name="playback_external_forward_subtitles_sub">Fetch subtitles in your preferred language from addons and pass them to the external player.</string>
+    <string name="playback_external_forward_subtitles_sub">Fetch addon subtitles in your preferred language and pass them to the external player. Some addons, including AIOMetadata, also need this enabled for watch tracking, even when they return no subtitles.</string>
     <string name="playback_external_send_skip_segments">Send intro and outro timestamps</string>
     <string name="playback_external_send_skip_segments_sub">Pass resolved intro/outro skip timestamps to the external player for auto-skipping. Only works in players that support it; other players ignore it.</string>
     <string name="playback_section_audio">Audio &amp; Video</string>


### PR DESCRIPTION
## Summary

Clarify the description of **Forward subtitles to external player** so users know that some addons, including AIOMetadata, require it for watch tracking even when they return no subtitles.

Only the existing English description string changes. No playback or tracking logic changes.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [x] Other: existing settings help-text clarification; requesting a maintainer exception as a draft.

## Why

I turned this off because I do not use any subtitle addons and assumed it only controlled forwarding subtitle files. Even I had no idea it needed to stay on for AIOMetadata tracking, and I was pulling my hair out trying to figure out why my episodes were no longer updating on AniList/MAL with external players while internal playback still worked. Turning it back on restored tracking.

AIOMetadata uses subtitle requests as a watch-tracking trigger, even when its response contains an empty subtitle list. The previous description only mentioned fetching and forwarding subtitles, so it gave no indication that disabling the setting could also stop addon-based tracking.

This is not a newly introduced tracking regression. It documents an existing dependency that is easy to miss.

## Issue or approval

No linked issue or maintainer exception has been granted. This draft requests consideration for a one-string help-text clarification. It is not being presented as a critical runtime bug fix or a translation to satisfy the current policy.

## Reproduction steps

1. Configure AIOMetadata with AniList/MAL watch tracking and use an external player.
2. Turn off **Forward subtitles to external player**, assuming it is unnecessary when no subtitle files are wanted.
3. Start an episode externally. AIOMetadata does not receive the subtitle request that triggers tracking.
4. Enable forwarding again, with a preferred subtitle language other than **None**, and repeat playback. Tracking works again.
5. Open Playback Settings in this build. The description now explains that addon tracking can depend on the setting even when no subtitles are returned.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The UI change is limited to correcting incomplete help text. The setting title, default value, layout, and behavior are unchanged.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [ ] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [ ] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The policy-related boxes remain unchecked deliberately: this is a text-only clarification, not a critical bug fix. A maintainer exception is requested; the current template check may reject this category.

## Scope boundaries

- Only `playback_external_forward_subtitles_sub` in `app/src/main/res/values/strings.xml` changes.
- No changes to subtitle fetching, external-player result handling, watched thresholds, scrobbling, or addon APIs.
- No changes to settings defaults, migrations, dependencies, translations, or native libraries.
- The screenshot is hosted on a separate media branch in my fork and is not included in this PR's code diff.

## Testing

- `git diff --check` passed.
- Parsed `strings.xml` successfully with an XML parser.
- `:app:assembleFullDebug --console=plain` passed on JDK 21. Existing compiler/resource/startup-profile warnings remain unrelated to this string change.
- Installed the ARM64 full-debug APK, version `0.9.2-beta` / code `1058`, on NVIDIA Shield Android TV (Android 11/API 30), alongside the regular app without clearing its data.
- Launched the installed build successfully and checked the updated description on the Shield. The attached screenshot shows the text wrapping within the setting row.
- Confirmed in my playback setup that enabling forwarding restored AIOMetadata tracking after it stopped with forwarding disabled. This confirmation concerns the existing behavior, not a logic fix in this PR.

## Screenshots / Video

**Before:**

> Fetch subtitles in your preferred language from addons and pass them to the external player.

**After, on NVIDIA Shield:**

![Updated external subtitle forwarding description explaining AIOMetadata tracking](https://raw.githubusercontent.com/Laskco/NuvioTV/8e12a4402759784356d62f8a7a5de9074cf5c9e8/docs/pr-media/external-subtitle-tracking.png)

## Breaking changes

None. Text-only change with no behavior, configuration, or schema changes.

## Linked issues

No existing issue linked. The user-facing confusion and reproduction are documented above; this draft requests an exception for the small wording correction.
