### PR TITLE
fix(player): restore IntroDB-first skip provider priority

### DIFF
--- a/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
+++ b/app/src/main/java/com/nuvio/tv/data/repository/SkipIntroRepository.kt
@@ -58,9 +58,9 @@ class SkipIntroRepository @Inject constructor(
         }
 
         return@coroutineScope mergeByPriority(
-            aniSkipDeferred.await(),
+            introDbDeferred.await(),
             animeSkipDeferred.await(),
-            introDbDeferred.await()
+            aniSkipDeferred.await()
         ).also { cache[cacheKey] = it }
     }
 
@@ -91,7 +91,7 @@ class SkipIntroRepository @Inject constructor(
         if (resolvedImdbId != null) {
             val tvdb = tvdbDeferred.await()
             val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
-                mergeByPriority(aniSkipDeferred.await(), animeSkip).also { cache[cacheKey] = it }
+                mergeByPriority(animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
             }
             val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
             val introDbDeferred = async {
@@ -108,7 +108,7 @@ class SkipIntroRepository @Inject constructor(
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return@coroutineScope mergeByPriority(aniSkipDeferred.await(), animeSkip, introDb).also { cache[cacheKey] = it }
+        return@coroutineScope mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
     }
 
     suspend fun getSkipIntervalsForKitsu(
@@ -142,7 +142,7 @@ class SkipIntroRepository @Inject constructor(
         if (resolvedImdbId != null) {
             val tvdb = tvdbDeferred.await()
             val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
-                mergeByPriority(aniSkipDeferred.await(), animeSkip).also { cache[cacheKey] = it }
+                mergeByPriority(animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
             }
             val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
             val introDbDeferred = async {
@@ -159,13 +159,13 @@ class SkipIntroRepository @Inject constructor(
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
-        return@coroutineScope mergeByPriority(aniSkipDeferred.await(), animeSkip, introDb).also { cache[cacheKey] = it }
+        return@coroutineScope mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
     }
 
     /**
      * Merge provider results into one best-of: fill each segment category (opening / ending /
      * recap) from the highest-priority provider that has it. Arguments MUST be passed in priority
-     * order (AniSkip has native anime IDs, then Anime-Skip, then IntroDB as fallback),
+     * order (IntroDB, then Anime-Skip, then AniSkip as fallback),
      * so a partial result from one provider never shadows a complete segment from another.
      */
     private fun mergeByPriority(vararg providerResults: List<SkipInterval>): List<SkipInterval> {


### PR DESCRIPTION
## Summary

Restore the original skip-provider priority from #2457: **IntroDB → Anime-Skip → AniSkip**.

I've removed the AniSkip toggle and the other setting changes from this PR. It now only changes provider priority in `SkipIntroRepository`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

After discussing this with skoruppa, changing the priority back makes more sense than adding another setting. As explained in [this comment](https://github.com/NuvioMedia/NuvioTV/pull/3507#issuecomment-5653290956), the incorrect IntroDB results that prompted #3001 were caused by the old MAL/Kitsu-to-IMDb episode mapping. That mapper has since been replaced with Simkl.

This puts IntroDB first again while keeping Anime-Skip and AniSkip available for missing segments. The current Simkl mapping is left untouched.

## Issue or approval

Approved priority-only change, following [skoruppa's confirmation in this PR](https://github.com/NuvioMedia/NuvioTV/pull/3507#issuecomment-5653290956). Related PRs: #2457 and #3001.

## Reproduction steps

1. Open an episode where IntroDB and an anime skip provider return conflicting timestamps, such as the Shakugan no Shana example below.
2. Previously, AniSkip took precedence over IntroDB for the same segment category.
3. With this change, IntroDB takes precedence. If it has no segment for a category, Anime-Skip and then AniSkip can fill it.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

The same priority applies to IMDb, MAL, and Kitsu lookups, shared by internal and external playback. No settings are added or changed.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue or approval discussion, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

The linked approval discussion covers this change; no separate issue was opened. Reproduction steps and testing notes are included in this PR.

## Scope boundaries

One file, priority changes only. No toggle, external-player setting changes, mapping changes, diagnostic logging, dependencies, or test files are included.

## Testing

- Local tests cover all eight provider-availability combinations across IMDb, MAL, and Kitsu: 24 cases, including partial-category fallback and cached results.
- Existing skip-visibility tests: 18 cases.
- All 42 tests passed, with no failures or skipped tests. `:app:assembleFullDebug` and `git diff --check` passed.
- The recordings below are from the earlier diagnostic builds, not the final priority-only build.

## Screenshots / Video

Original playback comparisons are retained below. Any toggle shown in these recordings was experimental and has been removed from this PR.

### Internal player

**Incorrect skip segment**

https://github.com/user-attachments/assets/deb252d4-aa48-4783-993b-5aab12bb2819

**Correct skip segment**

https://github.com/user-attachments/assets/94e9c651-0044-406c-8182-fa4c5f193983

### External player

**Incorrect skip segment**

https://github.com/user-attachments/assets/a339ad5e-0cec-4fc4-bbf4-815e503d1e9f

**Correct skip segment**

https://github.com/user-attachments/assets/75b1755e-a766-4c08-ab12-290458b448b2

## Breaking changes

None. No settings reset or migration.

## Linked issues

Discussion: https://github.com/NuvioMedia/NuvioTV/pull/3507#issuecomment-5653290956

Related PRs: #2457 and #3001.
